### PR TITLE
feat: support code block metadata in markdown

### DIFF
--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -643,8 +643,6 @@ MD),
                 'content' => trim(<<<'MD'
 # Zenn Syntax
 
-> **WIP:** This page is still under construction.
-
 Zenn supports a few convenient image patterns on top of regular Markdown.
 
 ## Basic Image
@@ -744,6 +742,49 @@ https://www.youtube.com/watch?v=WRVsOCh907o
 ```
 
 https://www.youtube.com/watch?v=WRVsOCh907o
+
+## Code Block with Filename
+
+Add `:filename` after the language name to display a filename label above the code block.
+
+Use `` ```php:index.php `` to attach a filename:
+
+```php:index.php
+<?php
+
+echo 'Hello, world!';
+```
+
+Use `` ```ts:src/utils.ts `` to attach a path:
+
+```ts:src/utils.ts
+export function greet(name: string): string {
+    return `Hello, ${name}!`;
+}
+```
+
+## Diff Highlighting
+
+Start the fence with `diff` followed by the language name to enable diff highlighting. Lines beginning with `+` are shown in green and lines beginning with `-` in red.
+
+Use `` ```diff js `` for diff highlighting:
+
+```diff js
+@@ -4,6 +4,5 @@
++    const foo = bar.baz([1, 2, 3]) + 1;
+-    let foo = bar.baz([1, 2, 3]);
+     return foo;
+```
+
+You can combine `diff` with a filename using `` ```diff ts:src/utils.ts ``:
+
+```diff ts:src/utils.ts
+@@ -1,5 +1,5 @@
+-export function greet(name: string) {
++export function greet(name: string): string {
+     return `Hello, ${name}!`;
+ }
+```
 MD),
                 'published_at' => now(),
             ]);

--- a/resources/js/components/code-block.tsx
+++ b/resources/js/components/code-block.tsx
@@ -1,5 +1,15 @@
 import { Check, Copy, MoveHorizontal, WrapText } from 'lucide-react';
 import Prism from 'prismjs';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-jsx';
+import 'prismjs/components/prism-markup-templating'; // required by prism-php
+import 'prismjs/components/prism-php';
+import 'prismjs/components/prism-python';
+import 'prismjs/components/prism-tsx';
+import 'prismjs/components/prism-typescript';
 import type { ComponentPropsWithoutRef } from 'react';
 import { useState } from 'react';
 import type { ExtraProps } from 'react-markdown';
@@ -15,7 +25,56 @@ const isMobileViewport = () =>
     typeof window !== 'undefined' &&
     window.matchMedia('(max-width: 767px)').matches;
 
-export function CodeBlock({ className, children }: CodeBlockProps) {
+/**
+ * Parses the fenced code block info string to extract language, filename, and
+ * whether this is a diff block.
+ *
+ * Supported formats:
+ *   php:index.php          → language=php, filename=index.php, isDiff=false
+ *   diff js:app.js         → language=js,  filename=app.js,   isDiff=true
+ *   diff js                → language=js,  filename=null,     isDiff=true
+ */
+function parseCodeMeta(
+    className: string | undefined,
+    metastring: string | undefined,
+): { language: string; filename: string | null; isDiff: boolean } {
+    const rawLang = /language-(\w+)/.exec(className ?? '')?.[1] ?? '';
+    let language = rawLang;
+    let filename: string | null = null;
+    let isDiff = false;
+
+    if (rawLang === 'diff') {
+        isDiff = true;
+        // meta holds the real language (and optional filename): "js:app.js" or "js"
+        const langPart = metastring?.split(/\s+/)[0] ?? '';
+
+        if (langPart.includes(':')) {
+            [language, filename] = langPart.split(':') as [string, string];
+        } else {
+            language = langPart;
+        }
+    } else if (className?.includes(':')) {
+        // className is "language-php:index.php" — colon separates lang from filename
+        const afterPrefix = (className ?? '').replace(/^.*language-/, '');
+        const colonIdx = afterPrefix.indexOf(':');
+
+        language = afterPrefix.slice(0, colonIdx);
+        filename = afterPrefix.slice(colonIdx + 1);
+    } else if (metastring) {
+        // Fallback: meta carries "lang[:filename]"
+        const langPart = metastring.split(/\s+/)[0] ?? '';
+
+        if (langPart.includes(':')) {
+            [language, filename] = langPart.split(':') as [string, string];
+        } else if (langPart) {
+            language = langPart;
+        }
+    }
+
+    return { language, filename, isDiff };
+}
+
+export function CodeBlock({ className, children, node }: CodeBlockProps) {
     const [wrap, setWrap] = useState(isMobileViewport);
     const [copied, setCopied] = useState(false);
     const [, copy] = useClipboard();
@@ -23,18 +82,6 @@ export function CodeBlock({ className, children }: CodeBlockProps) {
     const rawContent = String(children);
     const content = rawContent.replace(/\n$/, '');
 
-    const handleCopy = async () => {
-        const didCopy = await copy(content);
-
-        if (!didCopy) {
-            return;
-        }
-
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-    };
-    const languageMatch = /language-(\w+)/.exec(className || '');
-    const language = languageMatch?.[1] ?? '';
     // react-markdown v10: fenced code blocks always have a trailing newline in children
     const isInline = !className && !rawContent.endsWith('\n');
 
@@ -46,12 +93,191 @@ export function CodeBlock({ className, children }: CodeBlockProps) {
         );
     }
 
+    const metastring = node?.properties?.metastring as string | undefined;
+    const { language, filename, isDiff } = parseCodeMeta(className, metastring);
     const highlightLang = language === 'blade' ? 'html' : language;
 
     if (highlightLang === 'mermaid') {
         return <MermaidBlock code={content} />;
     }
 
+    const handleCopy = async () => {
+        let textToCopy = content;
+
+        if (isDiff) {
+            textToCopy = content
+                .split('\n')
+                .map((line) => {
+                    if (
+                        line.startsWith('+') ||
+                        line.startsWith('-') ||
+                        line.startsWith(' ')
+                    ) {
+                        return line.slice(1);
+                    }
+
+                    return line;
+                })
+                .join('\n');
+        }
+
+        const didCopy = await copy(textToCopy);
+
+        if (!didCopy) {
+            return;
+        }
+
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
+
+    const wrapToggleButton = (
+        <button
+            type="button"
+            onClick={() => setWrap((v) => !v)}
+            aria-label={
+                wrap ? 'Enable horizontal scrolling' : 'Enable line wrapping'
+            }
+            className="rounded p-1 text-gray-400 transition-colors hover:bg-gray-700 hover:text-gray-200"
+            title={wrap ? 'Scroll' : 'Wrap'}
+        >
+            {wrap ? <MoveHorizontal size={16} /> : <WrapText size={16} />}
+        </button>
+    );
+
+    const copyButton = (
+        <button
+            type="button"
+            onClick={handleCopy}
+            aria-label={copied ? 'Copied code to clipboard' : 'Copy code'}
+            className="rounded p-1 text-gray-400 transition-colors hover:bg-gray-700 hover:text-gray-200"
+            title="Copy"
+        >
+            {copied ? <Check size={16} /> : <Copy size={16} />}
+        </button>
+    );
+
+    // --- diff rendering ---
+    if (isDiff) {
+        const prismLanguage =
+            highlightLang && Prism.languages[highlightLang]
+                ? Prism.languages[highlightLang]
+                : null;
+
+        return (
+            <div className="not-prose my-4 overflow-hidden rounded-lg border border-gray-700 bg-[#282c34]">
+                <div className="flex items-center justify-between border-b border-gray-700 bg-gray-800 px-4 py-2 font-mono text-sm text-gray-300">
+                    <span>{filename ?? language}</span>
+                    <div className="flex gap-1">
+                        {wrapToggleButton}
+                        {copyButton}
+                    </div>
+                </div>
+                <div className={wrap ? '' : 'overflow-x-auto'}>
+                    <pre className="my-0 font-mono text-sm">
+                        <code>
+                            {content.split('\n').map((line, index) => {
+                                let bgColor = 'transparent';
+                                let symbol = ' ';
+                                let codeContent = line;
+
+                                if (line.startsWith('@@')) {
+                                    bgColor = 'rgba(59,130,246,0.15)';
+                                    symbol = ' ';
+                                    codeContent = line;
+                                } else if (line.startsWith('+')) {
+                                    bgColor = 'rgba(16,185,129,0.15)';
+                                    symbol = '+';
+                                    codeContent = line.slice(1);
+                                } else if (line.startsWith('-')) {
+                                    bgColor = 'rgba(239,68,68,0.15)';
+                                    symbol = '-';
+                                    codeContent = line.slice(1);
+                                } else if (line.startsWith(' ')) {
+                                    symbol = ' ';
+                                    codeContent = line.slice(1);
+                                }
+
+                                let highlightedHtml = escapeHtml(codeContent);
+
+                                if (prismLanguage && codeContent.trim()) {
+                                    try {
+                                        highlightedHtml = Prism.highlight(
+                                            codeContent,
+                                            prismLanguage,
+                                            highlightLang,
+                                        );
+                                    } catch {
+                                        // fall back to escaped plain text
+                                    }
+                                }
+
+                                return (
+                                    <div
+                                        key={index}
+                                        style={{ backgroundColor: bgColor }}
+                                        className={`grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-1 px-4 py-0.5 ${wrap ? 'break-words whitespace-pre-wrap' : ''}`}
+                                    >
+                                        <span
+                                            className="text-center text-gray-500 select-none"
+                                            aria-hidden="true"
+                                        >
+                                            {symbol}
+                                        </span>
+                                        <span
+                                            dangerouslySetInnerHTML={{
+                                                __html: highlightedHtml,
+                                            }}
+                                        />
+                                    </div>
+                                );
+                            })}
+                        </code>
+                    </pre>
+                </div>
+            </div>
+        );
+    }
+
+    // --- code block with filename header ---
+    if (filename) {
+        return (
+            <div className="not-prose my-4 overflow-hidden rounded-lg border border-gray-700 bg-[#282c34]">
+                <div className="flex items-center justify-between border-b border-gray-700 bg-gray-800 px-4 py-2 font-mono text-sm text-gray-300">
+                    <span>{filename}</span>
+                    <div className="flex gap-1">
+                        {wrapToggleButton}
+                        {copyButton}
+                    </div>
+                </div>
+                <pre
+                    className={`px-4 py-3 font-mono text-sm text-gray-300 ${wrap ? 'break-words whitespace-pre-wrap' : 'overflow-x-auto'}`}
+                    style={{ background: '#282c34' }}
+                >
+                    <code
+                        className={
+                            highlightLang
+                                ? `language-${highlightLang}`
+                                : undefined
+                        }
+                        style={{ background: 'transparent' }}
+                        dangerouslySetInnerHTML={{
+                            __html:
+                                highlightLang && Prism.languages[highlightLang]
+                                    ? Prism.highlight(
+                                          content,
+                                          Prism.languages[highlightLang],
+                                          highlightLang,
+                                      )
+                                    : escapeHtml(content),
+                        }}
+                    />
+                </pre>
+            </div>
+        );
+    }
+
+    // --- plain code block (existing behavior) ---
     return (
         <div className="not-prose relative my-4 overflow-hidden rounded-lg border border-gray-700 bg-[#282c34]">
             <div className="absolute top-2 right-2 flex gap-1">

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -10,6 +10,7 @@ import remarkEmoji from 'remark-emoji';
 import remarkGfm from 'remark-gfm';
 import remarkSupersub from 'remark-supersub';
 import { EmbedCard } from '@/components/embed-card';
+import { remarkCodeMeta } from '@/lib/remark-code-meta';
 import { remarkLinkifyToCard } from '@/lib/remark-linkify-to-card';
 import { remarkMark } from '@/lib/remark-mark';
 import { remarkZennDirective } from '@/lib/remark-zenn-directive';
@@ -71,6 +72,7 @@ export default function MarkdownContent({
         <ReactMarkdown
             remarkPlugins={[
                 [remarkGfm, { singleTilde: false }],
+                remarkCodeMeta,
                 remarkDirective,
                 remarkZennDirective,
                 remarkLinkifyToCard,

--- a/resources/js/lib/remark-code-meta.ts
+++ b/resources/js/lib/remark-code-meta.ts
@@ -1,0 +1,25 @@
+import type { Code, Root } from 'mdast';
+import { visit } from 'unist-util-visit';
+
+/**
+ * Remark plugin that preserves code block meta strings.
+ *
+ * Saves the meta portion of a fenced code block info string
+ * (everything after the first word) into node.data.hProperties.metastring
+ * so it is available as a prop in React components.
+ *
+ * Example: ```diff js:routes/web.php
+ *   lang = "diff", meta = "js:routes/web.php"
+ *   → hProperties.metastring = "js:routes/web.php"
+ */
+export function remarkCodeMeta() {
+    return (tree: Root) => {
+        visit(tree, 'code', (node: Code) => {
+            if (node.meta) {
+                const data = node.data || (node.data = {});
+                const hProperties = data.hProperties || (data.hProperties = {});
+                hProperties.metastring = node.meta;
+            }
+        });
+    };
+}

--- a/tests/Feature/PostSeederTest.php
+++ b/tests/Feature/PostSeederTest.php
@@ -7,7 +7,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
 
-test('post seeder creates the zenn syntax guide as work in progress', function () {
+test('post seeder creates the zenn syntax guide with code block examples', function () {
     $this->seed(PostSeeder::class);
 
     $namespace = PostNamespace::query()
@@ -24,12 +24,15 @@ test('post seeder creates the zenn syntax guide as work in progress', function (
 
     expect($post)->not->toBeNull();
     expect($post->title)->toBe('Zenn Syntax');
-    expect($post->content)->toContain('> **WIP:**');
     expect($post->content)->toContain('## Basic Image');
     expect($post->content)->toContain('## Sized Image');
     expect($post->content)->toContain('## Alt Text');
     expect($post->content)->toContain('## Caption');
     expect($post->content)->toContain('## Linked Image');
+    expect($post->content)->toContain('## Code Block with Filename');
+    expect($post->content)->toContain('```php:index.php');
+    expect($post->content)->toContain('## Diff Highlighting');
+    expect($post->content)->toContain('```diff ts:src/utils.ts');
     expect($post->content)->toContain('![Guide cover](/storage/namespaces/guide.png =250x)');
     expect($post->content)->toContain('![](/storage/namespaces/guide.png =250x)');
     expect($post->content)->toContain('*Guide cover image*');


### PR DESCRIPTION
## Summary
- preserve fenced code block meta strings so React code blocks can read filenames and diff metadata
- render filename headers and syntax-highlighted diff blocks in the markdown code component
- extend the seeded Zenn syntax guide examples and update the seeder test

## Validation
- `vendor/bin/sail bin pint --dirty --format agent`
- `vendor/bin/sail npx eslint resources/js/components/code-block.tsx resources/js/components/markdown-content.tsx resources/js/lib/remark-code-meta.ts`
- `vendor/bin/sail npm run types:check`
- `vendor/bin/sail artisan test --compact tests/Feature/PostSeederTest.php`