### PR TITLE
feat: add OGP link card embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Current seeded examples cover:
 3. Linked images with the same width metadata handling
 4. `:::message` and `:::message alert` callout blocks
 5. Fenced `mermaid` code blocks rendered as diagrams
+6. Link cards from standalone URLs and `@[card](URL)` directives, with OGP metadata fetched server-side and YouTube URLs rendered as iframe embeds
 
 ### Adding more Zenn syntax
 

--- a/app/Http/Controllers/Api/OgpController.php
+++ b/app/Http/Controllers/Api/OgpController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\OgpMetadataService;
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Validator;
+
+class OgpController extends Controller
+{
+    public function __construct(
+        private OgpMetadataService $ogpService
+    ) {}
+
+    /**
+     * OGPメタデータを取得する。
+     */
+    public function fetch(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'url' => [
+                'required',
+                'url:http,https',
+                'max:2048',
+                function (string $attribute, mixed $value, Closure $fail): void {
+                    if (! is_string($value) || ! $this->ogpService->isAllowedUrl($value)) {
+                        $fail("The {$attribute} field is invalid.");
+                    }
+                },
+            ],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Invalid URL',
+                'messages' => $validator->errors(),
+            ], 422);
+        }
+
+        $url = $request->string('url')->toString();
+
+        $metadata = Cache::remember('ogp:'.md5($url), now()->addHours(24), function () use ($url) {
+            return $this->ogpService->fetch($url);
+        });
+
+        if (! $metadata) {
+            return response()->json(['error' => 'Failed to fetch OGP metadata'], 404);
+        }
+
+        return response()->json($metadata);
+    }
+}

--- a/app/Http/Controllers/Api/OgpController.php
+++ b/app/Http/Controllers/Api/OgpController.php
@@ -17,7 +17,7 @@ class OgpController extends Controller
     ) {}
 
     /**
-     * OGPメタデータを取得する。
+     * Fetch OGP metadata for the given URL.
      */
     public function fetch(Request $request): JsonResponse
     {

--- a/app/Services/OgpMetadataService.php
+++ b/app/Services/OgpMetadataService.php
@@ -41,9 +41,9 @@ class OgpMetadataService
     }
 
     /**
-     * URLからOGPメタデータを取得する。
+     * Fetch OGP metadata for the given URL.
      *
-     * @param  string  $url  取得対象のURL
+     * @param  string  $url  The URL to fetch.
      * @return array{title: string, description: ?string, image: ?string, url: string}|null
      */
     public function fetch(string $url): ?array

--- a/app/Services/OgpMetadataService.php
+++ b/app/Services/OgpMetadataService.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Services;
+
+use DOMDocument;
+use DOMXPath;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class OgpMetadataService
+{
+    /**
+     * Determine whether the service may fetch metadata for the given URL.
+     */
+    public function isAllowedUrl(string $url): bool
+    {
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        $host = parse_url($url, PHP_URL_HOST);
+
+        if (! is_string($scheme) || ! in_array($scheme, ['http', 'https'], true)) {
+            return false;
+        }
+
+        if (! is_string($host) || $host === '') {
+            return false;
+        }
+
+        if ($this->isBlockedHost($host)) {
+            return false;
+        }
+
+        foreach ($this->resolveHostAddresses($host) as $address) {
+            if ($this->isBlockedHost($address)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * URLからOGPメタデータを取得する。
+     *
+     * @param  string  $url  取得対象のURL
+     * @return array{title: string, description: ?string, image: ?string, url: string}|null
+     */
+    public function fetch(string $url): ?array
+    {
+        try {
+            $response = Http::connectTimeout(5)
+                ->retry([200, 500, 1000], throw: false)
+                ->timeout(10)
+                ->withoutRedirecting()
+                ->withUserAgent('Mozilla/5.0 (compatible; OGP-Fetcher/1.0)')
+                ->get($url);
+
+            if (! $response->successful()) {
+                return null;
+            }
+
+            $html = $response->body();
+            $dom = $this->parseHtml($html);
+
+            if ($dom === null) {
+                return null;
+            }
+
+            $xpath = new DOMXPath($dom);
+
+            $title = $this->extractOgpTag($xpath, 'og:title')
+                ?? $this->extractTitle($xpath);
+
+            if (empty($title)) {
+                return null;
+            }
+
+            return [
+                'title' => $title,
+                'description' => $this->extractOgpTag($xpath, 'og:description')
+                    ?? $this->extractMetaTag($xpath, 'description'),
+                'image' => $this->extractOgpTag($xpath, 'og:image'),
+                'url' => $url,
+            ];
+        } catch (ConnectionException $e) {
+            Log::warning('OGP fetch failed', ['url' => $url, 'error' => $e->getMessage()]);
+
+            return null;
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveHostAddresses(string $host): array
+    {
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return [$host];
+        }
+
+        $records = dns_get_record($host, DNS_A | DNS_AAAA);
+
+        if ($records === false) {
+            return [];
+        }
+
+        return collect($records)
+            ->map(fn (array $record): ?string => $record['ip'] ?? $record['ipv6'] ?? null)
+            ->filter(fn (?string $address): bool => is_string($address) && $address !== '')
+            ->values()
+            ->all();
+    }
+
+    private function isBlockedHost(string $host): bool
+    {
+        $normalizedHost = Str::lower(trim($host, '[]'));
+
+        if (in_array($normalizedHost, ['localhost', 'localhost.localdomain'], true)) {
+            return true;
+        }
+
+        if (filter_var($normalizedHost, FILTER_VALIDATE_IP) === false) {
+            return false;
+        }
+
+        return filter_var(
+            $normalizedHost,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+        ) === false;
+    }
+
+    private function parseHtml(string $html): ?DOMDocument
+    {
+        $dom = new DOMDocument;
+
+        libxml_use_internal_errors(true);
+        $result = $dom->loadHTML($html, LIBXML_NONET | LIBXML_NOERROR);
+        libxml_clear_errors();
+
+        return $result ? $dom : null;
+    }
+
+    private function extractOgpTag(DOMXPath $xpath, string $property): ?string
+    {
+        $nodes = $xpath->query("//meta[@property='{$property}']/@content");
+
+        if ($nodes === false || $nodes->length === 0) {
+            return null;
+        }
+
+        $value = trim((string) $nodes->item(0)?->nodeValue);
+
+        return $value !== '' ? $value : null;
+    }
+
+    private function extractMetaTag(DOMXPath $xpath, string $name): ?string
+    {
+        $nodes = $xpath->query("//meta[@name='{$name}']/@content");
+
+        if ($nodes === false || $nodes->length === 0) {
+            return null;
+        }
+
+        $value = trim((string) $nodes->item(0)?->nodeValue);
+
+        return $value !== '' ? $value : null;
+    }
+
+    private function extractTitle(DOMXPath $xpath): ?string
+    {
+        $nodes = $xpath->query('//title');
+
+        if ($nodes === false || $nodes->length === 0) {
+            return null;
+        }
+
+        $value = trim((string) $nodes->item(0)?->textContent);
+
+        return $value !== '' ? $value : null;
+    }
+}

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -718,6 +718,32 @@ Your warning here
 :::message alert
 Your warning here
 :::
+
+## Link Card
+
+A URL placed alone on its own line is automatically displayed as a card.
+
+```md
+https://zenn.dev
+```
+
+https://zenn.dev
+
+Use the `@[card](URL)` form for URLs that contain underscores.
+
+```md
+@[card](https://zenn.dev/zenn/articles/markdown-guide)
+```
+
+@[card](https://zenn.dev/zenn/articles/markdown-guide)
+
+YouTube URLs are automatically embedded as a video player.
+
+```md
+https://www.youtube.com/watch?v=WRVsOCh907o
+```
+
+https://www.youtube.com/watch?v=WRVsOCh907o
 MD),
                 'published_at' => now(),
             ]);

--- a/resources/js/components/embed-card.tsx
+++ b/resources/js/components/embed-card.tsx
@@ -1,0 +1,180 @@
+import { ExternalLink } from 'lucide-react';
+import React from 'react';
+import { extractYoutubeVideoParameters } from '@/lib/url-matcher';
+
+interface EmbedCardProps {
+    url: string;
+    type: 'youtube' | 'card';
+}
+
+/**
+ * Renders a YouTube video as an iframe embed.
+ */
+function YoutubeEmbed({ url }: { url: string }) {
+    const params = extractYoutubeVideoParameters(url);
+
+    if (!params?.videoId) {
+        return <LinkCard url={url} />;
+    }
+
+    const time = Math.min(Number(params.start ?? 0), 48 * 60 * 60);
+    const startQuery = time ? `?start=${time}` : '';
+
+    return (
+        <div
+            className="not-prose my-4 flex justify-center"
+            data-test="embed-card-youtube"
+        >
+            <div className="w-full max-w-xl overflow-hidden rounded-lg border border-border bg-black">
+                <div className="relative" style={{ paddingBottom: '56.25%' }}>
+                    <iframe
+                        src={`https://www.youtube-nocookie.com/embed/${params.videoId}${startQuery}`}
+                        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                        allowFullScreen
+                        loading="lazy"
+                        className="absolute inset-0 size-full"
+                        title="YouTube video"
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Fetches OGP metadata for a URL and renders a rich link card.
+ * Falls back to a plain link when metadata is unavailable.
+ */
+function LinkCard({ url }: { url: string }) {
+    const [metadata, setMetadata] = React.useState<{
+        title?: string;
+        description?: string;
+        image?: string;
+    } | null>(null);
+    const [loading, setLoading] = React.useState(true);
+    const [error, setError] = React.useState(false);
+
+    const domain = (() => {
+        try {
+            return new URL(url).hostname;
+        } catch {
+            return url;
+        }
+    })();
+
+    React.useEffect(() => {
+        const fetchMetadata = async () => {
+            try {
+                const response = await fetch(
+                    `/api/ogp?url=${encodeURIComponent(url)}`,
+                );
+
+                if (response.ok) {
+                    const data = await response.json();
+                    setMetadata(data);
+                } else {
+                    setError(true);
+                }
+            } catch {
+                setError(true);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        void fetchMetadata();
+    }, [url]);
+
+    if (loading) {
+        return (
+            <div
+                className="not-prose my-4 overflow-hidden rounded-lg border border-border bg-card"
+                data-test="embed-card-card"
+            >
+                <div className="flex items-start gap-3 p-4">
+                    <ExternalLink className="mt-1 size-5 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0 flex-1">
+                        <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+                        <div className="mt-2 h-3 w-1/2 animate-pulse rounded bg-muted" />
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    if (error || !metadata) {
+        return (
+            <div
+                className="not-prose my-4 overflow-hidden rounded-lg border border-border bg-card"
+                data-test="embed-card-card"
+            >
+                <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-start gap-3 p-4 transition-colors hover:bg-muted"
+                >
+                    <ExternalLink className="mt-1 size-5 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-medium text-foreground">
+                            {url}
+                        </div>
+                        <div className="mt-1 text-xs text-muted-foreground">
+                            {domain}
+                        </div>
+                    </div>
+                </a>
+            </div>
+        );
+    }
+
+    return (
+        <div className="not-prose my-4" data-test="embed-card-card">
+            <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-3 overflow-hidden rounded-lg border border-border bg-card p-4 transition-all hover:border-foreground/20 hover:bg-muted"
+            >
+                {metadata.image && (
+                    <div className="shrink-0">
+                        <img
+                            src={metadata.image}
+                            alt=""
+                            className="size-16 rounded object-cover"
+                            loading="lazy"
+                            onError={(e) => {
+                                e.currentTarget.style.display = 'none';
+                            }}
+                        />
+                    </div>
+                )}
+                <div className="min-w-0 flex-1">
+                    <div className="line-clamp-1 text-sm font-semibold text-foreground">
+                        {metadata.title || url}
+                    </div>
+                    {metadata.description && (
+                        <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                            {metadata.description}
+                        </div>
+                    )}
+                    <div className="mt-1 text-[10px] text-muted-foreground/70">
+                        {domain}
+                    </div>
+                </div>
+                <ExternalLink className="size-4 shrink-0 text-muted-foreground" />
+            </a>
+        </div>
+    );
+}
+
+/**
+ * Dispatches to the appropriate embed component based on URL type.
+ */
+export function EmbedCard({ url, type }: EmbedCardProps) {
+    if (type === 'youtube') {
+        return <YoutubeEmbed url={url} />;
+    }
+
+    return <LinkCard url={url} />;
+}

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -3,6 +3,8 @@ import type { Components } from 'react-markdown';
 import ReactMarkdown from 'react-markdown';
 import remarkDirective from 'remark-directive';
 import remarkGfm from 'remark-gfm';
+import { EmbedCard } from '@/components/embed-card';
+import { remarkLinkifyToCard } from '@/lib/remark-linkify-to-card';
 import { remarkZennDirective } from '@/lib/remark-zenn-directive';
 import { cn } from '@/lib/utils';
 import {
@@ -60,8 +62,30 @@ export default function MarkdownContent({
 }: MarkdownContentProps) {
     return (
         <ReactMarkdown
-            remarkPlugins={[remarkGfm, remarkDirective, remarkZennDirective]}
-            components={{ aside: MessageBox, ...components }}
+            remarkPlugins={[
+                remarkGfm,
+                remarkDirective,
+                remarkZennDirective,
+                remarkLinkifyToCard,
+            ]}
+            components={{
+                aside: MessageBox,
+                div: (props: React.ComponentPropsWithoutRef<'div'>) => {
+                    const embedType = (props as Record<string, unknown>)[
+                        'data-embed-type'
+                    ] as 'youtube' | 'card' | undefined;
+                    const embedUrl = (props as Record<string, unknown>)[
+                        'data-embed-url'
+                    ] as string | undefined;
+
+                    if (embedType && embedUrl) {
+                        return <EmbedCard type={embedType} url={embedUrl} />;
+                    }
+
+                    return <div {...props} />;
+                },
+                ...components,
+            }}
         >
             {preprocessZennMarkdown(preprocessZennSyntax(content))}
         </ReactMarkdown>

--- a/resources/js/lib/remark-linkify-to-card.ts
+++ b/resources/js/lib/remark-linkify-to-card.ts
@@ -1,0 +1,92 @@
+/**
+ * A remark plugin that converts standalone URLs in paragraphs to embed card divs.
+ *
+ * When a paragraph contains only a single http(s) URL link (with optional surrounding
+ * whitespace), the paragraph node is converted to a <div> via data.hName and
+ * data.hProperties — no rehype-raw required.
+ */
+import type { Link, Paragraph, Root, Text } from 'mdast';
+import { visit } from 'unist-util-visit';
+import { isYoutubeUrl } from './url-matcher';
+
+export type EmbedType = 'youtube' | 'card';
+
+/**
+ * Returns the link node if the paragraph contains only a single standalone link,
+ * otherwise returns null.
+ */
+function isStandaloneLinkInParagraph(paragraph: Paragraph): Link | null {
+    const children = paragraph.children;
+
+    if (children.length === 1 && children[0].type === 'link') {
+        return children[0] as Link;
+    }
+
+    const linkIndex = children.findIndex((child) => child.type === 'link');
+
+    if (linkIndex === -1) {
+        return null;
+    }
+
+    const isOnlyWhitespace = (node: (typeof children)[number]) => {
+        if (node.type === 'text') {
+            return ((node as Text).value?.trim() ?? '') === '';
+        }
+
+        return node.type === 'break';
+    };
+
+    const beforeLink = children.slice(0, linkIndex);
+    const afterLink = children.slice(linkIndex + 1);
+
+    if (
+        beforeLink.every(isOnlyWhitespace) &&
+        afterLink.every(isOnlyWhitespace)
+    ) {
+        return children[linkIndex] as Link;
+    }
+
+    return null;
+}
+
+function detectEmbedType(url: string): EmbedType {
+    if (isYoutubeUrl(url)) {
+        return 'youtube';
+    }
+
+    return 'card';
+}
+
+/**
+ * remark-linkify-to-card plugin
+ */
+export function remarkLinkifyToCard() {
+    return (tree: Root) => {
+        visit(tree, 'paragraph', (node: Paragraph) => {
+            const standaloneLink = isStandaloneLinkInParagraph(node);
+
+            if (!standaloneLink) {
+                return;
+            }
+
+            const url = standaloneLink.url;
+
+            if (!url || !url.match(/^https?:\/\//)) {
+                return;
+            }
+
+            const embedType = detectEmbedType(url);
+
+            const data = (node.data ??= {});
+             
+            (data as any).hName = 'div';
+             
+            (data as any).hProperties = {
+                'data-embed-type': embedType,
+                'data-embed-url': url,
+            };
+
+            node.children = [];
+        });
+    };
+}

--- a/resources/js/lib/url-matcher.ts
+++ b/resources/js/lib/url-matcher.ts
@@ -1,0 +1,36 @@
+/**
+ * URL matching utilities
+ */
+
+/** Returns true if the URL is a YouTube video URL. */
+export function isYoutubeUrl(url: string): boolean {
+    return [
+        /^https?:\/\/youtu\.be\/[\w-]+(?:\?[\w=&-]+)?$/,
+        /^https?:\/\/(?:www\.)?youtube\.com\/watch\?[\w=&-]+$/,
+    ].some((pattern) => pattern.test(url));
+}
+
+const YOUTUBE_VIDEO_ID_LENGTH = 11;
+
+/**
+ * Extracts the video ID and optional start time (in seconds) from a YouTube URL.
+ */
+export function extractYoutubeVideoParameters(
+    youtubeUrl: string,
+): { videoId: string; start?: string } | undefined {
+    if (!isYoutubeUrl(youtubeUrl)) {
+        return undefined;
+    }
+
+    const url = new URL(youtubeUrl);
+    const params = new URLSearchParams(url.search || '');
+
+    const videoId = params.get('v') || url.pathname.split('/')[1];
+    const start = params.get('t')?.replace('s', '');
+
+    if (videoId?.length !== YOUTUBE_VIDEO_ID_LENGTH) {
+        return undefined;
+    }
+
+    return { videoId, start };
+}

--- a/resources/js/lib/zenn-markdown.ts
+++ b/resources/js/lib/zenn-markdown.ts
@@ -90,7 +90,13 @@ function rewriteImageLine(line: string, caption?: string): string | null {
 }
 
 export function preprocessZennSyntax(markdown: string): string {
-    return markdown.replace(/:::message\s+alert\b/g, ':::message{.alert}');
+    return (
+        markdown
+            // Normalize :::message alert to the attribute form remark-directive expects.
+            .replace(/:::message\s+alert\b/g, ':::message{.alert}')
+            // Convert @[card](URL) to a bare URL line so remark-linkify-to-card picks it up.
+            .replace(/^@\[card\]\((https?:\/\/[^\s)]+)\)$/gm, '$1')
+    );
 }
 
 export function preprocessZennMarkdown(markdown: string): string {

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,9 +1,14 @@
 <?php
 
+use App\Http\Controllers\Api\OgpController;
 use App\Http\Controllers\PostController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', [PostController::class, 'index'])->name('home');
+
+Route::get('/api/ogp', [OgpController::class, 'fetch'])
+    ->middleware('throttle:60,1')
+    ->name('api.ogp');
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::inertia('dashboard', 'dashboard')->name('dashboard');

--- a/tests/Browser/ZennMarkdownRenderingTest.php
+++ b/tests/Browser/ZennMarkdownRenderingTest.php
@@ -2,9 +2,28 @@
 
 use App\Models\Post;
 use App\Models\PostNamespace;
+use App\Services\OgpMetadataService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
+
+function fakeOgpMetadata(): void
+{
+    app()->bind(OgpMetadataService::class, function () {
+        return new class extends OgpMetadataService
+        {
+            public function fetch(string $url): ?array
+            {
+                return [
+                    'title' => 'Example Domain',
+                    'description' => 'This is an example.',
+                    'image' => null,
+                    'url' => $url,
+                ];
+            }
+        };
+    });
+}
 
 test('zenn-style markdown image metadata renders width and caption', function () {
     $namespace = PostNamespace::factory()->create([
@@ -29,7 +48,63 @@ MARKDOWN,
     $page = visit(route('posts.show', [$namespace, $post]));
 
     $page
+        ->assertNoJavaScriptErrors()
         ->assertSee('Guide cover image')
         ->assertAttribute('img[alt="Guide cover"]', 'width', '250')
         ->assertPresent('a[href="https://zenn.dev"]');
+});
+
+test('standalone URL renders as link card div', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Link Card
+
+https://example.com
+MARKDOWN,
+    ]);
+
+    fakeOgpMetadata();
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="embed-card-card"]');
+});
+
+test('@[card](URL) directive renders as link card', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Link Card
+
+@[card](https://example.com)
+MARKDOWN,
+    ]);
+
+    fakeOgpMetadata();
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="embed-card-card"]');
+});
+
+test('YouTube URL renders as iframe embed', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# YouTube
+
+https://www.youtube.com/watch?v=WRVsOCh907o
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="embed-card-youtube"]')
+        ->assertPresent('iframe[src*="youtube-nocookie.com"]');
 });

--- a/tests/Feature/Api/OgpControllerTest.php
+++ b/tests/Feature/Api/OgpControllerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use App\Services\OgpMetadataService;
+use Illuminate\Support\Facades\Cache;
+
+test('invalid URL returns 422', function () {
+    $response = $this->getJson('/api/ogp?url=not-a-url');
+
+    $response->assertUnprocessable()
+        ->assertJson(['error' => 'Invalid URL']);
+});
+
+test('url parameter is required', function () {
+    $response = $this->getJson('/api/ogp');
+
+    $response->assertUnprocessable()
+        ->assertJson(['error' => 'Invalid URL']);
+});
+
+test('private network URLs are rejected', function () {
+    $this->mock(OgpMetadataService::class)
+        ->shouldReceive('isAllowedUrl')
+        ->once()
+        ->with('http://127.0.0.1/private')
+        ->andReturnFalse()
+        ->getMock()
+        ->shouldNotReceive('fetch');
+
+    $response = $this->getJson('/api/ogp?url='.urlencode('http://127.0.0.1/private'));
+
+    $response->assertUnprocessable()
+        ->assertJson(['error' => 'Invalid URL']);
+});
+
+test('returns 200 with metadata when OGP fetch succeeds', function () {
+    $this->mock(OgpMetadataService::class)
+        ->shouldReceive('isAllowedUrl')
+        ->once()
+        ->with('https://example.com')
+        ->andReturnTrue()
+        ->getMock()
+        ->shouldReceive('fetch')
+        ->once()
+        ->andReturn([
+            'title' => 'Example Site',
+            'description' => 'An example website.',
+            'image' => 'https://example.com/og.png',
+            'url' => 'https://example.com',
+        ]);
+
+    $response = $this->getJson('/api/ogp?url='.urlencode('https://example.com'));
+
+    $response->assertSuccessful()
+        ->assertJson([
+            'title' => 'Example Site',
+            'description' => 'An example website.',
+            'url' => 'https://example.com',
+        ]);
+});
+
+test('returns 404 when OGP metadata cannot be fetched', function () {
+    $this->mock(OgpMetadataService::class)
+        ->shouldReceive('isAllowedUrl')
+        ->once()
+        ->with('https://example.com')
+        ->andReturnTrue()
+        ->getMock()
+        ->shouldReceive('fetch')
+        ->once()
+        ->andReturn(null);
+
+    $response = $this->getJson('/api/ogp?url='.urlencode('https://example.com'));
+
+    $response->assertNotFound()
+        ->assertJson(['error' => 'Failed to fetch OGP metadata']);
+});
+
+test('result is cached for 24 hours', function () {
+    $url = 'https://example.com';
+
+    $this->mock(OgpMetadataService::class)
+        ->shouldReceive('isAllowedUrl')
+        ->twice()
+        ->with($url)
+        ->andReturnTrue()
+        ->getMock()
+        ->shouldReceive('fetch')
+        ->once() // called only once despite two requests
+        ->andReturn([
+            'title' => 'Cached Site',
+            'description' => null,
+            'image' => null,
+            'url' => $url,
+        ]);
+
+    Cache::forget('ogp:'.md5($url));
+
+    $this->getJson('/api/ogp?url='.urlencode($url))->assertStatus(200);
+    $this->getJson('/api/ogp?url='.urlencode($url))->assertStatus(200);
+});


### PR DESCRIPTION
## Summary
- render standalone URLs and `@[card](...)` markdown directives as rich link cards
- embed YouTube links in markdown posts and add seeded examples plus regression coverage
- add a cached OGP endpoint with public-target validation and route throttling

## Testing
- `vendor/bin/sail artisan test --compact tests/Feature/Api/OgpControllerTest.php tests/Browser/ZennMarkdownRenderingTest.php`
- `vendor/bin/sail npm exec -- eslint resources/js/components/embed-card.tsx resources/js/components/markdown-content.tsx resources/js/lib/remark-linkify-to-card.ts resources/js/lib/url-matcher.ts resources/js/lib/zenn-markdown.ts`
- `vendor/bin/sail npm run types:check`