### PR TITLE
Add Mintlify tabs rendering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@ Custom markdown behavior is split into three layers:
 1. `resources/js/lib/zenn-markdown.ts`
    - Preprocesses source text before `react-markdown` parses it.
    - `preprocessZennSyntax()` normalizes shorthand Zenn directive syntax such as `:::message alert` into directive attributes that `remark-directive` can understand.
+   - The same preprocessing layer also normalizes selected Mintlify-style JSX snippets such as `<Tabs>` / `<Tab>` into directive syntax before parsing.
    - `preprocessZennMarkdown()` rewrites image syntax like `![](/path/to/image.png =250x)` and carries width, height, and caption metadata through the URL while skipping fenced code blocks.
 2. `resources/js/lib/remark-zenn-directive.ts`
    - Converts parsed Zenn container directives into HTML nodes that React can render.
    - Current support maps `:::message` and `:::message alert` into `<aside>` nodes with message or alert styling.
+   - `resources/js/lib/remark-tabs-directive.ts` maps `:::tabs` / `:::tab` directives into custom `<tabs>` / `<tab>` nodes for the React renderer.
 3. `resources/js/lib/markdown-components.tsx`
    - Overrides markdown element rendering for headings, code blocks, images, and caption-like paragraphs.
    - `resources/js/components/code-block.tsx` also treats fenced `mermaid` blocks specially and renders them through `resources/js/components/mermaid-block.tsx`.
+   - `resources/js/components/markdown-tabs.tsx` renders tab groups produced from Mintlify-style `<Tabs>` syntax.
 
 ### Supported extensions in this repository
 
@@ -27,6 +30,16 @@ Current seeded examples cover:
 4. `:::message` and `:::message alert` callout blocks
 5. Fenced `mermaid` code blocks rendered as diagrams
 6. Link cards from standalone URLs and `@[card](URL)` directives, with OGP metadata fetched server-side and YouTube URLs rendered as iframe embeds
+7. Mintlify-style `<Tabs>` / `<Tab>` blocks, normalized into directives before parsing and rendered as interactive tabs
+
+Planned components tracked in the `mintlify-syntax` seeded post (WIP):
+
+- `<Accordion>` — maps directly to `:::details`; no new component needed
+- `<Callout type="info|warning">` — maps directly to `:::message` / `:::message{.alert}`; no new component needed
+- `<Steps>` / `<Step>` — requires a new directive handler and React component
+- `<Card>` / `<CardGroup>` — includes self-closing `<Card ... />` syntax; requires a new code path
+- `<CodeGroup>` — variant of `<Tabs>` restricted to code blocks
+- `<Banner>`, `<Badge>`, `<Frame>`, Mermaid, `<ResponseField>`, `<ParamField>` — lower priority; decide per component whether to render natively or leave as literal code
 
 ### Adding more Zenn syntax
 
@@ -40,3 +53,36 @@ When adding a new Zenn-style snippet or block syntax:
 6. Add regression coverage in a browser test and, when appropriate, a feature test for seeded content.
 
 This keeps the markdown pipeline composable without introducing a separate renderer registry.
+
+### Adding Mintlify syntax
+
+Mintlify uses JSX-like tags (`<Tabs>`, `<Tab>`, `<Accordion>`, …) that `react-markdown` cannot parse directly. These are converted to `remark-directive` container directive syntax in `preprocessMintlifySyntax()` before the parser runs.
+
+The two-pass approach for any new component is:
+
+1. **Preprocessor** (`preprocessMintlifySyntax` in `zenn-markdown.ts`) — strip JSX tags and emit directive syntax.
+2. **Remark plugin** (`remark-tabs-directive.ts` or a new file) — set `hName` and `hProperties` on the AST node.
+3. **React component** (`markdown-content.tsx` component map) — render the final HTML.
+
+Some planned components skip steps 2 and 3 because they reuse existing Zenn rendering:
+
+| Mintlify tag | Directive output | Rendered by |
+|---|---|---|
+| `<Tabs>` / `<Tab>` | `::::tabs` / `:::tab` | `MarkdownTabs` / `MarkdownTab` via `remark-tabs-directive` |
+| `<Accordion title="X">` | `:::details[X]` | `DetailsBox` via `remarkZennDirective` — no new code |
+| `<Callout type="info">` | `:::message` | `MessageBox` via `remarkZennDirective` — no new code |
+| `<Callout type="warning">` | `:::message{.alert}` | `MessageBox` via `remarkZennDirective` — no new code |
+
+#### Things to be aware of when extending
+
+**`buildDirectiveAttributes` allowlist** — only attributes listed here are forwarded from the JSX tag into the directive attribute string. Add any new attribute names before relying on them downstream.
+
+```ts
+['title', 'icon', 'sync', 'borderBottom'].includes(key)
+```
+
+**Self-closing tags** — the open-tag regex (`/^<Foo(?<attributes>[^>]*)>$/`) does not match `<Card ... />`. Self-closing components need a separate regex branch in the preprocessor.
+
+**Container depth** — `<Tabs>` uses four colons (`::::`) at the outer level so the inner `:::tab` directives are unambiguously nested. Any new outer container that wraps a three-colon inner directive must use four colons for the same reason. Track depth with a counter similar to `mintlifyTabsDepth`.
+
+**Fenced code blocks inside tags** — the preprocessor tracks `activeFence` and strips tag-level indentation from fence lines. This is required because CommonMark treats a four-space-indented line starting with backticks as an indented code block rather than a fenced code block. Keep the `effectiveLine` stripping in place for any new tag-aware branch.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ The app renders markdown through `resources/js/components/markdown-content.tsx`,
 
 Custom markdown behavior is split into three layers:
 
-1. `resources/js/lib/zenn-markdown.ts`
+1. `resources/js/lib/markdown-syntax.ts`
    - Preprocesses source text before `react-markdown` parses it.
-   - `preprocessZennSyntax()` normalizes shorthand Zenn directive syntax such as `:::message alert` into directive attributes that `remark-directive` can understand.
+   - `preprocessMarkdownSyntax()` normalizes shorthand Zenn directive syntax such as `:::message alert` into directive attributes that `remark-directive` can understand.
    - The same preprocessing layer also normalizes selected Mintlify-style JSX snippets such as `<Tabs>` / `<Tab>` into directive syntax before parsing.
-   - `preprocessZennMarkdown()` rewrites image syntax like `![](/path/to/image.png =250x)` and carries width, height, and caption metadata through the URL while skipping fenced code blocks.
+   - `preprocessMarkdownContent()` rewrites image syntax like `![](/path/to/image.png =250x)` and carries width, height, and caption metadata through the URL while skipping fenced code blocks.
 2. `resources/js/lib/remark-zenn-directive.ts`
    - Converts parsed Zenn container directives into HTML nodes that React can render.
    - Current support maps `:::message` and `:::message alert` into `<aside>` nodes with message or alert styling.
@@ -45,8 +45,8 @@ Planned components tracked in the `mintlify-syntax` seeded post (WIP):
 
 When adding a new Zenn-style snippet or block syntax:
 
-1. Normalize shorthand source syntax in `preprocessZennSyntax()` when the parser needs a more explicit form.
-2. Extend `preprocessZennMarkdown()` when the feature is best represented as rewritten markdown or encoded metadata.
+1. Normalize shorthand source syntax in `preprocessMarkdownSyntax()` when the parser needs a more explicit form.
+2. Extend `preprocessMarkdownContent()` when the feature is best represented as rewritten markdown or encoded metadata.
 3. Add or update `remarkZennDirective()` when the feature should become a custom markdown node after parsing.
 4. Add or update a renderer in `createMarkdownComponents()` when the final HTML needs custom React output.
 5. Add seeded example content in `database/seeders/PostSeeder.php`.
@@ -60,7 +60,7 @@ Mintlify uses JSX-like tags (`<Tabs>`, `<Tab>`, `<Accordion>`, …) that `react-
 
 The two-pass approach for any new component is:
 
-1. **Preprocessor** (`preprocessMintlifySyntax` in `zenn-markdown.ts`) — strip JSX tags and emit directive syntax.
+1. **Preprocessor** (`preprocessMintlifySyntax` in `markdown-syntax.ts`) — strip JSX tags and emit directive syntax.
 2. **Remark plugin** (`remark-tabs-directive.ts` or a new file) — set `hName` and `hProperties` on the AST node.
 3. **React component** (`markdown-content.tsx` component map) — render the final HTML.
 

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -29,7 +29,7 @@ class PostSeeder extends Seeder
                 'name' => 'Guides',
                 'description' => 'Practical guides, walkthroughs, and reference notes for writing and publishing posts.',
                 'cover_image' => $coverImagePath,
-                'post_order' => ['index', 'extended-syntax', 'zenn-syntax'],
+                'post_order' => ['index', 'extended-syntax', 'zenn-syntax', 'mintlify-syntax'],
             ],
         );
 
@@ -875,6 +875,190 @@ The `@[github](URL)` form also works.
 ```
 
 @[github](https://github.com/zenn-dev/zenn-editor/blob/canary/lerna.json)
+MD),
+                'published_at' => now(),
+            ]);
+
+        Post::updateOrCreate(
+            ['namespace_id' => $namespace->id, 'slug' => 'mintlify-syntax'],
+            [
+                'user_id' => $user->id,
+                'title' => 'Mintlify Syntax (WIP)',
+                'content' => trim(<<<'MD'
+# Mintlify Syntax
+
+Mintlify ships with MDX-flavored components for docs sites. This page is a working draft that collects syntax examples we may support or document later.
+
+> **WIP:** Some examples below are shown as reference syntax only. They may not render with the current ThinkStream Markdown pipeline yet.
+
+---
+
+# Cards
+
+Mintlify uses `<Card>` blocks to create linked navigation tiles.
+
+```mdx
+<Card title="Tabs" icon="folder" href="/components/tabs">
+  Organize related content into a switchable tab UI.
+</Card>
+```
+
+Reference example:
+
+```mdx
+<Card title="Callouts" icon="message-square-warning" href="/components/callouts">
+  Highlight important information with styled alerts.
+</Card>
+```
+
+---
+
+# Card Groups
+
+Cards are often grouped to create documentation indexes.
+
+```mdx
+<CardGroup cols={2}>
+  <Card title="Tabs" icon="folder" href="/components/tabs" />
+  <Card title="Steps" icon="list-ordered" href="/components/steps" />
+</CardGroup>
+```
+
+For now, treat this as syntax documentation rather than a guaranteed rendered component.
+
+---
+
+# Tabs
+
+Mintlify commonly uses `<Tabs>` and `<Tab>` to switch between examples.
+
+Live example:
+
+<Tabs>
+  <Tab title="npm">
+    ```bash
+    npm install
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn install
+    ```
+  </Tab>
+  <Tab title="pnpm">
+    ```bash
+    pnpm install
+    ```
+  </Tab>
+</Tabs>
+
+Source example:
+
+````mdx
+<Tabs>
+  <Tab title="npm">
+    ```bash
+    npm install
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn install
+    ```
+  </Tab>
+  <Tab title="pnpm">
+    ```bash
+    pnpm install
+    ```
+  </Tab>
+</Tabs>
+````
+
+Possible fallback if tabs are unsupported: split content into headings such as `## npm` and `## pnpm`.
+
+---
+
+# Accordions
+
+Expandable sections are typically written like this:
+
+```mdx
+<Accordion title="Supported formats">
+  - Markdown
+  - MDX
+  - HTML snippets
+</Accordion>
+```
+
+This page keeps the original Mintlify syntax visible so we can decide later how to transform it.
+
+---
+
+# Callouts
+
+Callouts are useful for note, warning, and info states.
+
+```mdx
+<Callout type="info">
+  This syntax is still under review.
+</Callout>
+```
+
+```mdx
+<Callout type="warning">
+  Rendering support may require custom component mapping.
+</Callout>
+```
+
+---
+
+# Steps
+
+Step-based walkthroughs can be expressed like this:
+
+```mdx
+<Steps>
+  <Step title="Install dependencies">
+    Run your package manager.
+  </Step>
+  <Step title="Create content">
+    Add an `.mdx` page and frontmatter.
+  </Step>
+  <Step title="Publish">
+    Verify navigation and deploy.
+  </Step>
+</Steps>
+```
+
+---
+
+# API Blocks
+
+Mintlify also provides API-oriented components.
+
+```mdx
+<ResponseField name="id" type="string" required>
+  Unique identifier for the resource.
+</ResponseField>
+```
+
+```mdx
+<ParamField path="slug" type="string" required>
+  Slug used to resolve the page.
+</ParamField>
+```
+
+These are good candidates for a later conversion layer if we want richer API docs inside ThinkStream.
+
+---
+
+# Temporary Notes
+
+- Keep importing example syntax from Mintlify docs.
+- Decide which components should render natively versus stay as literal code samples.
+- Add transformation rules only after we have a clear supported subset.
+
+> **WIP:** Next pass can include Banner, Badge, CodeGroup, Frame, and Mermaid examples.
 MD),
                 'published_at' => now(),
             ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "html",
+    "name": "thinkstream",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -39,6 +39,7 @@
                 "micromark-extension-mark": "^1.0.2",
                 "playwright": "^1.59.1",
                 "prismjs": "^1.30.0",
+                "radix-ui": "^1.4.3",
                 "react": "^19.2.0",
                 "react-dom": "^19.2.0",
                 "react-markdown": "^10.1.0",
@@ -812,6 +813,191 @@
             "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
             "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="
         },
+        "node_modules/@radix-ui/react-accessible-icon": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz",
+            "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
+            "dependencies": {
+                "@radix-ui/react-visually-hidden": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-accordion": {
+            "version": "1.2.12",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+            "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-collapsible": "1.1.12",
+                "@radix-ui/react-collection": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-id": "1.1.1",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-use-controllable-state": "1.2.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-alert-dialog": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+            "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-dialog": "1.1.15",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@radix-ui/react-arrow": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -857,6 +1043,67 @@
             }
         },
         "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-aspect-ratio": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
+            "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-aspect-ratio/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-aspect-ratio/node_modules/@radix-ui/react-slot": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
             "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
@@ -1159,6 +1406,86 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
             "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-context-menu": {
+            "version": "2.2.16",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+            "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-menu": "2.1.16",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-use-callback-ref": "1.1.1",
+                "@radix-ui/react-use-controllable-state": "1.2.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
             "peerDependencies": {
                 "@types/react": "*",
                 "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1494,6 +1821,191 @@
                 }
             }
         },
+        "node_modules/@radix-ui/react-form": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
+            "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-id": "1.1.1",
+                "@radix-ui/react-label": "2.1.7",
+                "@radix-ui/react-primitive": "2.1.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-label": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+            "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-hover-card": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+            "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-dismissable-layer": "1.1.11",
+                "@radix-ui/react-popper": "1.2.8",
+                "@radix-ui/react-portal": "1.1.9",
+                "@radix-ui/react-presence": "1.1.5",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-use-controllable-state": "1.2.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@radix-ui/react-id": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
@@ -1625,6 +2137,90 @@
                 }
             }
         },
+        "node_modules/@radix-ui/react-menubar": {
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
+            "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-collection": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-id": "1.1.1",
+                "@radix-ui/react-menu": "2.1.16",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-roving-focus": "1.1.11",
+                "@radix-ui/react-use-controllable-state": "1.2.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-menubar/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-menubar/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-menubar/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@radix-ui/react-navigation-menu": {
             "version": "1.2.14",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
@@ -1697,6 +2293,263 @@
             }
         },
         "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-one-time-password-field": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
+            "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
+            "dependencies": {
+                "@radix-ui/number": "1.1.1",
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-collection": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-roving-focus": "1.1.11",
+                "@radix-ui/react-use-controllable-state": "1.2.2",
+                "@radix-ui/react-use-effect-event": "0.0.2",
+                "@radix-ui/react-use-is-hydrated": "0.1.0",
+                "@radix-ui/react-use-layout-effect": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-one-time-password-field/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-one-time-password-field/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-one-time-password-field/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-password-toggle-field": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
+            "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-id": "1.1.1",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-use-controllable-state": "1.2.2",
+                "@radix-ui/react-use-effect-event": "0.0.2",
+                "@radix-ui/react-use-is-hydrated": "0.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-password-toggle-field/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-password-toggle-field/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-password-toggle-field/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-popover": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+            "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-dismissable-layer": "1.1.11",
+                "@radix-ui/react-focus-guards": "1.1.3",
+                "@radix-ui/react-focus-scope": "1.1.7",
+                "@radix-ui/react-id": "1.1.1",
+                "@radix-ui/react-popper": "1.2.8",
+                "@radix-ui/react-portal": "1.1.9",
+                "@radix-ui/react-presence": "1.1.5",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-slot": "1.2.3",
+                "@radix-ui/react-use-controllable-state": "1.2.2",
+                "aria-hidden": "^1.2.4",
+                "react-remove-scroll": "^2.6.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
             "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
@@ -1904,6 +2757,166 @@
                 }
             }
         },
+        "node_modules/@radix-ui/react-progress": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+            "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+            "dependencies": {
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-primitive": "2.1.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-radio-group": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+            "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-presence": "1.1.5",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-roving-focus": "1.1.11",
+                "@radix-ui/react-use-controllable-state": "1.2.2",
+                "@radix-ui/react-use-previous": "1.1.1",
+                "@radix-ui/react-use-size": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@radix-ui/react-roving-focus": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
@@ -1971,6 +2984,89 @@
             }
         },
         "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-scroll-area": {
+            "version": "1.2.10",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+            "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+            "dependencies": {
+                "@radix-ui/number": "1.1.1",
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-presence": "1.1.5",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-use-callback-ref": "1.1.1",
+                "@radix-ui/react-use-layout-effect": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-slot": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
             "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
@@ -2104,10 +3200,344 @@
                 }
             }
         },
+        "node_modules/@radix-ui/react-slider": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+            "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+            "dependencies": {
+                "@radix-ui/number": "1.1.1",
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-collection": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-use-controllable-state": "1.2.2",
+                "@radix-ui/react-use-layout-effect": "1.1.1",
+                "@radix-ui/react-use-previous": "1.1.1",
+                "@radix-ui/react-use-size": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@radix-ui/react-slot": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
             "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+            "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-use-controllable-state": "1.2.2",
+                "@radix-ui/react-use-previous": "1.1.1",
+                "@radix-ui/react-use-size": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+            "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-id": "1.1.1",
+                "@radix-ui/react-presence": "1.1.5",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-roving-focus": "1.1.11",
+                "@radix-ui/react-use-controllable-state": "1.2.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toast": {
+            "version": "1.2.15",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+            "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-collection": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-dismissable-layer": "1.1.11",
+                "@radix-ui/react-portal": "1.1.9",
+                "@radix-ui/react-presence": "1.1.5",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-use-callback-ref": "1.1.1",
+                "@radix-ui/react-use-controllable-state": "1.2.2",
+                "@radix-ui/react-use-layout-effect": "1.1.1",
+                "@radix-ui/react-visually-hidden": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
             "dependencies": {
                 "@radix-ui/react-compose-refs": "1.1.2"
             },
@@ -2249,6 +3679,109 @@
             }
         },
         "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toolbar": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
+            "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-roving-focus": "1.1.11",
+                "@radix-ui/react-separator": "1.1.7",
+                "@radix-ui/react-toggle-group": "1.1.11"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-separator": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+            "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-slot": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
             "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
@@ -10264,6 +11797,205 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/radix-ui": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
+            "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-accessible-icon": "1.1.7",
+                "@radix-ui/react-accordion": "1.2.12",
+                "@radix-ui/react-alert-dialog": "1.1.15",
+                "@radix-ui/react-arrow": "1.1.7",
+                "@radix-ui/react-aspect-ratio": "1.1.7",
+                "@radix-ui/react-avatar": "1.1.10",
+                "@radix-ui/react-checkbox": "1.3.3",
+                "@radix-ui/react-collapsible": "1.1.12",
+                "@radix-ui/react-collection": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-context-menu": "2.2.16",
+                "@radix-ui/react-dialog": "1.1.15",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-dismissable-layer": "1.1.11",
+                "@radix-ui/react-dropdown-menu": "2.1.16",
+                "@radix-ui/react-focus-guards": "1.1.3",
+                "@radix-ui/react-focus-scope": "1.1.7",
+                "@radix-ui/react-form": "0.1.8",
+                "@radix-ui/react-hover-card": "1.1.15",
+                "@radix-ui/react-label": "2.1.7",
+                "@radix-ui/react-menu": "2.1.16",
+                "@radix-ui/react-menubar": "1.1.16",
+                "@radix-ui/react-navigation-menu": "1.2.14",
+                "@radix-ui/react-one-time-password-field": "0.1.8",
+                "@radix-ui/react-password-toggle-field": "0.1.3",
+                "@radix-ui/react-popover": "1.1.15",
+                "@radix-ui/react-popper": "1.2.8",
+                "@radix-ui/react-portal": "1.1.9",
+                "@radix-ui/react-presence": "1.1.5",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-progress": "1.1.7",
+                "@radix-ui/react-radio-group": "1.3.8",
+                "@radix-ui/react-roving-focus": "1.1.11",
+                "@radix-ui/react-scroll-area": "1.2.10",
+                "@radix-ui/react-select": "2.2.6",
+                "@radix-ui/react-separator": "1.1.7",
+                "@radix-ui/react-slider": "1.3.6",
+                "@radix-ui/react-slot": "1.2.3",
+                "@radix-ui/react-switch": "1.2.6",
+                "@radix-ui/react-tabs": "1.1.13",
+                "@radix-ui/react-toast": "1.2.15",
+                "@radix-ui/react-toggle": "1.1.10",
+                "@radix-ui/react-toggle-group": "1.1.11",
+                "@radix-ui/react-toolbar": "1.1.11",
+                "@radix-ui/react-tooltip": "1.2.8",
+                "@radix-ui/react-use-callback-ref": "1.1.1",
+                "@radix-ui/react-use-controllable-state": "1.2.2",
+                "@radix-ui/react-use-effect-event": "0.0.2",
+                "@radix-ui/react-use-escape-keydown": "1.1.1",
+                "@radix-ui/react-use-is-hydrated": "0.1.0",
+                "@radix-ui/react-use-layout-effect": "1.1.1",
+                "@radix-ui/react-use-size": "1.1.1",
+                "@radix-ui/react-visually-hidden": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/radix-ui/node_modules/@radix-ui/react-avatar": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+            "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+            "dependencies": {
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-use-callback-ref": "1.1.1",
+                "@radix-ui/react-use-is-hydrated": "0.1.0",
+                "@radix-ui/react-use-layout-effect": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/radix-ui/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/radix-ui/node_modules/@radix-ui/react-label": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+            "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/radix-ui/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/radix-ui/node_modules/@radix-ui/react-separator": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+            "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/radix-ui/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/react": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "micromark-extension-mark": "^1.0.2",
         "playwright": "^1.59.1",
         "prismjs": "^1.30.0",
+        "radix-ui": "^1.4.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",

--- a/resources/js/components/code-block.tsx
+++ b/resources/js/components/code-block.tsx
@@ -1,20 +1,10 @@
 import { Check, Copy, MoveHorizontal, WrapText } from 'lucide-react';
-import Prism from 'prismjs';
-import 'prismjs/components/prism-bash';
-import 'prismjs/components/prism-css';
-import 'prismjs/components/prism-javascript';
-import 'prismjs/components/prism-json';
-import 'prismjs/components/prism-jsx';
-import 'prismjs/components/prism-markup-templating'; // required by prism-php
-import 'prismjs/components/prism-php';
-import 'prismjs/components/prism-python';
-import 'prismjs/components/prism-tsx';
-import 'prismjs/components/prism-typescript';
 import type { ComponentPropsWithoutRef } from 'react';
 import { useState } from 'react';
 import type { ExtraProps } from 'react-markdown';
 import { MermaidBlock } from '@/components/mermaid-block';
 import { useClipboard } from '@/hooks/use-clipboard';
+import Prism from '@/lib/prism';
 
 type CodeBlockProps = ComponentPropsWithoutRef<'code'> & ExtraProps;
 

--- a/resources/js/components/github-embed.tsx
+++ b/resources/js/components/github-embed.tsx
@@ -1,16 +1,6 @@
 import { ExternalLink, FileCode } from 'lucide-react';
-import Prism from 'prismjs';
-import 'prismjs/components/prism-bash';
-import 'prismjs/components/prism-css';
-import 'prismjs/components/prism-javascript';
-import 'prismjs/components/prism-json';
-import 'prismjs/components/prism-jsx';
-import 'prismjs/components/prism-markup-templating';
-import 'prismjs/components/prism-php';
-import 'prismjs/components/prism-python';
-import 'prismjs/components/prism-tsx';
-import 'prismjs/components/prism-typescript';
 import React from 'react';
+import Prism from '@/lib/prism';
 import { parseGithubUrl } from '@/lib/url-matcher';
 
 /** Maximum number of lines to display when no line range is specified. */

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -10,9 +10,11 @@ import remarkEmoji from 'remark-emoji';
 import remarkGfm from 'remark-gfm';
 import remarkSupersub from 'remark-supersub';
 import { EmbedCard } from '@/components/embed-card';
+import { MarkdownTab, MarkdownTabs } from '@/components/markdown-tabs';
 import { remarkCodeMeta } from '@/lib/remark-code-meta';
 import { remarkLinkifyToCard } from '@/lib/remark-linkify-to-card';
 import { remarkMark } from '@/lib/remark-mark';
+import { remarkTabsDirective } from '@/lib/remark-tabs-directive';
 import { remarkZennDirective } from '@/lib/remark-zenn-directive';
 import { cn } from '@/lib/utils';
 import {
@@ -97,6 +99,47 @@ export default function MarkdownContent({
     content,
     components,
 }: MarkdownContentProps) {
+    const markdownComponents: Components & {
+        tabs?: (props: Record<string, unknown>) => React.ReactElement;
+        tab?: (props: Record<string, unknown>) => React.ReactElement;
+    } = {
+        aside: MessageBox,
+        details: DetailsBox,
+        summary: SummaryEl,
+        tabs: (props: Record<string, unknown>) => <MarkdownTabs {...props} />,
+        tab: (props: Record<string, unknown>) => <MarkdownTab {...props} />,
+        dl: ({ node, ...props }) => {
+            void node;
+
+            return <dl className="my-4 space-y-1" {...props} />;
+        },
+        dt: ({ node, ...props }) => {
+            void node;
+
+            return <dt className="font-semibold" {...props} />;
+        },
+        dd: ({ node, ...props }) => {
+            void node;
+
+            return <dd className="ml-4 text-muted-foreground" {...props} />;
+        },
+        div: (props: React.ComponentPropsWithoutRef<'div'>) => {
+            const embedType = (props as Record<string, unknown>)[
+                'data-embed-type'
+            ] as 'youtube' | 'card' | 'github' | undefined;
+            const embedUrl = (props as Record<string, unknown>)[
+                'data-embed-url'
+            ] as string | undefined;
+
+            if (embedType && embedUrl) {
+                return <EmbedCard type={embedType} url={embedUrl} />;
+            }
+
+            return <div {...props} />;
+        },
+        ...components,
+    };
+
     return (
         <ReactMarkdown
             remarkPlugins={[
@@ -104,6 +147,7 @@ export default function MarkdownContent({
                 remarkCodeMeta,
                 remarkDirective,
                 remarkZennDirective,
+                remarkTabsDirective,
                 remarkLinkifyToCard,
                 remarkSupersub,
                 remarkDefinitionList,
@@ -121,43 +165,7 @@ export default function MarkdownContent({
                     }),
                 } as any,
             }}
-            components={{
-                aside: MessageBox,
-                details: DetailsBox,
-                summary: SummaryEl,
-                dl: ({ node, ...props }) => {
-                    void node;
-
-                    return <dl className="my-4 space-y-1" {...props} />;
-                },
-                dt: ({ node, ...props }) => {
-                    void node;
-
-                    return <dt className="font-semibold" {...props} />;
-                },
-                dd: ({ node, ...props }) => {
-                    void node;
-
-                    return (
-                        <dd className="ml-4 text-muted-foreground" {...props} />
-                    );
-                },
-                div: (props: React.ComponentPropsWithoutRef<'div'>) => {
-                    const embedType = (props as Record<string, unknown>)[
-                        'data-embed-type'
-                    ] as 'youtube' | 'card' | 'github' | undefined;
-                    const embedUrl = (props as Record<string, unknown>)[
-                        'data-embed-url'
-                    ] as string | undefined;
-
-                    if (embedType && embedUrl) {
-                        return <EmbedCard type={embedType} url={embedUrl} />;
-                    }
-
-                    return <div {...props} />;
-                },
-                ...components,
-            }}
+            components={markdownComponents}
         >
             {preprocessZennMarkdown(preprocessZennSyntax(content))}
         </ReactMarkdown>

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -11,16 +11,16 @@ import remarkGfm from 'remark-gfm';
 import remarkSupersub from 'remark-supersub';
 import { EmbedCard } from '@/components/embed-card';
 import { MarkdownTab, MarkdownTabs } from '@/components/markdown-tabs';
+import {
+    preprocessMarkdownContent,
+    preprocessMarkdownSyntax,
+} from '@/lib/markdown-syntax';
 import { remarkCodeMeta } from '@/lib/remark-code-meta';
 import { remarkLinkifyToCard } from '@/lib/remark-linkify-to-card';
 import { remarkMark } from '@/lib/remark-mark';
 import { remarkTabsDirective } from '@/lib/remark-tabs-directive';
 import { remarkZennDirective } from '@/lib/remark-zenn-directive';
 import { cn } from '@/lib/utils';
-import {
-    preprocessZennMarkdown,
-    preprocessZennSyntax,
-} from '@/lib/zenn-markdown';
 
 function DetailsBox({
     children,
@@ -167,7 +167,7 @@ export default function MarkdownContent({
             }}
             components={markdownComponents}
         >
-            {preprocessZennMarkdown(preprocessZennSyntax(content))}
+            {preprocessMarkdownContent(preprocessMarkdownSyntax(content))}
         </ReactMarkdown>
     );
 }

--- a/resources/js/components/markdown-image.tsx
+++ b/resources/js/components/markdown-image.tsx
@@ -1,6 +1,6 @@
 import type { ComponentPropsWithoutRef } from 'react';
+import { parseMarkdownImageMetadata } from '@/lib/markdown-syntax';
 import { cn } from '@/lib/utils';
-import { parseZennImageMetadata } from '@/lib/zenn-markdown';
 
 type MarkdownImageProps = ComponentPropsWithoutRef<'img'>;
 
@@ -11,7 +11,7 @@ export function MarkdownImage({
     style,
     ...props
 }: MarkdownImageProps) {
-    const image = parseZennImageMetadata(src);
+    const image = parseMarkdownImageMetadata(src);
 
     return (
         <img

--- a/resources/js/components/markdown-tabs.tsx
+++ b/resources/js/components/markdown-tabs.tsx
@@ -1,0 +1,254 @@
+import type { ReactNode } from 'react';
+import { Children, isValidElement, useEffect, useMemo, useState } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
+
+interface MarkdownTabsProps {
+    sync?: string | boolean;
+    borderBottom?: string | boolean;
+    children?: ReactNode;
+}
+
+interface MarkdownTabProps {
+    title?: string;
+    icon?: string;
+    children?: ReactNode;
+}
+
+interface TabEntry {
+    title: string;
+    content: ReactNode;
+    value: string;
+}
+
+type PreferredSelection = {
+    title?: string;
+};
+
+const TABS_STORAGE_KEY = 'markdown-tabs-selection';
+const TABS_CHANGE_EVENT = 'markdown-tabs:selection-change';
+
+function getStoredSelection(): PreferredSelection | null {
+    if (typeof window === 'undefined') {
+        return null;
+    }
+
+    try {
+        const raw = window.localStorage.getItem(TABS_STORAGE_KEY);
+
+        if (!raw) {
+            return null;
+        }
+
+        return JSON.parse(raw) as PreferredSelection;
+    } catch {
+        return null;
+    }
+}
+
+function setStoredSelection(selection: PreferredSelection): void {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        window.localStorage.setItem(
+            TABS_STORAGE_KEY,
+            JSON.stringify(selection),
+        );
+    } catch {
+        // Ignore storage failures in restricted environments.
+    }
+}
+
+function resolveBoolean(
+    value: string | boolean | undefined,
+    fallback: boolean,
+): boolean {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    if (typeof value === 'string') {
+        return value !== 'false' && value !== '0';
+    }
+
+    return fallback;
+}
+
+export function MarkdownTabs({
+    sync = true,
+    borderBottom = true,
+    children,
+    ...rest
+}: MarkdownTabsProps & Record<string, unknown>) {
+    const dataSync = rest['data-tabs-sync'] as string | boolean | undefined;
+    const dataBorder = rest['data-tabs-border-bottom'] as
+        | string
+        | boolean
+        | undefined;
+    const isSyncEnabled = resolveBoolean(dataSync ?? sync, true);
+    const showBorderBottom = resolveBoolean(dataBorder ?? borderBottom, true);
+    const tabs = useMemo(() => extractTabs(children), [children]);
+    const [preferredSelection, setPreferredSelection] =
+        useState<PreferredSelection | null>(() =>
+            isSyncEnabled ? getStoredSelection() : null,
+        );
+    const [selectedValue, setSelectedValue] = useState<string>('');
+
+    useEffect(() => {
+        if (tabs.length === 0) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setSelectedValue('');
+
+            return;
+        }
+
+        const currentTab = tabs.find((tab) => tab.value === selectedValue);
+
+        if (
+            currentTab &&
+            preferredSelection &&
+            currentTab.title === preferredSelection.title
+        ) {
+            return;
+        }
+
+        const matchedTab =
+            preferredSelection?.title && isSyncEnabled
+                ? tabs.find((tab) => tab.title === preferredSelection.title)
+                : null;
+        const nextValue = matchedTab?.value ?? tabs[0].value;
+
+        if (nextValue !== selectedValue) {
+            setSelectedValue(nextValue);
+        }
+    }, [isSyncEnabled, preferredSelection, selectedValue, tabs]);
+
+    useEffect(() => {
+        if (!isSyncEnabled || typeof window === 'undefined') {
+            return undefined;
+        }
+
+        const handleSelectionChange = (event: Event) => {
+            const customEvent = event as CustomEvent<PreferredSelection>;
+
+            if (customEvent.detail?.title) {
+                setPreferredSelection(customEvent.detail);
+            }
+        };
+
+        window.addEventListener(
+            TABS_CHANGE_EVENT,
+            handleSelectionChange as EventListener,
+        );
+
+        return () => {
+            window.removeEventListener(
+                TABS_CHANGE_EVENT,
+                handleSelectionChange as EventListener,
+            );
+        };
+    }, [isSyncEnabled]);
+
+    if (tabs.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="not-prose my-6" data-test="markdown-tabs">
+            <Tabs
+                value={selectedValue}
+                onValueChange={(value) => {
+                    const selectedTab = tabs.find((tab) => tab.value === value);
+
+                    if (!selectedTab) {
+                        return;
+                    }
+
+                    setSelectedValue(selectedTab.value);
+
+                    if (!isSyncEnabled) {
+                        return;
+                    }
+
+                    const nextSelection = { title: selectedTab.title };
+                    setPreferredSelection(nextSelection);
+                    setStoredSelection(nextSelection);
+
+                    if (typeof window !== 'undefined') {
+                        window.dispatchEvent(
+                            new CustomEvent(TABS_CHANGE_EVENT, {
+                                detail: nextSelection,
+                            }),
+                        );
+                    }
+                }}
+                className="w-full"
+            >
+                <TabsList
+                    className={cn(
+                        'h-auto w-full justify-start gap-2 rounded-2xl bg-muted/50 p-2',
+                        showBorderBottom && 'border border-border/70',
+                    )}
+                >
+                    {tabs.map((tab) => (
+                        <TabsTrigger
+                            key={tab.value}
+                            value={tab.value}
+                            data-test={`markdown-tab-trigger-${tab.title}`}
+                            className="flex-none rounded-xl px-4 py-2 text-sm font-medium"
+                        >
+                            {tab.title}
+                        </TabsTrigger>
+                    ))}
+                </TabsList>
+
+                {tabs.map((tab) => (
+                    <TabsContent
+                        key={tab.value}
+                        value={tab.value}
+                        data-test={`markdown-tab-panel-${tab.title}`}
+                        className="mt-4 rounded-2xl border border-border/70 bg-background/80 p-5 shadow-[0_1px_0_rgba(15,23,42,0.04)]"
+                    >
+                        {tab.content}
+                    </TabsContent>
+                ))}
+            </Tabs>
+        </div>
+    );
+}
+
+export function MarkdownTab({ children }: MarkdownTabProps) {
+    return <>{children}</>;
+}
+
+function extractTabs(children: ReactNode): TabEntry[] {
+    const nodes = Children.toArray(children);
+    const tabs: TabEntry[] = [];
+
+    nodes.forEach((child, index) => {
+        if (!isValidElement(child)) {
+            return;
+        }
+
+        const props = child.props as MarkdownTabProps & {
+            'data-tab-title'?: string;
+            title?: string;
+        };
+        const title =
+            props.title ?? props['data-tab-title'] ?? `Tab ${index + 1}`;
+
+        if (!props.title && !props['data-tab-title']) {
+            return;
+        }
+
+        tabs.push({
+            title,
+            content: props.children,
+            value: `${title}-${index}`,
+        });
+    });
+
+    return tabs;
+}

--- a/resources/js/components/ui/tabs.tsx
+++ b/resources/js/components/ui/tabs.tsx
@@ -1,0 +1,89 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/resources/js/lib/markdown-components.tsx
+++ b/resources/js/lib/markdown-components.tsx
@@ -4,7 +4,7 @@ import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 import type { Components } from 'react-markdown';
 import { CodeBlock } from '@/components/code-block';
 import { MarkdownImage } from '@/components/markdown-image';
-import { parseZennImageMetadata } from '@/lib/zenn-markdown';
+import { parseMarkdownImageMetadata } from '@/lib/markdown-syntax';
 
 function slugify(text: string): string {
     return text
@@ -32,7 +32,7 @@ function extractCaptionFromNode(node: ReactNode): string | undefined {
     }
 
     if (typeof node.props.src === 'string') {
-        return parseZennImageMetadata(node.props.src).caption;
+        return parseMarkdownImageMetadata(node.props.src).caption;
     }
 
     const children = Children.toArray(node.props.children);

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -1,6 +1,6 @@
-const WIDTH_PARAM = '__zenn_width';
-const HEIGHT_PARAM = '__zenn_height';
-const CAPTION_PARAM = '__zenn_caption';
+const IMAGE_WIDTH_PARAM = '__markdown_width';
+const IMAGE_HEIGHT_PARAM = '__markdown_height';
+const IMAGE_CAPTION_PARAM = '__markdown_caption';
 
 type ImageMetadata = {
     src: string;
@@ -28,15 +28,15 @@ function buildUrlWithMetadata(url: string, metadata: EncodedMetadata): string {
     const urlObject = new URL(url, 'https://zenn.local');
 
     if (metadata.width) {
-        urlObject.searchParams.set(WIDTH_PARAM, metadata.width);
+        urlObject.searchParams.set(IMAGE_WIDTH_PARAM, metadata.width);
     }
 
     if (metadata.height) {
-        urlObject.searchParams.set(HEIGHT_PARAM, metadata.height);
+        urlObject.searchParams.set(IMAGE_HEIGHT_PARAM, metadata.height);
     }
 
     if (metadata.caption) {
-        urlObject.searchParams.set(CAPTION_PARAM, metadata.caption);
+        urlObject.searchParams.set(IMAGE_CAPTION_PARAM, metadata.caption);
     }
 
     if (isAbsoluteUrl(url)) {
@@ -259,7 +259,7 @@ export function preprocessMintlifySyntax(markdown: string): string {
     return processedLines.join('\n');
 }
 
-export function preprocessZennSyntax(markdown: string): string {
+export function preprocessMarkdownSyntax(markdown: string): string {
     return (
         preprocessMintlifySyntax(markdown)
             // Normalize :::message alert to the attribute form remark-directive expects.
@@ -273,7 +273,7 @@ export function preprocessZennSyntax(markdown: string): string {
     );
 }
 
-export function preprocessZennMarkdown(markdown: string): string {
+export function preprocessMarkdownContent(markdown: string): string {
     const lines = markdown.split('\n');
     const processedLines: string[] = [];
     let activeFence: string | null = null;
@@ -330,19 +330,21 @@ export function preprocessZennMarkdown(markdown: string): string {
     return processedLines.join('\n');
 }
 
-export function parseZennImageMetadata(url?: string | null): ImageMetadata {
+export function parseMarkdownImageMetadata(
+    url?: string | null,
+): ImageMetadata {
     if (!url) {
         return { src: '' };
     }
 
     const urlObject = new URL(url, 'https://zenn.local');
-    const width = urlObject.searchParams.get(WIDTH_PARAM);
-    const height = urlObject.searchParams.get(HEIGHT_PARAM);
-    const caption = urlObject.searchParams.get(CAPTION_PARAM);
+    const width = urlObject.searchParams.get(IMAGE_WIDTH_PARAM);
+    const height = urlObject.searchParams.get(IMAGE_HEIGHT_PARAM);
+    const caption = urlObject.searchParams.get(IMAGE_CAPTION_PARAM);
 
-    urlObject.searchParams.delete(WIDTH_PARAM);
-    urlObject.searchParams.delete(HEIGHT_PARAM);
-    urlObject.searchParams.delete(CAPTION_PARAM);
+    urlObject.searchParams.delete(IMAGE_WIDTH_PARAM);
+    urlObject.searchParams.delete(IMAGE_HEIGHT_PARAM);
+    urlObject.searchParams.delete(IMAGE_CAPTION_PARAM);
 
     return {
         src: isAbsoluteUrl(url)

--- a/resources/js/lib/prism.ts
+++ b/resources/js/lib/prism.ts
@@ -1,0 +1,3 @@
+import Prism from 'prismjs';
+
+export default Prism;

--- a/resources/js/lib/remark-tabs-directive.ts
+++ b/resources/js/lib/remark-tabs-directive.ts
@@ -1,0 +1,45 @@
+import type { Root } from 'mdast';
+import type { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+interface ContainerDirectiveNode extends Node {
+    type: 'containerDirective';
+    name: string;
+    attributes?: Record<string, string | boolean | undefined>;
+    data?: {
+        hName?: string;
+        hProperties?: Record<string, unknown>;
+    };
+}
+
+export function remarkTabsDirective() {
+    return (tree: Root) => {
+        visit(tree, (node: Node) => {
+            if (node.type !== 'containerDirective') {
+                return;
+            }
+
+            const directiveNode = node as ContainerDirectiveNode;
+
+            if (directiveNode.name === 'tabs') {
+                directiveNode.data = directiveNode.data || {};
+                directiveNode.data.hName = 'tabs';
+                directiveNode.data.hProperties = {
+                    'data-tabs-sync':
+                        directiveNode.attributes?.sync ?? undefined,
+                    'data-tabs-border-bottom':
+                        directiveNode.attributes?.borderBottom ?? undefined,
+                };
+            }
+
+            if (directiveNode.name === 'tab') {
+                directiveNode.data = directiveNode.data || {};
+                directiveNode.data.hName = 'tab';
+                directiveNode.data.hProperties = {
+                    'data-tab-title': directiveNode.attributes?.title,
+                    'data-tab-icon': directiveNode.attributes?.icon,
+                };
+            }
+        });
+    };
+}

--- a/resources/js/lib/zenn-markdown.ts
+++ b/resources/js/lib/zenn-markdown.ts
@@ -89,9 +89,179 @@ function rewriteImageLine(line: string, caption?: string): string | null {
     return null;
 }
 
+function parseJsxAttributes(
+    attributeSource: string,
+): Record<string, string | boolean> {
+    const attributes: Record<string, string | boolean> = {};
+    const attributePattern = /(\w+)(?:=(?:"([^"]*)"|\{(true|false)\}))?/g;
+
+    for (const match of attributeSource.matchAll(attributePattern)) {
+        const [, key, quotedValue, booleanValue] = match;
+
+        if (!key) {
+            continue;
+        }
+
+        if (quotedValue !== undefined) {
+            attributes[key] = quotedValue;
+            continue;
+        }
+
+        if (booleanValue !== undefined) {
+            attributes[key] = booleanValue === 'true';
+            continue;
+        }
+
+        attributes[key] = true;
+    }
+
+    return attributes;
+}
+
+function buildDirectiveAttributes(
+    attributes: Record<string, string | boolean>,
+): string {
+    const supportedEntries = Object.entries(attributes).filter(([key]) =>
+        ['title', 'icon', 'sync', 'borderBottom'].includes(key),
+    );
+
+    if (supportedEntries.length === 0) {
+        return '';
+    }
+
+    const serialized = supportedEntries
+        .map(([key, value]) => {
+            if (typeof value === 'boolean') {
+                return `${key}="${value ? 'true' : 'false'}"`;
+            }
+
+            return `${key}="${value.replaceAll('"', '&quot;')}"`;
+        })
+        .join(' ');
+
+    return `{${serialized}}`;
+}
+
+export function preprocessMintlifySyntax(markdown: string): string {
+    const lines = markdown.split('\n');
+    const processedLines: string[] = [];
+    let activeFence: string | null = null;
+    let mintlifyTabsDepth = 0;
+    const mintlifyTagStack: Array<'Tabs' | 'Tab'> = [];
+
+    const pushLine = (value: string): void => {
+        processedLines.push(value);
+    };
+
+    const pushBlankLineIfNeeded = (): void => {
+        if (processedLines.at(-1) !== '') {
+            processedLines.push('');
+        }
+    };
+
+    for (const line of lines) {
+        const trimmedLine = line.trim();
+        const indentWidth = mintlifyTagStack.length * 2;
+        const effectiveLine =
+            mintlifyTagStack.length > 0
+                ? line.replace(new RegExp(`^ {0,${indentWidth}}`), '')
+                : line;
+        const fenceMatch = /^(`{3,}|~{3,})/.exec(trimmedLine);
+
+        if (fenceMatch) {
+            const fence = fenceMatch[1];
+            const remainder = trimmedLine.slice(fence.length);
+
+            if (activeFence === null) {
+                activeFence = fence;
+            } else if (
+                fence[0] === activeFence[0] &&
+                fence.length >= activeFence.length &&
+                remainder.trim() === ''
+            ) {
+                activeFence = null;
+            }
+
+            processedLines.push(effectiveLine);
+
+            continue;
+        }
+
+        if (activeFence !== null) {
+            processedLines.push(effectiveLine);
+
+            continue;
+        }
+
+        const tabsOpenMatch = /^<Tabs(?<attributes>[^>]*)>$/.exec(trimmedLine);
+
+        if (tabsOpenMatch) {
+            const attributes = parseJsxAttributes(
+                tabsOpenMatch.groups?.attributes ?? '',
+            );
+
+            pushBlankLineIfNeeded();
+            pushLine(`::::tabs${buildDirectiveAttributes(attributes)}`);
+            pushLine('');
+            mintlifyTabsDepth++;
+            mintlifyTagStack.push('Tabs');
+
+            continue;
+        }
+
+        const tabOpenMatch = /^<Tab(?<attributes>[^>]*)>$/.exec(trimmedLine);
+
+        if (tabOpenMatch) {
+            const attributes = parseJsxAttributes(
+                tabOpenMatch.groups?.attributes ?? '',
+            );
+
+            pushBlankLineIfNeeded();
+            pushLine(`:::tab${buildDirectiveAttributes(attributes)}`);
+            pushLine('');
+            mintlifyTagStack.push('Tab');
+
+            continue;
+        }
+
+        if (trimmedLine === '</Tab>') {
+            if (mintlifyTagStack.at(-1) === 'Tab') {
+                mintlifyTagStack.pop();
+            }
+
+            pushBlankLineIfNeeded();
+            pushLine(':::');
+
+            continue;
+        }
+
+        if (trimmedLine === '</Tabs>') {
+            if (mintlifyTagStack.at(-1) === 'Tabs') {
+                mintlifyTagStack.pop();
+            }
+
+            pushBlankLineIfNeeded();
+            pushLine(mintlifyTabsDepth > 0 ? '::::' : ':::');
+            mintlifyTabsDepth = Math.max(0, mintlifyTabsDepth - 1);
+
+            continue;
+        }
+
+        if (mintlifyTagStack.length > 0) {
+            processedLines.push(effectiveLine);
+
+            continue;
+        }
+
+        processedLines.push(line);
+    }
+
+    return processedLines.join('\n');
+}
+
 export function preprocessZennSyntax(markdown: string): string {
     return (
-        markdown
+        preprocessMintlifySyntax(markdown)
             // Normalize :::message alert to the attribute form remark-directive expects.
             .replace(/:::message\s+alert\b/g, ':::message{.alert}')
             // Convert :::details title to the label form remark-directive expects.

--- a/resources/js/types/prism-components.d.ts
+++ b/resources/js/types/prism-components.d.ts
@@ -1,0 +1,10 @@
+declare module 'prismjs/components/prism-markup-templating';
+declare module 'prismjs/components/prism-bash';
+declare module 'prismjs/components/prism-css';
+declare module 'prismjs/components/prism-javascript';
+declare module 'prismjs/components/prism-json';
+declare module 'prismjs/components/prism-jsx';
+declare module 'prismjs/components/prism-php';
+declare module 'prismjs/components/prism-python';
+declare module 'prismjs/components/prism-tsx';
+declare module 'prismjs/components/prism-typescript';

--- a/tests/Browser/MintlifyTabsRenderingTest.php
+++ b/tests/Browser/MintlifyTabsRenderingTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('mintlify-style tabs render as interactive tab controls', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Tabs
+
+<Tabs>
+  <Tab title="npm">
+    ```bash
+    npm install
+    ```
+  </Tab>
+  <Tab title="pnpm">
+    ```bash
+    pnpm install
+    ```
+  </Tab>
+</Tabs>
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="markdown-tabs"]')
+        ->assertPresent('[data-test="markdown-tab-trigger-npm"]')
+        ->assertPresent('[data-test="markdown-tab-trigger-pnpm"]')
+        ->assertSee('npm install');
+});
+
+test('mintlify-style tabs inside fenced code blocks stay as literal code', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Tabs Example
+
+````mdx
+<Tabs>
+  <Tab title="npm">
+    ```bash
+    npm install
+    ```
+  </Tab>
+</Tabs>
+````
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertMissing('[data-test="markdown-tabs"]')
+        ->assertSee('<Tabs>')
+        ->assertSee('<Tab title="npm">');
+});

--- a/tests/Feature/PostSeederTest.php
+++ b/tests/Feature/PostSeederTest.php
@@ -42,3 +42,32 @@ test('post seeder creates the zenn syntax guide with code block examples', funct
     expect($post->content)->toContain('[![](/storage/namespaces/guide.png =250x)](https://zenn.dev)');
     expect($post->published_at)->not->toBeNull();
 });
+
+test('post seeder creates the mintlify syntax draft page', function () {
+    $this->seed(PostSeeder::class);
+
+    $namespace = PostNamespace::query()
+        ->where('slug', 'guides')
+        ->first();
+
+    expect($namespace)->not->toBeNull();
+    expect($namespace->post_order)->toContain('mintlify-syntax');
+
+    $post = Post::query()
+        ->where('namespace_id', $namespace->id)
+        ->where('slug', 'mintlify-syntax')
+        ->first();
+
+    expect($post)->not->toBeNull();
+    expect($post->title)->toBe('Mintlify Syntax (WIP)');
+    expect($post->content)->toContain('# Mintlify Syntax');
+    expect($post->content)->toContain('<Card title="Tabs" icon="folder" href="/components/tabs">');
+    expect($post->content)->toContain('Live example:');
+    expect($post->content)->toContain('<Tabs>');
+    expect($post->content)->toContain('<Tab title="yarn">');
+    expect($post->content)->toContain('yarn install');
+    expect($post->content)->toContain('<Accordion title="Supported formats">');
+    expect($post->content)->toContain('<Callout type="warning">');
+    expect($post->content)->toContain('<ResponseField name="id" type="string" required>');
+    expect($post->published_at)->not->toBeNull();
+});


### PR DESCRIPTION
## Summary
- add Mintlify-style `<Tabs>` and `<Tab>` preprocessing, directive handling, and React rendering
- seed and document a Mintlify syntax draft page with browser and feature coverage
- route Prism usage through a shared wrapper so Mintlify code blocks no longer trigger browser runtime errors

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/PostSeederTest.php tests/Browser/MintlifyTabsRenderingTest.php
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build
- vendor/bin/sail npx eslint --no-warn-ignored resources/js/components/code-block.tsx resources/js/components/github-embed.tsx resources/js/components/markdown-content.tsx resources/js/components/markdown-tabs.tsx resources/js/components/ui/tabs.tsx resources/js/lib/prism.ts resources/js/lib/remark-tabs-directive.ts resources/js/lib/zenn-markdown.ts resources/js/types/prism-components.d.ts