### PR TITLE
Add Zenn markdown rendering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # thinkstream
+
+## Markdown rendering
+
+The app renders markdown through `resources/js/components/markdown-content.tsx`, which wraps `react-markdown` with `remark-gfm`.
+
+Custom markdown behavior is split into two layers:
+
+1. `resources/js/lib/zenn-markdown.ts`
+   - Preprocesses markdown before rendering.
+   - Current Zenn support rewrites image syntax like `![](/path/to/image.png =250x)` and carries width, height, and caption metadata through the URL.
+   - Any new Zenn-style syntax should be normalized here first, while skipping fenced code blocks.
+2. `resources/js/lib/markdown-components.tsx`
+   - Overrides markdown element rendering for headings, code blocks, images, and caption-like paragraphs.
+   - Use this file when a syntax feature needs custom React output after preprocessing.
+
+### Adding more Zenn syntax
+
+When adding a new Zenn-style snippet or block syntax:
+
+1. Extend `preprocessZennMarkdown()` in `resources/js/lib/zenn-markdown.ts`.
+2. Convert the new syntax into standard markdown or metadata that `react-markdown` can safely consume.
+3. Add or update a renderer in `createMarkdownComponents()` when the final HTML needs custom React output.
+4. Add seeded example content in `database/seeders/PostSeeder.php`.
+5. Add regression coverage in a browser test and, when appropriate, a feature test for seeded content.
+
+This keeps the markdown pipeline composable without introducing a separate renderer registry.

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -29,7 +29,7 @@ class PostSeeder extends Seeder
                 'name' => 'Guides',
                 'description' => 'Practical guides, walkthroughs, and reference notes for writing and publishing posts.',
                 'cover_image' => $coverImagePath,
-                'post_order' => ['index', 'extended-syntax'],
+                'post_order' => ['index', 'extended-syntax', 'zenn-syntax'],
             ],
         );
 
@@ -631,6 +631,67 @@ Without the plugin these render as literal text. You can always paste the emoji 
 ---
 
 > **WIP:** More examples coming soon.
+MD),
+                'published_at' => now(),
+            ]);
+
+        Post::updateOrCreate(
+            ['namespace_id' => $namespace->id, 'slug' => 'zenn-syntax'],
+            [
+                'user_id' => $user->id,
+                'title' => 'Zenn Syntax',
+                'content' => trim(<<<'MD'
+# Zenn Syntax
+
+> **WIP:** This page is still under construction.
+
+Zenn supports a few convenient image patterns on top of regular Markdown.
+
+## Basic Image
+
+```md
+![](/storage/namespaces/guide.png)
+```
+
+![](/storage/namespaces/guide.png)
+
+## Sized Image
+
+Use `=250x` after the image URL to set the width in pixels.
+
+```md
+![](/storage/namespaces/guide.png =250x)
+```
+
+![](/storage/namespaces/guide.png =250x)
+
+## Alt Text
+
+```md
+![Guide cover](/storage/namespaces/guide.png =250x)
+```
+
+![Guide cover](/storage/namespaces/guide.png =250x)
+
+## Caption
+
+Place italic text on the next line to display it like a caption.
+
+```md
+![](/storage/namespaces/guide.png =250x)
+*Guide cover image*
+```
+
+![](/storage/namespaces/guide.png =250x)
+*Guide cover image*
+
+## Linked Image
+
+```md
+[![](/storage/namespaces/guide.png =250x)](https://zenn.dev)
+```
+
+[![](/storage/namespaces/guide.png =250x)](https://zenn.dev)
 MD),
                 'published_at' => now(),
             ]);

--- a/resources/js/components/code-block.tsx
+++ b/resources/js/components/code-block.tsx
@@ -1,16 +1,5 @@
 import { Check, Copy, MoveHorizontal, WrapText } from 'lucide-react';
 import Prism from 'prismjs';
-import 'prismjs/components/prism-bash';
-import 'prismjs/components/prism-css';
-import 'prismjs/components/prism-javascript';
-import 'prismjs/components/prism-json';
-import 'prismjs/components/prism-jsx';
-import 'prismjs/components/prism-markup-templating';
-import 'prismjs/components/prism-php';
-import 'prismjs/components/prism-python';
-import 'prismjs/components/prism-sql';
-import 'prismjs/components/prism-tsx';
-import 'prismjs/components/prism-typescript';
 import type { ComponentPropsWithoutRef } from 'react';
 import { useState } from 'react';
 import type { ExtraProps } from 'react-markdown';

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -1,0 +1,20 @@
+import type { Components } from 'react-markdown';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { preprocessZennMarkdown } from '@/lib/zenn-markdown';
+
+type MarkdownContentProps = {
+    content: string;
+    components?: Components;
+};
+
+export default function MarkdownContent({
+    content,
+    components,
+}: MarkdownContentProps) {
+    return (
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+            {preprocessZennMarkdown(content)}
+        </ReactMarkdown>
+    );
+}

--- a/resources/js/components/markdown-editor.tsx
+++ b/resources/js/components/markdown-editor.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import { CodeBlock } from '@/components/code-block';
 import InputError from '@/components/input-error';
+import MarkdownContent from '@/components/markdown-content';
 import { Label } from '@/components/ui/label';
+import { createMarkdownComponents } from '@/lib/markdown-components';
 import { cn } from '@/lib/utils';
 
 type Props = {
@@ -45,12 +44,10 @@ export default function MarkdownEditor({
                     <div className="h-[600px] overflow-y-auto rounded-md border border-input bg-transparent px-3 py-2 text-sm">
                         {value ? (
                             <div className="prose prose-sm max-w-none dark:prose-invert">
-                                <ReactMarkdown
-                                    remarkPlugins={[remarkGfm]}
-                                    components={{ code: CodeBlock }}
-                                >
-                                    {value}
-                                </ReactMarkdown>
+                                <MarkdownContent
+                                    content={value}
+                                    components={createMarkdownComponents()}
+                                />
                             </div>
                         ) : (
                             <p className="text-muted-foreground">

--- a/resources/js/components/markdown-image.tsx
+++ b/resources/js/components/markdown-image.tsx
@@ -1,0 +1,31 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import { cn } from '@/lib/utils';
+import { parseZennImageMetadata } from '@/lib/zenn-markdown';
+
+type MarkdownImageProps = ComponentPropsWithoutRef<'img'>;
+
+export function MarkdownImage({
+    alt,
+    className,
+    src,
+    style,
+    ...props
+}: MarkdownImageProps) {
+    const image = parseZennImageMetadata(src);
+
+    return (
+        <img
+            {...props}
+            src={image.src}
+            alt={alt}
+            width={image.width}
+            height={image.height}
+            loading="lazy"
+            className={cn('mx-auto my-6 block h-auto max-w-full', className)}
+            style={{
+                ...(image.width ? { width: `${image.width}px` } : {}),
+                ...style,
+            }}
+        />
+    );
+}

--- a/resources/js/hooks/use-markdown-toc.tsx
+++ b/resources/js/hooks/use-markdown-toc.tsx
@@ -1,7 +1,6 @@
-import { Link as LinkIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import type { Components } from 'react-markdown';
-import { CodeBlock } from '@/components/code-block';
+import { createMarkdownComponents } from '@/lib/markdown-components';
 
 export type Heading = { level: number; text: string; id: string };
 
@@ -66,51 +65,6 @@ function extractHeadings(content: string, postSlug: string): Heading[] {
     return headings;
 }
 
-function copyAnchorUrl(id: string): void {
-    if (typeof window === 'undefined') {
-        return;
-    }
-
-    const url = new URL(window.location.href);
-    url.hash = id;
-
-    window.history.replaceState(window.history.state, '', url);
-
-    void navigator.clipboard?.writeText(url.toString());
-}
-
-function makeHeadingComponents(postSlug: string): Components {
-    const makeTag = (level: number) =>
-        function Heading({ children }: { children?: React.ReactNode }) {
-            const text =
-                typeof children === 'string'
-                    ? children
-                    : String(children ?? '');
-            const id = `${postSlug}-${slugify(text)}`;
-            const Tag = `h${level}` as 'h1' | 'h2' | 'h3';
-
-            return (
-                <Tag id={id} className="group scroll-mt-6">
-                    <span className="inline-flex items-center gap-2">
-                        {children}
-                        <a
-                            href={`#${id}`}
-                            onClick={() => copyAnchorUrl(id)}
-                            aria-label={`Copy link to ${text}`}
-                            title="Copy link to this section"
-                            data-test={`heading-anchor-${id}`}
-                            className="text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none"
-                        >
-                            <LinkIcon className="size-4" />
-                        </a>
-                    </span>
-                </Tag>
-            );
-        };
-
-    return { h1: makeTag(1), h2: makeTag(2), h3: makeTag(3), code: CodeBlock };
-}
-
 /**
  * Pre-computes TOC headings and custom heading components for a list of markdown posts.
  * Results are memoized and keyed by post slug.
@@ -124,7 +78,7 @@ export function useMarkdownToc(
         for (const post of posts) {
             map.set(post.slug, {
                 headings: extractHeadings(post.content, post.slug),
-                components: makeHeadingComponents(post.slug),
+                components: createMarkdownComponents(post.slug),
             });
         }
 

--- a/resources/js/lib/markdown-components.tsx
+++ b/resources/js/lib/markdown-components.tsx
@@ -1,0 +1,127 @@
+import { Link as LinkIcon } from 'lucide-react';
+import {
+    Children,
+    isValidElement,
+} from 'react';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import type { Components } from 'react-markdown';
+import { CodeBlock } from '@/components/code-block';
+import { MarkdownImage } from '@/components/markdown-image';
+import { parseZennImageMetadata } from '@/lib/zenn-markdown';
+
+function slugify(text: string): string {
+    return text
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, '')
+        .replace(/[\s_]+/g, '-');
+}
+
+function copyAnchorUrl(id: string): void {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    const url = new URL(window.location.href);
+    url.hash = id;
+
+    window.history.replaceState(window.history.state, '', url);
+
+    void navigator.clipboard?.writeText(url.toString());
+}
+
+function extractCaptionFromNode(node: ReactNode): string | undefined {
+    if (!isValidElement<{ src?: string; children?: ReactNode }>(node)) {
+        return undefined;
+    }
+
+    if (typeof node.props.src === 'string') {
+        return parseZennImageMetadata(node.props.src).caption;
+    }
+
+    const children = Children.toArray(node.props.children);
+
+    if (children.length !== 1) {
+        return undefined;
+    }
+
+    return extractCaptionFromNode(children[0]);
+}
+
+function MarkdownParagraph({
+    children,
+    ...props
+}: ComponentPropsWithoutRef<'p'>) {
+    const nodes = Children.toArray(children).filter((node) => {
+        return typeof node !== 'string' || node.trim() !== '';
+    });
+
+    if (nodes.length !== 1) {
+        return <p {...props}>{children}</p>;
+    }
+
+    const caption = extractCaptionFromNode(nodes[0]);
+
+    if (!caption) {
+        return <p {...props}>{children}</p>;
+    }
+
+    return (
+        <figure className="my-6">
+            {nodes[0]}
+            <figcaption className="mt-2 text-center text-sm leading-relaxed text-muted-foreground">
+                {caption}
+            </figcaption>
+        </figure>
+    );
+}
+
+function makeHeadingComponents(
+    postSlug?: string,
+): Pick<Components, 'h1' | 'h2' | 'h3'> {
+    if (!postSlug) {
+        return {};
+    }
+
+    const makeTag = (level: 1 | 2 | 3) =>
+        function Heading({ children }: { children?: ReactNode }) {
+            const text =
+                typeof children === 'string'
+                    ? children
+                    : String(children ?? '');
+            const id = `${postSlug}-${slugify(text)}`;
+            const Tag = `h${level}` as 'h1' | 'h2' | 'h3';
+
+            return (
+                <Tag id={id} className="group scroll-mt-6">
+                    <span className="inline-flex items-center gap-2">
+                        {children}
+                        <a
+                            href={`#${id}`}
+                            onClick={() => copyAnchorUrl(id)}
+                            aria-label={`Copy link to ${text}`}
+                            title="Copy link to this section"
+                            data-test={`heading-anchor-${id}`}
+                            className="text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none"
+                        >
+                            <LinkIcon className="size-4" />
+                        </a>
+                    </span>
+                </Tag>
+            );
+        };
+
+    return {
+        h1: makeTag(1),
+        h2: makeTag(2),
+        h3: makeTag(3),
+    };
+}
+
+export function createMarkdownComponents(postSlug?: string): Components {
+    return {
+        ...makeHeadingComponents(postSlug),
+        code: CodeBlock,
+        img: MarkdownImage,
+        p: MarkdownParagraph,
+    };
+}

--- a/resources/js/lib/zenn-markdown.ts
+++ b/resources/js/lib/zenn-markdown.ts
@@ -1,0 +1,169 @@
+const WIDTH_PARAM = '__zenn_width';
+const HEIGHT_PARAM = '__zenn_height';
+const CAPTION_PARAM = '__zenn_caption';
+
+type ImageMetadata = {
+    src: string;
+    width?: number;
+    height?: number;
+    caption?: string;
+};
+
+type EncodedMetadata = {
+    width?: string;
+    height?: string;
+    caption?: string;
+};
+
+function isAbsoluteUrl(url: string): boolean {
+    return (
+        url.startsWith('http://') ||
+        url.startsWith('https://') ||
+        url.startsWith('//') ||
+        url.startsWith('data:')
+    );
+}
+
+function buildUrlWithMetadata(url: string, metadata: EncodedMetadata): string {
+    const urlObject = new URL(url, 'https://zenn.local');
+
+    if (metadata.width) {
+        urlObject.searchParams.set(WIDTH_PARAM, metadata.width);
+    }
+
+    if (metadata.height) {
+        urlObject.searchParams.set(HEIGHT_PARAM, metadata.height);
+    }
+
+    if (metadata.caption) {
+        urlObject.searchParams.set(CAPTION_PARAM, metadata.caption);
+    }
+
+    if (isAbsoluteUrl(url)) {
+        return urlObject.toString();
+    }
+
+    return `${urlObject.pathname}${urlObject.search}${urlObject.hash}`;
+}
+
+function encodeImageTarget(target: string, caption?: string): string {
+    const match = /^(?<url>\S+?)(?:\s+=(?<width>\d+)x(?<height>\d*))?$/.exec(
+        target,
+    );
+
+    if (!match?.groups?.url) {
+        return target;
+    }
+
+    return buildUrlWithMetadata(match.groups.url, {
+        width: match.groups.width,
+        height: match.groups.height,
+        caption,
+    });
+}
+
+function rewriteImageLine(line: string, caption?: string): string | null {
+    const plainImageMatch = /^!\[(?<alt>[^\]]*)\]\((?<target>.+)\)$/.exec(line);
+
+    if (plainImageMatch?.groups?.target !== undefined) {
+        const encodedTarget = encodeImageTarget(
+            plainImageMatch.groups.target,
+            caption,
+        );
+
+        return `![${plainImageMatch.groups.alt}](${encodedTarget})`;
+    }
+
+    const linkedImageMatch =
+        /^\[!\[(?<alt>[^\]]*)\]\((?<target>.+)\)\]\((?<href>.+)\)$/.exec(line);
+
+    if (linkedImageMatch?.groups?.target !== undefined) {
+        const encodedTarget = encodeImageTarget(
+            linkedImageMatch.groups.target,
+            caption,
+        );
+
+        return `[![${linkedImageMatch.groups.alt}](${encodedTarget})](${linkedImageMatch.groups.href})`;
+    }
+
+    return null;
+}
+
+export function preprocessZennMarkdown(markdown: string): string {
+    const lines = markdown.split('\n');
+    const processedLines: string[] = [];
+    let activeFence: string | null = null;
+
+    for (let index = 0; index < lines.length; index++) {
+        const currentLine = lines[index];
+        const trimmedLine = currentLine.trim();
+        const fenceMatch = /^(`{3,}|~{3,})/.exec(trimmedLine);
+
+        if (fenceMatch) {
+            const fence = fenceMatch[1];
+
+            if (activeFence === null) {
+                activeFence = fence;
+            } else if (
+                fence[0] === activeFence[0] &&
+                fence.length >= activeFence.length
+            ) {
+                activeFence = null;
+            }
+
+            processedLines.push(currentLine);
+
+            continue;
+        }
+
+        if (activeFence !== null) {
+            processedLines.push(currentLine);
+
+            continue;
+        }
+
+        const nextLine = lines[index + 1];
+        const captionMatch = /^\*(.+)\*$/.exec(nextLine?.trim() ?? '');
+        const rewrittenLine = rewriteImageLine(
+            trimmedLine,
+            captionMatch?.[1]?.trim(),
+        );
+
+        if (rewrittenLine === null) {
+            processedLines.push(currentLine);
+            continue;
+        }
+
+        processedLines.push(currentLine.replace(trimmedLine, rewrittenLine));
+
+        if (captionMatch) {
+            index++;
+        }
+    }
+
+    return processedLines.join('\n');
+}
+
+export function parseZennImageMetadata(url?: string | null): ImageMetadata {
+    if (!url) {
+        return { src: '' };
+    }
+
+    const urlObject = new URL(url, 'https://zenn.local');
+    const width = urlObject.searchParams.get(WIDTH_PARAM);
+    const height = urlObject.searchParams.get(HEIGHT_PARAM);
+    const caption = urlObject.searchParams.get(CAPTION_PARAM);
+
+    urlObject.searchParams.delete(WIDTH_PARAM);
+    urlObject.searchParams.delete(HEIGHT_PARAM);
+    urlObject.searchParams.delete(CAPTION_PARAM);
+
+    return {
+        src: isAbsoluteUrl(url)
+            ? urlObject.toString()
+            : `${urlObject.pathname}${urlObject.search}${urlObject.hash}`,
+        width: width ? Number(width) : undefined,
+        height: height ? Number(height) : undefined,
+        caption: caption || undefined,
+    };
+}

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -1,7 +1,7 @@
 import { Form, Head, Link, setLayoutProps } from '@inertiajs/react';
-import ReactMarkdown from 'react-markdown';
-import { CodeBlock } from '@/components/code-block';
+import MarkdownContent from '@/components/markdown-content';
 import { Button } from '@/components/ui/button';
+import { createMarkdownComponents } from '@/lib/markdown-components';
 import { dashboard } from '@/routes';
 import {
     destroy,
@@ -101,9 +101,10 @@ export default function Show({
 
                 <div className="rounded-xl border p-6">
                     <div className="prose max-w-none prose-neutral dark:prose-invert">
-                        <ReactMarkdown components={{ code: CodeBlock }}>
-                            {post.content}
-                        </ReactMarkdown>
+                        <MarkdownContent
+                            content={post.content}
+                            components={createMarkdownComponents()}
+                        />
                     </div>
                 </div>
             </div>

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -1,8 +1,7 @@
 import { Head, Link, usePage } from '@inertiajs/react';
 import { PanelRightClose, PanelRightOpen } from 'lucide-react';
 import { useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
+import MarkdownContent from '@/components/markdown-content';
 import TableOfContents from '@/components/table-of-contents';
 import { useMarkdownToc } from '@/hooks/use-markdown-toc';
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -161,15 +160,13 @@ export default function Namespace({
                                             </time>
                                         </header>
                                         <div className="prose max-w-none prose-neutral dark:prose-invert">
-                                            <ReactMarkdown
-                                                remarkPlugins={[remarkGfm]}
+                                            <MarkdownContent
+                                                content={post.content}
                                                 components={
                                                     toc.get(post.slug)!
                                                         .components
                                                 }
-                                            >
-                                                {post.content}
-                                            </ReactMarkdown>
+                                            />
                                         </div>
                                     </article>
                                 ))}

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -7,8 +7,7 @@ import {
     PanelRightOpen,
 } from 'lucide-react';
 import { useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
+import MarkdownContent from '@/components/markdown-content';
 import TableOfContents from '@/components/table-of-contents';
 import { useMarkdownToc } from '@/hooks/use-markdown-toc';
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -238,12 +237,10 @@ export default function Show({
                                 </time>
                             </header>
                             <div className="prose max-w-none prose-neutral dark:prose-invert">
-                                <ReactMarkdown
-                                    remarkPlugins={[remarkGfm]}
+                                <MarkdownContent
+                                    content={post.content}
                                     components={entry?.components}
-                                >
-                                    {post.content}
-                                </ReactMarkdown>
+                                />
                             </div>
                         </article>
                     </main>

--- a/tests/Browser/ZennMarkdownRenderingTest.php
+++ b/tests/Browser/ZennMarkdownRenderingTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('zenn-style markdown image metadata renders width and caption', function () {
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+        'is_published' => true,
+    ]);
+
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'slug' => 'zenn-images',
+        'title' => 'Zenn Images',
+        'content' => <<<'MARKDOWN'
+# Zenn Images
+
+![Guide cover](/storage/namespaces/guide.png =250x)
+*Guide cover image*
+
+[![](/storage/namespaces/guide.png =250x)](https://zenn.dev)
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page
+        ->assertSee('Guide cover image')
+        ->assertAttribute('img[alt="Guide cover"]', 'width', '250')
+        ->assertPresent('a[href="https://zenn.dev"]');
+});

--- a/tests/Feature/PostSeederTest.php
+++ b/tests/Feature/PostSeederTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+use Database\Seeders\PostSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('post seeder creates the zenn syntax guide as work in progress', function () {
+    $this->seed(PostSeeder::class);
+
+    $namespace = PostNamespace::query()
+        ->where('slug', 'guides')
+        ->first();
+
+    expect($namespace)->not->toBeNull();
+    expect($namespace->post_order)->toContain('zenn-syntax');
+
+    $post = Post::query()
+        ->where('namespace_id', $namespace->id)
+        ->where('slug', 'zenn-syntax')
+        ->first();
+
+    expect($post)->not->toBeNull();
+    expect($post->title)->toBe('Zenn Syntax');
+    expect($post->content)->toContain('> **WIP:**');
+    expect($post->content)->toContain('## Basic Image');
+    expect($post->content)->toContain('## Sized Image');
+    expect($post->content)->toContain('## Alt Text');
+    expect($post->content)->toContain('## Caption');
+    expect($post->content)->toContain('## Linked Image');
+    expect($post->content)->toContain('![Guide cover](/storage/namespaces/guide.png =250x)');
+    expect($post->content)->toContain('![](/storage/namespaces/guide.png =250x)');
+    expect($post->content)->toContain('*Guide cover image*');
+    expect($post->content)->toContain('[![](/storage/namespaces/guide.png =250x)](https://zenn.dev)');
+    expect($post->published_at)->not->toBeNull();
+});


### PR DESCRIPTION
## Summary
- add a shared markdown rendering pipeline with Zenn-style preprocessing and component overrides
- support Zenn image metadata patterns for sizing, captions, and linked images across previews and post pages
- seed a Zenn syntax guide, add regression coverage, and document how to extend the markdown pipeline

## Details
This proposal keeps `react-markdown` as the renderer and layers Zenn support in two places:
- `resources/js/lib/zenn-markdown.ts` preprocesses Zenn-style syntax before rendering
- `resources/js/lib/markdown-components.tsx` customizes how markdown nodes are rendered in React

It also centralizes rendering through `resources/js/components/markdown-content.tsx`, so admin previews and public post pages share the same behavior.

As part of this work, the change also avoids eager Prism language-module loading, which prevents markdown pages from crashing in fresh/browser-test environments and is related to #8.

## Testing
- targeted ESLint on changed frontend files
- `npm run types:check`
- `npm run build`
- `php artisan test tests/Feature/PostSeederTest.php tests/Browser/ZennMarkdownRenderingTest.php`

Related to #8.