### PR TITLE
Add GitHub file embeds for markdown posts

### DIFF
--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -849,6 +849,32 @@ You can combine `diff` with a filename using `` ```diff ts:src/utils.ts ``:
      return `Hello, ${name}!`;
  }
 ```
+
+## GitHub Embed
+
+A GitHub file URL placed alone on its own line is automatically embedded as a code block.
+
+```md
+https://github.com/zenn-dev/zenn-editor/blob/canary/lerna.json
+```
+
+https://github.com/zenn-dev/zenn-editor/blob/canary/lerna.json
+
+Use a line range with `#L{start}-L{end}` to show a specific section.
+
+```md
+https://github.com/zenn-dev/zenn-editor/blob/canary/lerna.json#L1-L3
+```
+
+https://github.com/zenn-dev/zenn-editor/blob/canary/lerna.json#L1-L3
+
+The `@[github](URL)` form also works.
+
+```md
+@[github](https://github.com/zenn-dev/zenn-editor/blob/canary/lerna.json)
+```
+
+@[github](https://github.com/zenn-dev/zenn-editor/blob/canary/lerna.json)
 MD),
                 'published_at' => now(),
             ]);

--- a/resources/js/components/embed-card.tsx
+++ b/resources/js/components/embed-card.tsx
@@ -1,10 +1,11 @@
 import { ExternalLink } from 'lucide-react';
 import React from 'react';
+import { GithubEmbed } from '@/components/github-embed';
 import { extractYoutubeVideoParameters } from '@/lib/url-matcher';
 
 interface EmbedCardProps {
     url: string;
-    type: 'youtube' | 'card';
+    type: 'youtube' | 'card' | 'github';
 }
 
 /**
@@ -174,6 +175,10 @@ function LinkCard({ url }: { url: string }) {
 export function EmbedCard({ url, type }: EmbedCardProps) {
     if (type === 'youtube') {
         return <YoutubeEmbed url={url} />;
+    }
+
+    if (type === 'github') {
+        return <GithubEmbed url={url} />;
     }
 
     return <LinkCard url={url} />;

--- a/resources/js/components/github-embed.tsx
+++ b/resources/js/components/github-embed.tsx
@@ -1,0 +1,266 @@
+import { ExternalLink, FileCode } from 'lucide-react';
+import Prism from 'prismjs';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-jsx';
+import 'prismjs/components/prism-markup-templating';
+import 'prismjs/components/prism-php';
+import 'prismjs/components/prism-python';
+import 'prismjs/components/prism-tsx';
+import 'prismjs/components/prism-typescript';
+import React from 'react';
+import { parseGithubUrl } from '@/lib/url-matcher';
+
+/** Maximum number of lines to display when no line range is specified. */
+const MAX_LINES = 200;
+
+const EXTENSION_TO_LANGUAGE: Record<string, string> = {
+    ts: 'typescript',
+    tsx: 'tsx',
+    js: 'javascript',
+    jsx: 'jsx',
+    php: 'php',
+    py: 'python',
+    css: 'css',
+    json: 'json',
+    sh: 'bash',
+    bash: 'bash',
+    html: 'html',
+    htm: 'html',
+    md: 'markdown',
+    yml: 'yaml',
+    yaml: 'yaml',
+};
+
+function detectLanguage(path: string): string {
+    const ext = path.split('.').at(-1)?.toLowerCase() ?? '';
+
+    return EXTENSION_TO_LANGUAGE[ext] ?? ext;
+}
+
+function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+interface GithubEmbedProps {
+    url: string;
+}
+
+export function GithubEmbed({ url }: GithubEmbedProps) {
+    const info = React.useMemo(() => parseGithubUrl(url), [url]);
+    const [lines, setLines] = React.useState<string[] | null>(null);
+    const [loading, setLoading] = React.useState(true);
+    const [error, setError] = React.useState(false);
+
+    React.useEffect(() => {
+        setLines(null);
+        setError(false);
+        setLoading(true);
+
+        if (!info) {
+            setError(true);
+            setLoading(false);
+
+            return;
+        }
+
+        const rawUrl = `https://raw.githubusercontent.com/${info.owner}/${info.repo}/${info.branch}/${info.path}`;
+
+        const fetchContent = async () => {
+            try {
+                const response = await fetch(rawUrl);
+
+                if (!response.ok) {
+                    setError(true);
+
+                    return;
+                }
+
+                const text = await response.text();
+                const allLines = text.split('\n');
+
+                const start = info.lineStart ?? 1;
+                const end = info.lineEnd ?? info.lineStart ?? null;
+
+                if (end !== null) {
+                    setLines(allLines.slice(start - 1, end));
+                } else if (info.lineStart !== undefined) {
+                    setLines(allLines.slice(start - 1, start));
+                } else {
+                    setLines(allLines.slice(0, MAX_LINES));
+                }
+            } catch {
+                setError(true);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        void fetchContent();
+    }, [info]);
+
+    if (!info) {
+        return (
+            <div className="not-prose my-4" data-test="embed-github">
+                <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-500 underline"
+                >
+                    {url}
+                </a>
+            </div>
+        );
+    }
+
+    const filename = info.path.split('/').at(-1) ?? info.path;
+    const language = detectLanguage(info.path);
+    const lineStart = info.lineStart ?? 1;
+
+    const lineLabel =
+        info.lineStart !== undefined
+            ? info.lineEnd !== undefined
+                ? `L${info.lineStart}–L${info.lineEnd}`
+                : `L${info.lineStart}`
+            : null;
+
+    const headerLabel = `${info.owner}/${info.repo}/${info.path}${lineLabel ? ` (${lineLabel})` : ''}`;
+
+    if (loading) {
+        return (
+            <div
+                className="not-prose my-4 overflow-hidden rounded-lg border border-gray-700 bg-[#282c34]"
+                data-test="embed-github"
+            >
+                <div className="flex items-center justify-between border-b border-gray-700 bg-gray-800 px-4 py-2">
+                    <div className="flex min-w-0 items-center gap-2">
+                        <FileCode
+                            size={14}
+                            className="shrink-0 text-gray-400"
+                        />
+                        <div className="h-3.5 w-48 animate-pulse rounded bg-gray-600" />
+                    </div>
+                    <div className="h-3.5 w-24 animate-pulse rounded bg-gray-600" />
+                </div>
+                <div className="space-y-2 px-4 py-3">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                        <div
+                            key={i}
+                            className="h-3 animate-pulse rounded bg-gray-700"
+                            style={{ width: `${60 + (i % 3) * 15}%` }}
+                        />
+                    ))}
+                </div>
+            </div>
+        );
+    }
+
+    if (error || lines === null) {
+        return (
+            <div
+                className="not-prose my-4 overflow-hidden rounded-lg border border-gray-700 bg-[#282c34]"
+                data-test="embed-github"
+            >
+                <div className="flex items-center justify-between border-b border-gray-700 bg-gray-800 px-4 py-2">
+                    <div className="flex min-w-0 items-center gap-2 truncate font-mono text-xs text-gray-300">
+                        <FileCode
+                            size={14}
+                            className="shrink-0 text-gray-400"
+                        />
+                        <span className="truncate">{headerLabel}</span>
+                    </div>
+                    <a
+                        href={url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-3 flex shrink-0 items-center gap-1 text-xs text-gray-400 hover:text-gray-200"
+                    >
+                        <ExternalLink size={12} />
+                        View
+                    </a>
+                </div>
+                <div className="px-4 py-3 font-mono text-xs text-gray-400">
+                    Failed to load file content.
+                </div>
+            </div>
+        );
+    }
+
+    const highlightedLines = lines.map((line) => {
+        if (language && Prism.languages[language]) {
+            try {
+                return Prism.highlight(
+                    line,
+                    Prism.languages[language],
+                    language,
+                );
+            } catch {
+                return escapeHtml(line);
+            }
+        }
+
+        return escapeHtml(line);
+    });
+
+    return (
+        <div
+            className="not-prose my-4 overflow-hidden rounded-lg border border-gray-700 bg-[#282c34]"
+            data-test="embed-github"
+        >
+            <div className="flex items-center justify-between border-b border-gray-700 bg-gray-800 px-4 py-2">
+                <div className="flex min-w-0 items-center gap-2 font-mono text-xs text-gray-300">
+                    <FileCode size={14} className="shrink-0 text-gray-400" />
+                    <a
+                        href={url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="truncate hover:text-white hover:underline"
+                        title={headerLabel}
+                    >
+                        {filename}
+                    </a>
+                    {lineLabel && (
+                        <span className="text-gray-500">{lineLabel}</span>
+                    )}
+                </div>
+                <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="ml-3 flex shrink-0 items-center gap-1 text-xs text-gray-400 hover:text-gray-200"
+                >
+                    <ExternalLink size={12} />
+                    {info.owner}/{info.repo}
+                </a>
+            </div>
+            <div className="overflow-x-auto">
+                <pre className="my-0 font-mono text-sm">
+                    <code>
+                        {highlightedLines.map((html, index) => (
+                            <div
+                                key={index}
+                                className="grid grid-cols-[2.5rem_minmax(0,1fr)] items-start px-4 py-0.5 hover:bg-white/5"
+                            >
+                                <span
+                                    className="pr-4 text-right text-xs text-gray-500 select-none"
+                                    aria-hidden="true"
+                                >
+                                    {lineStart + index}
+                                </span>
+                                <span
+                                    dangerouslySetInnerHTML={{ __html: html }}
+                                />
+                            </div>
+                        ))}
+                    </code>
+                </pre>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -145,7 +145,7 @@ export default function MarkdownContent({
                 div: (props: React.ComponentPropsWithoutRef<'div'>) => {
                     const embedType = (props as Record<string, unknown>)[
                         'data-embed-type'
-                    ] as 'youtube' | 'card' | undefined;
+                    ] as 'youtube' | 'card' | 'github' | undefined;
                     const embedUrl = (props as Record<string, unknown>)[
                         'data-embed-url'
                     ] as string | undefined;

--- a/resources/js/lib/remark-linkify-to-card.ts
+++ b/resources/js/lib/remark-linkify-to-card.ts
@@ -7,9 +7,9 @@
  */
 import type { Link, Paragraph, Root, Text } from 'mdast';
 import { visit } from 'unist-util-visit';
-import { isYoutubeUrl } from './url-matcher';
+import { isGithubUrl, isYoutubeUrl } from './url-matcher';
 
-export type EmbedType = 'youtube' | 'card';
+export type EmbedType = 'youtube' | 'card' | 'github';
 
 /**
  * Returns the link node if the paragraph contains only a single standalone link,
@@ -52,6 +52,10 @@ function isStandaloneLinkInParagraph(paragraph: Paragraph): Link | null {
 function detectEmbedType(url: string): EmbedType {
     if (isYoutubeUrl(url)) {
         return 'youtube';
+    }
+
+    if (isGithubUrl(url)) {
+        return 'github';
     }
 
     return 'card';

--- a/resources/js/lib/url-matcher.ts
+++ b/resources/js/lib/url-matcher.ts
@@ -2,6 +2,49 @@
  * URL matching utilities
  */
 
+/**
+ * Returns true if the URL is a GitHub file blob URL.
+ * Ported from zenn-editor's url-matcher.
+ */
+export function isGithubUrl(url: string): boolean {
+    return /^https:\/\/github\.com\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/([a-zA-Z0-9](-?[a-zA-Z0-9._]){0,99})\/blob\/[^~\s:?[*^/\\]{2,}\/[\w!\-_~.*%()'"/]+(?:#L\d+(?:-L\d+)?)?$/.test(
+        url,
+    );
+}
+
+export type GithubFileInfo = {
+    owner: string;
+    repo: string;
+    branch: string;
+    path: string;
+    lineStart?: number;
+    lineEnd?: number;
+};
+
+/**
+ * Parses a GitHub blob URL into its components.
+ * Returns null if the URL does not match the expected format.
+ */
+export function parseGithubUrl(url: string): GithubFileInfo | null {
+    const match =
+        /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/([^/]+)\/(.+?)(?:#L(\d+)(?:-L(\d+))?)?$/.exec(
+            url,
+        );
+
+    if (!match) {
+        return null;
+    }
+
+    return {
+        owner: match[1],
+        repo: match[2],
+        branch: match[3],
+        path: match[4],
+        lineStart: match[5] ? parseInt(match[5], 10) : undefined,
+        lineEnd: match[6] ? parseInt(match[6], 10) : undefined,
+    };
+}
+
 /** Returns true if the URL is a YouTube video URL. */
 export function isYoutubeUrl(url: string): boolean {
     return [

--- a/resources/js/lib/zenn-markdown.ts
+++ b/resources/js/lib/zenn-markdown.ts
@@ -98,6 +98,8 @@ export function preprocessZennSyntax(markdown: string): string {
             .replace(/:::details\s+(.+?)(\r?\n)/g, ':::details[$1]$2')
             // Convert @[card](URL) to a bare URL line so remark-linkify-to-card picks it up.
             .replace(/^@\[card\]\((https?:\/\/[^\s)]+)\)$/gm, '$1')
+            // Convert @[github](URL) to a bare URL line so remark-linkify-to-card picks it up.
+            .replace(/^@\[github\]\((https?:\/\/[^\s)]+)\)$/gm, '$1')
     );
 }
 

--- a/tests/Browser/ZennMarkdownRenderingTest.php
+++ b/tests/Browser/ZennMarkdownRenderingTest.php
@@ -128,3 +128,35 @@ MARKDOWN,
         ->assertPresent('[data-test="embed-card-youtube"]')
         ->assertPresent('iframe[src*="youtube-nocookie.com"]');
 });
+
+test('GitHub URL renders as github embed', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# GitHub
+
+https://github.com/zenn-dev/zenn-editor/blob/canary/lerna.json
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="embed-github"]');
+});
+
+test('@[github](URL) directive renders as github embed', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# GitHub
+
+@[github](https://github.com/zenn-dev/zenn-editor/blob/canary/lerna.json)
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="embed-github"]');
+});

--- a/tests/Feature/PostSeederTest.php
+++ b/tests/Feature/PostSeederTest.php
@@ -33,6 +33,9 @@ test('post seeder creates the zenn syntax guide with code block examples', funct
     expect($post->content)->toContain('```php:index.php');
     expect($post->content)->toContain('## Diff Highlighting');
     expect($post->content)->toContain('```diff ts:src/utils.ts');
+    expect($post->content)->toContain('## GitHub Embed');
+    expect($post->content)->toContain('https://github.com/zenn-dev/zenn-editor/blob/canary/lerna.json');
+    expect($post->content)->toContain('@[github](https://github.com/zenn-dev/zenn-editor/blob/canary/lerna.json)');
     expect($post->content)->toContain('![Guide cover](/storage/namespaces/guide.png =250x)');
     expect($post->content)->toContain('![](/storage/namespaces/guide.png =250x)');
     expect($post->content)->toContain('*Guide cover image*');


### PR DESCRIPTION
## Summary
- add GitHub blob URL detection and a dedicated embed component that renders file previews with optional line ranges
- wire GitHub embeds into markdown preprocessing and embed dispatch, and document the syntax in the seeded Zenn guide
- extend seeder coverage and add browser assertions for standalone GitHub URLs and `@[github](...)`

## Validation
- `vendor/bin/sail npx eslint resources/js/components/embed-card.tsx resources/js/components/github-embed.tsx resources/js/components/markdown-content.tsx resources/js/lib/remark-linkify-to-card.ts resources/js/lib/url-matcher.ts resources/js/lib/zenn-markdown.ts`
- `vendor/bin/sail npm run types:check`
- `vendor/bin/sail artisan test --compact tests/Feature/PostSeederTest.php`

## Notes
- `vendor/bin/sail artisan test --compact tests/Browser/ZennMarkdownRenderingTest.php` still fails on browser assertions that already exist on `main`; the newly added GitHub cases fail in the same pre-existing suite failure mode.