### PR TITLE
Add fast markdown test coverage

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -1,0 +1,67 @@
+name: browser-tests
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - '.github/workflows/browser-tests.yml'
+      - 'app/**'
+      - 'bootstrap/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'config/**'
+      - 'database/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'resources/js/**'
+      - 'routes/**'
+      - 'tests/Browser/**'
+      - 'vite.config.ts'
+  workflow_dispatch:
+
+jobs:
+  browser:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          tools: composer:v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install Composer Dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Install Node Dependencies
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Copy Environment File
+        run: cp .env.example .env
+
+      - name: Generate Application Key
+        run: php artisan key:generate
+
+      - name: Create SQLite Database
+        run: touch testing
+
+      - name: Build Assets
+        run: npm run build
+
+      - name: Markdown Browser Tests
+        run: ./vendor/bin/pest --ci tests/Browser/ZennMarkdownRenderingTest.php tests/Browser/MintlifyTabsRenderingTest.php

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,31 @@ on:
       - workos
 
 jobs:
-  ci:
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install Node Dependencies
+        run: npm ci
+
+      - name: Type Check
+        run: npm run types:check
+
+      - name: Markdown Syntax Tests
+        run: npm run markdown:test
+
+      - name: Build Assets
+        run: npm run build
+
+  php-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -32,14 +56,6 @@ jobs:
           tools: composer:v2
           coverage: xdebug
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Install Node Dependencies
-        run: npm i
-
       - name: Install Dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
@@ -49,8 +65,8 @@ jobs:
       - name: Generate Application Key
         run: php artisan key:generate
 
-      - name: Build Assets
-        run: npm run build
+      - name: Create SQLite Database
+        run: touch testing
 
-      - name: Tests
-        run: ./vendor/bin/pest
+      - name: Feature and Unit Tests
+        run: ./vendor/bin/pest --ci tests/Feature tests/Unit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,23 +21,41 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          tools: composer:v2
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
 
+      - name: Install Composer Dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
       - name: Install Node Dependencies
         run: npm ci
+
+      - name: Copy Environment File
+        run: cp .env.example .env
+
+      - name: Generate Application Key
+        run: php artisan key:generate
+
+      - name: Generate Wayfinder Types
+        run: php artisan wayfinder:generate --no-interaction
+
+      - name: Build Assets
+        run: npm run build
 
       - name: Type Check
         run: npm run types:check
 
       - name: Markdown Syntax Tests
         run: npm run markdown:test
-
-      - name: Build Assets
-        run: npm run build
 
   php-tests:
     runs-on: ubuntu-latest
@@ -56,8 +74,17 @@ jobs:
           tools: composer:v2
           coverage: xdebug
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
       - name: Install Dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Install Node Dependencies
+        run: npm ci
 
       - name: Copy Environment File
         run: cp .env.example .env
@@ -67,6 +94,9 @@ jobs:
 
       - name: Create SQLite Database
         run: touch testing
+
+      - name: Build Assets
+        run: npm run build
 
       - name: Feature and Unit Tests
         run: ./vendor/bin/pest --ci tests/Feature tests/Unit

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ yarn-error.log
 testing
 /tests/Browser/Screenshots
 /.playwright-cli
+/.tmp

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
         "format:check": "prettier --check resources/",
         "lint": "eslint . --fix",
         "lint:check": "eslint .",
+        "markdown:test": "npm run markdown:test:build && node --test $(find .tmp/markdown-tests/tests-node -name '*.test.js' | sort)",
+        "markdown:test:build": "rm -rf .tmp/markdown-tests && tsc --project tsconfig.markdown-tests.json",
         "types:check": "tsc --noEmit"
     },
     "devDependencies": {

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    parseMarkdownImageMetadata,
+    preprocessMarkdownContent,
+    preprocessMarkdownSyntax,
+} from '../../resources/js/lib/markdown-syntax.ts';
+
+test('preprocessMarkdownSyntax normalizes Zenn shorthand and Mintlify tabs', () => {
+    const output = preprocessMarkdownSyntax(`:::message alert
+Watch out
+:::
+
+:::details More Info
+Hidden content
+:::
+
+@[card](https://example.com)
+@[github](https://github.com/owner/repo)
+
+<Tabs sync={false} borderBottom={true}>
+  <Tab title="npm" icon="package">
+    \`\`\`bash
+    npm install
+    \`\`\`
+  </Tab>
+</Tabs>`);
+
+    assert.match(output, /:::message\{\.alert\}/);
+    assert.match(output, /:::details\[More Info\]/);
+    assert.match(output, /^https:\/\/example\.com$/m);
+    assert.match(output, /^https:\/\/github\.com\/owner\/repo$/m);
+    assert.match(
+        output,
+        /::::tabs\{sync="false" borderBottom="true"\}/,
+    );
+    assert.match(output, /:::tab\{title="npm" icon="package"\}/);
+});
+
+test('preprocessMarkdownSyntax leaves Mintlify tags untouched inside fenced code blocks', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`\`mdx
+<Tabs>
+  <Tab title="npm">
+    \`\`\`bash
+    npm install
+    \`\`\`
+  </Tab>
+</Tabs>
+\`\`\`\``);
+
+    assert.doesNotMatch(output, /::::tabs/);
+    assert.match(output, /<Tabs>/);
+    assert.match(output, /<Tab title="npm">/);
+});
+
+test('preprocessMarkdownContent encodes image metadata outside fences only', () => {
+    const output = preprocessMarkdownContent(`![Guide cover](/storage/guide.png =250x)
+*Guide cover image*
+
+\`\`\`md
+![Literal](/storage/literal.png =100x)
+*Leave me alone*
+\`\`\``);
+
+    const encodedImage = output.match(/!\[Guide cover\]\((?<target>[^)]+)\)/);
+
+    assert.ok(encodedImage?.groups?.target);
+
+    const metadata = parseMarkdownImageMetadata(encodedImage.groups.target);
+
+    assert.equal(metadata.src, '/storage/guide.png');
+    assert.equal(metadata.width, 250);
+    assert.equal(metadata.caption, 'Guide cover image');
+
+    assert.match(output, /!\[Literal\]\(\/storage\/literal\.png =100x\)/);
+    assert.match(output, /\*Leave me alone\*/);
+});
+
+test('parseMarkdownImageMetadata decodes absolute URLs and strips helper params', () => {
+    const metadata = parseMarkdownImageMetadata(
+        'https://example.com/image.png?__markdown_width=320&__markdown_height=180&__markdown_caption=Hero+image&fit=cover',
+    );
+
+    assert.deepEqual(metadata, {
+        src: 'https://example.com/image.png?fit=cover',
+        width: 320,
+        height: 180,
+        caption: 'Hero image',
+    });
+});

--- a/tests-node/markdown/remark-tabs-directive.test.ts
+++ b/tests-node/markdown/remark-tabs-directive.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { remarkTabsDirective } from '../../resources/js/lib/remark-tabs-directive.ts';
+
+test('remarkTabsDirective maps tabs and tab directives to renderable nodes', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'tabs',
+                attributes: {
+                    sync: 'false',
+                    borderBottom: 'true',
+                },
+                children: [
+                    {
+                        type: 'containerDirective',
+                        name: 'tab',
+                        attributes: {
+                            title: 'npm',
+                            icon: 'package',
+                        },
+                        children: [],
+                    },
+                ],
+            },
+        ],
+    };
+
+    remarkTabsDirective()(tree as never);
+
+    const tabsNode = tree.children[0] as {
+        data?: { hName?: string; hProperties?: Record<string, unknown> };
+        children: Array<{
+            data?: { hName?: string; hProperties?: Record<string, unknown> };
+        }>;
+    };
+    const tabNode = tabsNode.children[0];
+
+    assert.equal(tabsNode.data?.hName, 'tabs');
+    assert.deepEqual(tabsNode.data?.hProperties, {
+        'data-tabs-sync': 'false',
+        'data-tabs-border-bottom': 'true',
+    });
+
+    assert.equal(tabNode.data?.hName, 'tab');
+    assert.deepEqual(tabNode.data?.hProperties, {
+        'data-tab-title': 'npm',
+        'data-tab-icon': 'package',
+    });
+});
+
+test('remarkTabsDirective ignores unrelated directives', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'message',
+                attributes: {
+                    className: 'alert',
+                },
+                children: [],
+            },
+        ],
+    };
+
+    remarkTabsDirective()(tree as never);
+
+    assert.equal(
+        (tree.children[0] as { data?: unknown }).data,
+        undefined,
+    );
+});

--- a/tsconfig.markdown-tests.json
+++ b/tsconfig.markdown-tests.json
@@ -1,0 +1,18 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": false,
+        "outDir": ".tmp/markdown-tests",
+        "rootDir": ".",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "types": ["node"],
+        "allowImportingTsExtensions": true,
+        "rewriteRelativeImportExtensions": true
+    },
+    "include": [
+        "resources/js/lib/markdown-syntax.ts",
+        "resources/js/lib/remark-tabs-directive.ts",
+        "tests-node/**/*.ts"
+    ]
+}


### PR DESCRIPTION
## Summary
- add a fast Node-based markdown test layer for syntax preprocessing and remark directive mapping
- keep PR CI fast by running frontend type/build checks, markdown tests, and Pest feature/unit suites
- move markdown browser coverage into a dedicated main/manual workflow so real-browser checks stay available without blocking every PR

## Testing
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build
- vendor/bin/sail artisan test --compact tests/Feature tests/Unit tests/Browser/ZennMarkdownRenderingTest.php tests/Browser/MintlifyTabsRenderingTest.php
- vendor/bin/sail npx eslint --no-warn-ignored resources/js/lib/markdown-syntax.ts resources/js/lib/remark-tabs-directive.ts tests-node/markdown/*.ts