### PR TITLE
Add Zenn details blocks and fix Boost MCP startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,9 @@ yarn-error.log
 /.fleet
 /.idea
 /.nova
-/.vscode
+/.vscode/*
+!/.vscode/
+!/.vscode/mcp.json
 /.zed
 testing
 /tests/Browser/Screenshots

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,9 +1,9 @@
 {
-    "mcpServers": {
+    "servers": {
         "laravel-boost": {
             "command": "php",
             "args": [
-                "artisan",
+                "../artisan",
                 "boost:mcp"
             ]
         }

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -717,6 +717,70 @@ Your warning here
 Your warning here
 :::
 
+## Details (Collapsible)
+
+Wrap content in `:::details` followed by a title to create a collapsible block. The content is hidden until the reader clicks to expand it.
+
+```md
+:::details Click to expand
+This content is hidden by default.
+:::
+```
+
+:::details Click to expand
+This content is hidden by default.
+:::
+
+Any block content can go inside — paragraphs, code, lists, and even other directives.
+
+```md
+:::details Show code example
+Here is some hidden code:
+
+```ts
+function add(a: number, b: number): number {
+    return a + b;
+}
+` ``
+
+And a list:
+
+- Item one
+- Item two
+:::
+```
+
+:::details Show code example
+Here is some hidden code:
+
+```ts
+function add(a: number, b: number): number {
+    return a + b;
+}
+```
+
+And a list:
+
+- Item one
+- Item two
+:::
+
+To nest directives, use more colons on the outer block.
+
+```md
+::::details Details with a nested callout
+:::message
+This note is inside a collapsible section.
+:::
+::::
+```
+
+::::details Details with a nested callout
+:::message
+This note is inside a collapsible section.
+:::
+::::
+
 ## Link Card
 
 A URL placed alone on its own line is automatically displayed as a card.

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -144,3 +144,14 @@
         @apply bg-background text-foreground;
     }
 }
+
+details.details-block[open] > summary {
+    border-radius: var(--radius) var(--radius) 0 0;
+}
+
+details.details-block > summary + div {
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border);
+    border-top: none;
+    border-radius: 0 0 var(--radius) var(--radius);
+}

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -20,6 +20,35 @@ import {
     preprocessZennSyntax,
 } from '@/lib/zenn-markdown';
 
+function DetailsBox({
+    children,
+    ...props
+}: React.ComponentPropsWithoutRef<'details'>) {
+    return (
+        <details
+            className="details-block not-prose my-4 rounded-md border border-border text-sm"
+            data-test="details-block"
+            {...props}
+        >
+            {children}
+        </details>
+    );
+}
+
+function SummaryEl({
+    children,
+    ...props
+}: React.ComponentPropsWithoutRef<'summary'>) {
+    return (
+        <summary
+            className="cursor-pointer rounded-md bg-muted px-4 py-2 leading-relaxed font-medium select-none"
+            {...props}
+        >
+            {children}
+        </summary>
+    );
+}
+
 function MessageBox({
     children,
     className,
@@ -94,6 +123,8 @@ export default function MarkdownContent({
             }}
             components={{
                 aside: MessageBox,
+                details: DetailsBox,
+                summary: SummaryEl,
                 dl: ({ node, ...props }) => {
                     void node;
 

--- a/resources/js/lib/remark-zenn-directive.ts
+++ b/resources/js/lib/remark-zenn-directive.ts
@@ -1,4 +1,4 @@
-import type { Root } from 'mdast';
+import type { Paragraph, Root, Text } from 'mdast';
 import type { Node } from 'unist';
 import { visit } from 'unist-util-visit';
 
@@ -22,20 +22,56 @@ export function remarkZennDirective() {
 
             const directiveNode = node as ContainerDirectiveNode;
 
-            if (directiveNode.name !== 'message') {
-                return;
+            if (directiveNode.name === 'message') {
+                const attributes = directiveNode.attributes ?? {};
+                const className =
+                    attributes.className ?? attributes.class ?? '';
+                const isAlert =
+                    className.includes('alert') ||
+                    attributes.alert !== undefined;
+
+                const data = directiveNode.data ?? (directiveNode.data = {});
+                data.hName = 'aside';
+                data.hProperties = {
+                    className: `msg ${isAlert ? 'alert' : 'message'}`,
+                };
             }
 
-            const attributes = directiveNode.attributes ?? {};
-            const className = attributes.className ?? attributes.class ?? '';
-            const isAlert =
-                className.includes('alert') || attributes.alert !== undefined;
+            if (directiveNode.name === 'details') {
+                let summaryText = '詳細';
+                const bodyChildren = [...directiveNode.children];
 
-            const data = directiveNode.data ?? (directiveNode.data = {});
-            data.hName = 'aside';
-            data.hProperties = {
-                className: `msg ${isAlert ? 'alert' : 'message'}`,
-            };
+                if (
+                    bodyChildren.length > 0 &&
+                    bodyChildren[0].type === 'paragraph'
+                ) {
+                    const first = bodyChildren.shift() as Paragraph;
+
+                    if (first.children?.[0]?.type === 'text') {
+                        summaryText = (first.children[0] as Text).value;
+                    }
+                }
+
+                const data = directiveNode.data ?? (directiveNode.data = {});
+                data.hName = 'details';
+                data.hProperties = {};
+
+                directiveNode.children = [
+                    {
+                        type: 'paragraph',
+                        data: { hName: 'summary' },
+                        children: [{ type: 'text', value: summaryText }],
+                    } as Paragraph,
+                    {
+                        type: 'paragraph',
+                        data: {
+                            hName: 'div',
+                            hProperties: { className: 'details-content' },
+                        },
+                        children: bodyChildren,
+                    } as Paragraph,
+                ];
+            }
         });
     };
 }

--- a/resources/js/lib/remark-zenn-directive.ts
+++ b/resources/js/lib/remark-zenn-directive.ts
@@ -38,7 +38,7 @@ export function remarkZennDirective() {
             }
 
             if (directiveNode.name === 'details') {
-                let summaryText = '詳細';
+                let summaryText = 'Details';
                 const bodyChildren = [...directiveNode.children];
 
                 if (

--- a/resources/js/lib/zenn-markdown.ts
+++ b/resources/js/lib/zenn-markdown.ts
@@ -94,6 +94,8 @@ export function preprocessZennSyntax(markdown: string): string {
         markdown
             // Normalize :::message alert to the attribute form remark-directive expects.
             .replace(/:::message\s+alert\b/g, ':::message{.alert}')
+            // Convert :::details title to the label form remark-directive expects.
+            .replace(/:::details\s+(.+?)(\r?\n)/g, ':::details[$1]$2')
             // Convert @[card](URL) to a bare URL line so remark-linkify-to-card picks it up.
             .replace(/^@\[card\]\((https?:\/\/[^\s)]+)\)$/gm, '$1')
     );

--- a/tests/Browser/ZennMarkdownRenderingTest.php
+++ b/tests/Browser/ZennMarkdownRenderingTest.php
@@ -92,6 +92,26 @@ MARKDOWN,
         ->assertPresent('[data-test="embed-card-card"]');
 });
 
+test(':::details directive renders as details/summary element', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Details Test
+
+:::details 詳細を見る
+隠れているコンテンツ
+:::
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="details-block"]')
+        ->assertSee('詳細を見る');
+});
+
 test('YouTube URL renders as iframe embed', function () {
     $namespace = PostNamespace::factory()->create(['is_published' => true]);
     $post = Post::factory()->for($namespace, 'namespace')->published()->create([

--- a/tests/Browser/ZennMarkdownRenderingTest.php
+++ b/tests/Browser/ZennMarkdownRenderingTest.php
@@ -98,8 +98,8 @@ test(':::details directive renders as details/summary element', function () {
         'content' => <<<'MARKDOWN'
 # Details Test
 
-:::details 詳細を見る
-隠れているコンテンツ
+:::details Show details
+Hidden content
 :::
 MARKDOWN,
     ]);
@@ -109,7 +109,7 @@ MARKDOWN,
     $page
         ->assertNoJavaScriptErrors()
         ->assertPresent('[data-test="details-block"]')
-        ->assertSee('詳細を見る');
+        ->assertSee('Show details');
 });
 
 test('YouTube URL renders as iframe embed', function () {


### PR DESCRIPTION
## Summary
- add support for Zenn-style `:::details` directives in the markdown renderer and style the resulting details/summary UI
- cover the new details output in browser tests and expand the seeded sample post with collapsible block examples
- make the Laravel Boost MCP configuration start reliably from both project-level and VS Code config files without depending on Sail-relative paths

## Testing
- `vendor/bin/sail artisan test --compact tests/Browser/ZennMarkdownRenderingTest.php`