### PR TITLE
Add wrap toggle for markdown code blocks

### DIFF
--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -168,6 +168,14 @@ npm install react-markdown
 npm run dev
 ```
 
+## Wide Code Block Example
+
+Long lines scroll horizontally on desktop and wrap on mobile.
+
+```sql
+SELECT users.id, users.name, orders.id AS order_id, orders.total, orders.status FROM users INNER JOIN orders ON orders.user_id = users.id WHERE orders.status IN ('pending', 'processing') ORDER BY orders.created_at DESC;
+```
+
 ---
 
 # Links and Images
@@ -199,6 +207,7 @@ npm run dev
 | CSS        | Styling       | Medium     |
 | JavaScript | Programming   | Hard       |
 | Markdown   | Documentation | Easy       |
+
 MD),
                 'published_at' => now(),
             ]);

--- a/resources/js/components/code-block.tsx
+++ b/resources/js/components/code-block.tsx
@@ -1,3 +1,4 @@
+import { MoveHorizontal, WrapText } from 'lucide-react';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-bash';
 import 'prismjs/components/prism-css';
@@ -10,6 +11,7 @@ import 'prismjs/components/prism-python';
 import 'prismjs/components/prism-tsx';
 import 'prismjs/components/prism-typescript';
 import type { ComponentPropsWithoutRef } from 'react';
+import { useState } from 'react';
 import type { ExtraProps } from 'react-markdown';
 
 type CodeBlockProps = ComponentPropsWithoutRef<'code'> & ExtraProps;
@@ -17,7 +19,13 @@ type CodeBlockProps = ComponentPropsWithoutRef<'code'> & ExtraProps;
 const escapeHtml = (value: string) =>
     value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
+const isMobileViewport = () =>
+    typeof window !== 'undefined' &&
+    window.matchMedia('(max-width: 767px)').matches;
+
 export function CodeBlock({ className, children }: CodeBlockProps) {
+    const [wrap, setWrap] = useState(isMobileViewport);
+
     const rawContent = String(children);
     const content = rawContent.replace(/\n$/, '');
     const languageMatch = /language-(\w+)/.exec(className || '');
@@ -36,12 +44,36 @@ export function CodeBlock({ className, children }: CodeBlockProps) {
     const highlightLang = language === 'blade' ? 'html' : language;
 
     return (
-        <div className="not-prose my-4 overflow-hidden rounded-lg border border-gray-700 bg-gray-900">
-            <pre className="overflow-x-auto bg-[#282c34] px-4 py-3 font-mono text-sm text-gray-300">
+        <div className="not-prose relative my-4 overflow-hidden rounded-lg border border-gray-700 bg-gray-900">
+            <button
+                type="button"
+                onClick={() => setWrap((v) => !v)}
+                aria-label={
+                    wrap
+                        ? 'Enable horizontal scrolling'
+                        : 'Enable line wrapping'
+                }
+                className="absolute top-2 right-2 rounded p-1 text-gray-400 transition-colors hover:bg-gray-700 hover:text-gray-200"
+                title={wrap ? 'Scroll' : 'Wrap'}
+            >
+                {wrap ? <MoveHorizontal size={20} /> : <WrapText size={20} />}
+            </button>
+            <pre
+                className={`bg-[#282c34] px-4 py-3 pr-10 font-mono text-sm text-gray-300 ${wrap ? 'break-words whitespace-pre-wrap' : 'overflow-x-auto'}`}
+            >
                 <code
                     className={
                         highlightLang ? `language-${highlightLang}` : undefined
                     }
+                    style={{
+                        background: 'transparent',
+                        ...(wrap
+                            ? {
+                                  whiteSpace: 'pre-wrap',
+                                  overflowWrap: 'break-word',
+                              }
+                            : {}),
+                    }}
                     dangerouslySetInnerHTML={{
                         __html:
                             highlightLang && Prism.languages[highlightLang]


### PR DESCRIPTION
## Summary
- add a wrap/scroll toggle to markdown code blocks and default wrapping on mobile
- keep the code block toggle safe inside forms with an explicit button type and label
- extend the seeded markdown guide with a wide SQL example that demonstrates the new behavior

## Notes
- repo-wide `composer ci:check` currently stops in `npm run lint:check` because ESLint recurses into `knowledge-base-inertia` artifacts and crashes with `RangeError: Invalid string length`
- targeted file checks passed, and `npm run build` passed
- `php artisan test` is blocked in this environment because the sqlite driver is unavailable (`could not find driver`)