### PR TITLE
Add Zenn message directive support

### DIFF
--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -692,6 +692,32 @@ Place italic text on the next line to display it like a caption.
 ```
 
 [![](/storage/namespaces/guide.png =250x)](https://zenn.dev)
+
+## Message
+
+Wrap content in `:::message` to display an info callout.
+
+```md
+:::message
+Your message here
+:::
+```
+
+:::message
+Your message here
+:::
+
+Use `:::message alert` for warnings.
+
+```md
+:::message alert
+Your warning here
+:::
+```
+
+:::message alert
+Your warning here
+:::
 MD),
                 'published_at' => now(),
             ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
                 "react": "^19.2.0",
                 "react-dom": "^19.2.0",
                 "react-markdown": "^10.1.0",
+                "remark-directive": "^4.0.0",
                 "remark-gfm": "^4.0.1",
                 "tailwind-merge": "^3.0.1",
                 "tailwindcss": "^4.0.0",
@@ -6667,6 +6668,27 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/mdast-util-directive": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+            "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "ccount": "^2.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "parse-entities": "^4.0.0",
+                "stringify-entities": "^4.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/mdast-util-find-and-replace": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
@@ -7016,6 +7038,25 @@
                 "micromark-util-subtokenize": "^2.0.0",
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-extension-directive": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+            "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-factory-whitespace": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "parse-entities": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/micromark-extension-gfm": {
@@ -8263,6 +8304,22 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/remark-directive": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
+            "integrity": "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-directive": "^3.0.0",
+                "micromark-extension-directive": "^4.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/remark-gfm": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
+        "remark-directive": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.0.1",
         "tailwindcss": "^4.0.0",

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -1,7 +1,53 @@
+import { AlertCircle, Info } from 'lucide-react';
 import type { Components } from 'react-markdown';
 import ReactMarkdown from 'react-markdown';
+import remarkDirective from 'remark-directive';
 import remarkGfm from 'remark-gfm';
-import { preprocessZennMarkdown } from '@/lib/zenn-markdown';
+import { remarkZennDirective } from '@/lib/remark-zenn-directive';
+import { cn } from '@/lib/utils';
+import {
+    preprocessZennMarkdown,
+    preprocessZennSyntax,
+} from '@/lib/zenn-markdown';
+
+function MessageBox({
+    children,
+    className,
+    ...props
+}: React.ComponentPropsWithoutRef<'aside'>) {
+    const isAlert = className?.includes('alert');
+
+    if (!className?.includes('msg')) {
+        return (
+            <aside className={className} {...props}>
+                {children}
+            </aside>
+        );
+    }
+
+    const Icon = isAlert ? AlertCircle : Info;
+
+    return (
+        <aside
+            className={cn(
+                'not-prose my-6 flex items-start gap-3 rounded-md px-4 py-4 text-sm leading-relaxed',
+                isAlert
+                    ? 'bg-amber-50 text-amber-900 dark:bg-amber-950/40 dark:text-amber-100'
+                    : 'bg-blue-50 text-blue-900 dark:bg-blue-950/40 dark:text-blue-100',
+            )}
+            {...props}
+        >
+            <Icon
+                className={cn(
+                    'mt-0.5 shrink-0',
+                    isAlert ? 'text-amber-500' : 'text-blue-500',
+                )}
+                size={18}
+            />
+            <div className="min-w-0 flex-1">{children}</div>
+        </aside>
+    );
+}
 
 type MarkdownContentProps = {
     content: string;
@@ -13,8 +59,11 @@ export default function MarkdownContent({
     components,
 }: MarkdownContentProps) {
     return (
-        <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
-            {preprocessZennMarkdown(content)}
+        <ReactMarkdown
+            remarkPlugins={[remarkGfm, remarkDirective, remarkZennDirective]}
+            components={{ aside: MessageBox, ...components }}
+        >
+            {preprocessZennMarkdown(preprocessZennSyntax(content))}
         </ReactMarkdown>
     );
 }

--- a/resources/js/lib/markdown-components.tsx
+++ b/resources/js/lib/markdown-components.tsx
@@ -1,8 +1,5 @@
 import { Link as LinkIcon } from 'lucide-react';
-import {
-    Children,
-    isValidElement,
-} from 'react';
+import { Children, isValidElement } from 'react';
 import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 import type { Components } from 'react-markdown';
 import { CodeBlock } from '@/components/code-block';

--- a/resources/js/lib/remark-zenn-directive.ts
+++ b/resources/js/lib/remark-zenn-directive.ts
@@ -1,0 +1,41 @@
+import type { Root } from 'mdast';
+import type { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+interface ContainerDirectiveNode extends Node {
+    type: 'containerDirective';
+    name: string;
+    attributes?: Record<string, string | undefined>;
+    children: Node[];
+    data?: {
+        hName?: string;
+        hProperties?: Record<string, unknown>;
+    };
+}
+
+export function remarkZennDirective() {
+    return (tree: Root) => {
+        visit(tree, (node: Node) => {
+            if (node.type !== 'containerDirective') {
+                return;
+            }
+
+            const directiveNode = node as ContainerDirectiveNode;
+
+            if (directiveNode.name !== 'message') {
+                return;
+            }
+
+            const attributes = directiveNode.attributes ?? {};
+            const className = attributes.className ?? attributes.class ?? '';
+            const isAlert =
+                className.includes('alert') || attributes.alert !== undefined;
+
+            const data = directiveNode.data ?? (directiveNode.data = {});
+            data.hName = 'aside';
+            data.hProperties = {
+                className: `msg ${isAlert ? 'alert' : 'message'}`,
+            };
+        });
+    };
+}

--- a/resources/js/lib/zenn-markdown.ts
+++ b/resources/js/lib/zenn-markdown.ts
@@ -89,6 +89,10 @@ function rewriteImageLine(line: string, caption?: string): string | null {
     return null;
 }
 
+export function preprocessZennSyntax(markdown: string): string {
+    return markdown.replace(/:::message\s+alert\b/g, ':::message{.alert}');
+}
+
 export function preprocessZennMarkdown(markdown: string): string {
     const lines = markdown.split('\n');
     const processedLines: string[] = [];


### PR DESCRIPTION
## Summary
- add support for Zenn-style :::message and :::message alert blocks
- wire the markdown pipeline to parse directives and render message callouts as custom asides
- expand the seeded Zenn syntax guide and include the required dependency updates

## Details
This proposal extends the existing markdown pipeline without introducing a separate renderer.

- resources/js/lib/zenn-markdown.ts normalizes Zenn-specific syntax before rendering
- resources/js/lib/remark-zenn-directive.ts maps Zenn message directives to renderable markdown nodes
- resources/js/components/markdown-content.tsx registers the directive plugins and renders message boxes with the app's UI styles

The seeded Zenn Syntax post now includes examples for both info and alert message blocks.

## Testing
- npm run format
- targeted ESLint on changed frontend files
- npm run types:check
- npm run build