### PR TITLE
Support Mintlify card markdown components

### DIFF
--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -887,9 +887,7 @@ MD),
                 'content' => trim(<<<'MD'
 # Mintlify Syntax
 
-Mintlify ships with MDX-flavored components for docs sites. This page is a working draft that collects syntax examples we may support or document later.
-
-> **WIP:** Some examples below are shown as reference syntax only. They may not render with the current ThinkStream Markdown pipeline yet.
+Mintlify ships with MDX-flavored components for docs sites. This page covers the components supported by the ThinkStream Markdown pipeline.
 
 ---
 
@@ -897,17 +895,21 @@ Mintlify ships with MDX-flavored components for docs sites. This page is a worki
 
 Mintlify uses `<Card>` blocks to create linked navigation tiles.
 
-```mdx
-<Card title="Tabs" icon="folder" href="/components/tabs">
+Live example:
+
+<Card title="Tabs" icon="folder" href="/guides/index">
   Organize related content into a switchable tab UI.
 </Card>
-```
 
-Reference example:
+<Card title="Callouts" icon="message-square-warning" href="/guides/zenn-syntax">
+  Highlight important information with styled alerts.
+</Card>
+
+Source:
 
 ```mdx
-<Card title="Callouts" icon="message-square-warning" href="/components/callouts">
-  Highlight important information with styled alerts.
+<Card title="Tabs" icon="folder" href="/guides/index">
+  Organize related content into a switchable tab UI.
 </Card>
 ```
 
@@ -917,14 +919,43 @@ Reference example:
 
 Cards are often grouped to create documentation indexes.
 
+Live example:
+
+<CardGroup cols={2}>
+  <Card title="Tabs" icon="folder" href="/guides/index">
+    Organize related content into a switchable tab UI.
+  </Card>
+  <Card title="Steps" icon="list-ordered" href="/guides/zenn-syntax">
+    Sequential steps guide the reader through a process.
+  </Card>
+  <Card title="Callouts" icon="message-square-warning" href="/guides/extended-syntax">
+    Highlight important information with styled alerts.
+  </Card>
+  <Card title="Code Blocks" icon="code" href="/guides/index">
+    Display syntax-highlighted code with optional filenames.
+  </Card>
+</CardGroup>
+
+Self-closing cards (no body text):
+
+<CardGroup cols={3}>
+  <Card title="npm" icon="download" href="/guides/index" />
+  <Card title="yarn" icon="zap" href="/guides/index" />
+  <Card title="pnpm" icon="rocket" href="/guides/index" />
+</CardGroup>
+
+Source:
+
 ```mdx
 <CardGroup cols={2}>
-  <Card title="Tabs" icon="folder" href="/components/tabs" />
-  <Card title="Steps" icon="list-ordered" href="/components/steps" />
+  <Card title="Tabs" icon="folder" href="/guides/index">
+    Organize related content into a switchable tab UI.
+  </Card>
+  <Card title="Steps" icon="list-ordered" href="/guides/zenn-syntax">
+    Sequential steps guide the reader through a process.
+  </Card>
 </CardGroup>
 ```
-
-For now, treat this as syntax documentation rather than a guaranteed rendered component.
 
 ---
 

--- a/resources/js/components/markdown-card-group.tsx
+++ b/resources/js/components/markdown-card-group.tsx
@@ -1,4 +1,3 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
     AlertCircle,
     ArrowRight,
@@ -44,10 +43,12 @@ import {
     Users,
     XCircle,
     Zap,
-    type LucideIcon,
 } from 'lucide-react';
-import { useMemo } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Icon } from '@/components/ui/icon';
 import { sanitizeMarkdownCardHref } from '@/lib/markdown-card-href';
+import { cn } from '@/lib/utils';
 
 const ICON_MAP: Record<string, LucideIcon> = {
     clock: Clock,
@@ -157,23 +158,24 @@ export function MarkdownCard({
     'data-card-href': href,
     children,
 }: MarkdownCardProps) {
-    const IconComponent = useMemo(() => getLucideIcon(icon), [icon]);
+    const iconNode = getLucideIcon(icon);
     const safeHref = sanitizeMarkdownCardHref(href);
 
     const cardContent = (
         <Card
-            className={[
+            className={cn(
                 'group h-full border transition-all hover:border-primary/50 hover:shadow-md',
-                safeHref ? 'cursor-pointer' : null,
-            ]
-                .filter(Boolean)
-                .join(' ')}
+                safeHref && 'cursor-pointer',
+            )}
         >
             <CardHeader>
                 <div className="flex items-start gap-3">
-                    {icon && IconComponent ? (
+                    {iconNode ? (
                         <div className="flex-shrink-0 rounded-lg bg-primary/10 p-2 transition-colors group-hover:bg-primary/20">
-                            <IconComponent className="h-5 w-5 text-primary" />
+                            <Icon
+                                iconNode={iconNode}
+                                className="h-5 w-5 text-primary"
+                            />
                         </div>
                     ) : null}
                     <CardTitle className="text-base leading-tight">

--- a/resources/js/components/markdown-card-group.tsx
+++ b/resources/js/components/markdown-card-group.tsx
@@ -1,0 +1,218 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+    AlertCircle,
+    ArrowRight,
+    Award,
+    Bell,
+    Brain,
+    Calendar,
+    CheckCircle,
+    ChevronDown,
+    Clock,
+    Code,
+    Database,
+    Download,
+    ExternalLink,
+    Eye,
+    FileCode,
+    Filter,
+    Flag,
+    Folder,
+    Frame,
+    GitBranch,
+    HelpCircle,
+    Info,
+    LayoutGrid,
+    Leaf,
+    Link,
+    ListOrdered,
+    Lock,
+    Mail,
+    MessageCircle,
+    MessageSquareWarning,
+    Mouse,
+    Palette,
+    Rocket,
+    Search,
+    Settings,
+    Smile,
+    Sparkles,
+    TextCursorInput,
+    Timer,
+    Upload,
+    User,
+    Users,
+    XCircle,
+    Zap,
+    type LucideIcon,
+} from 'lucide-react';
+import { useMemo } from 'react';
+import { sanitizeMarkdownCardHref } from '@/lib/markdown-card-href';
+
+const ICON_MAP: Record<string, LucideIcon> = {
+    clock: Clock,
+    timer: Timer,
+    rocket: Rocket,
+    mouse: Mouse,
+    zap: Zap,
+    lock: Lock,
+    brain: Brain,
+    sparkles: Sparkles,
+    'arrow-right': ArrowRight,
+    arrowright: ArrowRight,
+    info: Info,
+    'alert-circle': AlertCircle,
+    alertcircle: AlertCircle,
+    'check-circle': CheckCircle,
+    checkcircle: CheckCircle,
+    'x-circle': XCircle,
+    xcircle: XCircle,
+    'help-circle': HelpCircle,
+    helpcircle: HelpCircle,
+    code: Code,
+    database: Database,
+    'file-code': FileCode,
+    filecode: FileCode,
+    folder: Folder,
+    frame: Frame,
+    settings: Settings,
+    user: User,
+    users: Users,
+    mail: Mail,
+    bell: Bell,
+    calendar: Calendar,
+    search: Search,
+    filter: Filter,
+    eye: Eye,
+    'layout-grid': LayoutGrid,
+    layoutgrid: LayoutGrid,
+    leaf: Leaf,
+    'list-ordered': ListOrdered,
+    listordered: ListOrdered,
+    'chevron-down': ChevronDown,
+    chevrondown: ChevronDown,
+    download: Download,
+    upload: Upload,
+    'external-link': ExternalLink,
+    externallink: ExternalLink,
+    link: Link,
+    'message-circle': MessageCircle,
+    messagecircle: MessageCircle,
+    'message-square-warning': MessageSquareWarning,
+    messagesquarewarning: MessageSquareWarning,
+    flag: Flag,
+    award: Award,
+    smile: Smile,
+    'git-branch': GitBranch,
+    gitbranch: GitBranch,
+    'text-cursor-input': TextCursorInput,
+    textcursorinput: TextCursorInput,
+    palette: Palette,
+};
+
+function getLucideIcon(iconName: string | undefined): LucideIcon | undefined {
+    if (!iconName) {
+        return undefined;
+    }
+
+    return ICON_MAP[iconName.toLowerCase().trim()];
+}
+
+const GRID_COLS_CLASS: Record<number, string> = {
+    1: 'md:grid-cols-1',
+    2: 'md:grid-cols-2',
+    3: 'md:grid-cols-3',
+    4: 'md:grid-cols-4',
+};
+
+interface MarkdownCardGroupProps {
+    'data-card-group-cols'?: string;
+    children?: React.ReactNode;
+}
+
+export function MarkdownCardGroup({
+    'data-card-group-cols': colsAttr,
+    children,
+}: MarkdownCardGroupProps) {
+    const cols = Math.min(4, Math.max(1, parseInt(colsAttr ?? '2', 10) || 2));
+    const gridColsClass = GRID_COLS_CLASS[cols] ?? 'md:grid-cols-2';
+
+    return (
+        <div className={`not-prose my-6 grid gap-4 ${gridColsClass}`}>
+            {children}
+        </div>
+    );
+}
+
+interface MarkdownCardProps {
+    'data-card-title'?: string;
+    'data-card-icon'?: string;
+    'data-card-href'?: string;
+    children?: React.ReactNode;
+}
+
+export function MarkdownCard({
+    'data-card-title': title,
+    'data-card-icon': icon,
+    'data-card-href': href,
+    children,
+}: MarkdownCardProps) {
+    const IconComponent = useMemo(() => getLucideIcon(icon), [icon]);
+    const safeHref = sanitizeMarkdownCardHref(href);
+
+    const cardContent = (
+        <Card
+            className={[
+                'group h-full border transition-all hover:border-primary/50 hover:shadow-md',
+                safeHref ? 'cursor-pointer' : null,
+            ]
+                .filter(Boolean)
+                .join(' ')}
+        >
+            <CardHeader>
+                <div className="flex items-start gap-3">
+                    {icon && IconComponent ? (
+                        <div className="flex-shrink-0 rounded-lg bg-primary/10 p-2 transition-colors group-hover:bg-primary/20">
+                            <IconComponent className="h-5 w-5 text-primary" />
+                        </div>
+                    ) : null}
+                    <CardTitle className="text-base leading-tight">
+                        {title ?? 'Untitled'}
+                    </CardTitle>
+                </div>
+            </CardHeader>
+            {children ? (
+                <CardContent>
+                    <div className="text-sm leading-relaxed text-muted-foreground">
+                        {children}
+                    </div>
+                </CardContent>
+            ) : null}
+        </Card>
+    );
+
+    if (safeHref) {
+        const isExternal = /^https?:\/\//.test(safeHref);
+
+        if (isExternal) {
+            return (
+                <a
+                    href={safeHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block no-underline"
+                >
+                    {cardContent}
+                </a>
+            );
+        }
+
+        return (
+            <a href={safeHref} className="block no-underline">
+                {cardContent}
+            </a>
+        );
+    }
+
+    return cardContent;
+}

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -10,11 +10,16 @@ import remarkEmoji from 'remark-emoji';
 import remarkGfm from 'remark-gfm';
 import remarkSupersub from 'remark-supersub';
 import { EmbedCard } from '@/components/embed-card';
+import {
+    MarkdownCard,
+    MarkdownCardGroup,
+} from '@/components/markdown-card-group';
 import { MarkdownTab, MarkdownTabs } from '@/components/markdown-tabs';
 import {
     preprocessMarkdownContent,
     preprocessMarkdownSyntax,
 } from '@/lib/markdown-syntax';
+import { remarkCardDirective } from '@/lib/remark-card-directive';
 import { remarkCodeMeta } from '@/lib/remark-code-meta';
 import { remarkLinkifyToCard } from '@/lib/remark-linkify-to-card';
 import { remarkMark } from '@/lib/remark-mark';
@@ -102,12 +107,22 @@ export default function MarkdownContent({
     const markdownComponents: Components & {
         tabs?: (props: Record<string, unknown>) => React.ReactElement;
         tab?: (props: Record<string, unknown>) => React.ReactElement;
+        card?: (props: Record<string, unknown>) => React.ReactElement;
+        cardgroup?: (props: Record<string, unknown>) => React.ReactElement;
     } = {
         aside: MessageBox,
         details: DetailsBox,
         summary: SummaryEl,
         tabs: (props: Record<string, unknown>) => <MarkdownTabs {...props} />,
         tab: (props: Record<string, unknown>) => <MarkdownTab {...props} />,
+        card: (props: Record<string, unknown>) => (
+            <MarkdownCard {...(props as Parameters<typeof MarkdownCard>[0])} />
+        ),
+        cardgroup: (props: Record<string, unknown>) => (
+            <MarkdownCardGroup
+                {...(props as Parameters<typeof MarkdownCardGroup>[0])}
+            />
+        ),
         dl: ({ node, ...props }) => {
             void node;
 
@@ -148,6 +163,7 @@ export default function MarkdownContent({
                 remarkDirective,
                 remarkZennDirective,
                 remarkTabsDirective,
+                remarkCardDirective,
                 remarkLinkifyToCard,
                 remarkSupersub,
                 remarkDefinitionList,

--- a/resources/js/lib/markdown-card-href.ts
+++ b/resources/js/lib/markdown-card-href.ts
@@ -1,0 +1,11 @@
+import { defaultUrlTransform } from 'react-markdown';
+
+export function sanitizeMarkdownCardHref(href?: string): string | undefined {
+    if (!href) {
+        return undefined;
+    }
+
+    const sanitizedHref = defaultUrlTransform(href.trim());
+
+    return sanitizedHref === '' ? undefined : sanitizedHref;
+}

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -93,10 +93,11 @@ function parseJsxAttributes(
     attributeSource: string,
 ): Record<string, string | boolean> {
     const attributes: Record<string, string | boolean> = {};
-    const attributePattern = /(\w+)(?:=(?:"([^"]*)"|\{(true|false)\}))?/g;
+    const attributePattern =
+        /(\w+)(?:=(?:"([^"]*)"|\{(true|false|\d+(?:\.\d+)?)\}))?/g;
 
     for (const match of attributeSource.matchAll(attributePattern)) {
-        const [, key, quotedValue, booleanValue] = match;
+        const [, key, quotedValue, jsxValue] = match;
 
         if (!key) {
             continue;
@@ -107,8 +108,15 @@ function parseJsxAttributes(
             continue;
         }
 
-        if (booleanValue !== undefined) {
-            attributes[key] = booleanValue === 'true';
+        if (jsxValue !== undefined) {
+            if (jsxValue === 'true') {
+                attributes[key] = true;
+            } else if (jsxValue === 'false') {
+                attributes[key] = false;
+            } else {
+                // Numeric value — store as string
+                attributes[key] = jsxValue;
+            }
             continue;
         }
 
@@ -122,7 +130,7 @@ function buildDirectiveAttributes(
     attributes: Record<string, string | boolean>,
 ): string {
     const supportedEntries = Object.entries(attributes).filter(([key]) =>
-        ['title', 'icon', 'sync', 'borderBottom'].includes(key),
+        ['title', 'icon', 'sync', 'borderBottom', 'href', 'cols'].includes(key),
     );
 
     if (supportedEntries.length === 0) {
@@ -147,7 +155,7 @@ export function preprocessMintlifySyntax(markdown: string): string {
     const processedLines: string[] = [];
     let activeFence: string | null = null;
     let mintlifyTabsDepth = 0;
-    const mintlifyTagStack: Array<'Tabs' | 'Tab'> = [];
+    const mintlifyTagStack: Array<'Tabs' | 'Tab' | 'Card' | 'CardGroup'> = [];
 
     const pushLine = (value: string): void => {
         processedLines.push(value);
@@ -189,6 +197,68 @@ export function preprocessMintlifySyntax(markdown: string): string {
 
         if (activeFence !== null) {
             processedLines.push(effectiveLine);
+
+            continue;
+        }
+
+        const cardGroupOpenMatch = /^<CardGroup(?<attributes>[^>]*)>$/.exec(
+            trimmedLine,
+        );
+
+        if (cardGroupOpenMatch) {
+            const attributes = parseJsxAttributes(
+                cardGroupOpenMatch.groups?.attributes ?? '',
+            );
+
+            pushBlankLineIfNeeded();
+            pushLine(`::::cardgroup${buildDirectiveAttributes(attributes)}`);
+            pushLine('');
+            mintlifyTagStack.push('CardGroup');
+
+            continue;
+        }
+
+        if (trimmedLine === '</CardGroup>') {
+            if (mintlifyTagStack.at(-1) === 'CardGroup') {
+                mintlifyTagStack.pop();
+            }
+
+            pushBlankLineIfNeeded();
+            pushLine('::::');
+
+            continue;
+        }
+
+        const cardTagMatch = /^<Card(?<attributes>[^>]*)>$/.exec(trimmedLine);
+
+        if (cardTagMatch) {
+            const rawAttrs = cardTagMatch.groups?.attributes ?? '';
+            const isSelfClosing = rawAttrs.trimEnd().endsWith('/');
+            const cleanAttrs = isSelfClosing
+                ? rawAttrs.trimEnd().slice(0, -1)
+                : rawAttrs;
+            const attributes = parseJsxAttributes(cleanAttrs);
+
+            pushBlankLineIfNeeded();
+            pushLine(`:::card${buildDirectiveAttributes(attributes)}`);
+            pushLine('');
+
+            if (isSelfClosing) {
+                pushLine(':::');
+            } else {
+                mintlifyTagStack.push('Card');
+            }
+
+            continue;
+        }
+
+        if (trimmedLine === '</Card>') {
+            if (mintlifyTagStack.at(-1) === 'Card') {
+                mintlifyTagStack.pop();
+            }
+
+            pushBlankLineIfNeeded();
+            pushLine(':::');
 
             continue;
         }
@@ -330,9 +400,7 @@ export function preprocessMarkdownContent(markdown: string): string {
     return processedLines.join('\n');
 }
 
-export function parseMarkdownImageMetadata(
-    url?: string | null,
-): ImageMetadata {
+export function parseMarkdownImageMetadata(url?: string | null): ImageMetadata {
     if (!url) {
         return { src: '' };
     }

--- a/resources/js/lib/remark-card-directive.ts
+++ b/resources/js/lib/remark-card-directive.ts
@@ -1,0 +1,44 @@
+import type { Root } from 'mdast';
+import type { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+interface ContainerDirectiveNode extends Node {
+    type: 'containerDirective';
+    name: string;
+    attributes?: Record<string, string | boolean | undefined>;
+    data?: {
+        hName?: string;
+        hProperties?: Record<string, unknown>;
+    };
+}
+
+export function remarkCardDirective() {
+    return (tree: Root) => {
+        visit(tree, (node: Node) => {
+            if (node.type !== 'containerDirective') {
+                return;
+            }
+
+            const directiveNode = node as ContainerDirectiveNode;
+
+            if (directiveNode.name === 'cardgroup') {
+                directiveNode.data = directiveNode.data || {};
+                directiveNode.data.hName = 'cardgroup';
+                directiveNode.data.hProperties = {
+                    'data-card-group-cols':
+                        directiveNode.attributes?.cols ?? undefined,
+                };
+            }
+
+            if (directiveNode.name === 'card') {
+                directiveNode.data = directiveNode.data || {};
+                directiveNode.data.hName = 'card';
+                directiveNode.data.hProperties = {
+                    'data-card-title': directiveNode.attributes?.title,
+                    'data-card-icon': directiveNode.attributes?.icon,
+                    'data-card-href': directiveNode.attributes?.href,
+                };
+            }
+        });
+    };
+}

--- a/tests-node/markdown/markdown-card-href.test.ts
+++ b/tests-node/markdown/markdown-card-href.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { sanitizeMarkdownCardHref } from '../../resources/js/lib/markdown-card-href.ts';
+
+test('sanitizeMarkdownCardHref preserves safe URLs', () => {
+    assert.equal(sanitizeMarkdownCardHref('/guides/index'), '/guides/index');
+    assert.equal(
+        sanitizeMarkdownCardHref('https://example.com/docs/cards'),
+        'https://example.com/docs/cards',
+    );
+});
+
+test('sanitizeMarkdownCardHref removes unsafe URLs', () => {
+    assert.equal(
+        sanitizeMarkdownCardHref('javascript:alert("xss")'),
+        undefined,
+    );
+    assert.equal(
+        sanitizeMarkdownCardHref('data:text/html,<script>alert(1)</script>'),
+        undefined,
+    );
+});

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -37,6 +37,27 @@ Hidden content
     assert.match(output, /:::tab\{title="npm" icon="package"\}/);
 });
 
+test('preprocessMarkdownSyntax converts Mintlify CardGroup and Card to directive syntax', () => {
+    const output = preprocessMarkdownSyntax(`<CardGroup cols={2}>
+  <Card title="Tabs" icon="folder" href="/components/tabs">
+    Organize related content.
+  </Card>
+  <Card title="Steps" icon="list-ordered" href="/components/steps" />
+</CardGroup>`);
+
+    assert.match(output, /::::cardgroup\{cols="2"\}/);
+    assert.match(output, /:::card\{title="Tabs" icon="folder" href="\/components\/tabs"\}/);
+    assert.match(output, /:::card\{title="Steps" icon="list-ordered" href="\/components\/steps"\}/);
+});
+
+test('preprocessMarkdownSyntax converts standalone Mintlify Card to directive syntax', () => {
+    const output = preprocessMarkdownSyntax(`<Card title="Callouts" icon="message-square-warning" href="/components/callouts">
+  Highlight important information with styled alerts.
+</Card>`);
+
+    assert.match(output, /:::card\{title="Callouts" icon="message-square-warning" href="\/components\/callouts"\}/);
+});
+
 test('preprocessMarkdownSyntax leaves Mintlify tags untouched inside fenced code blocks', () => {
     const output = preprocessMarkdownSyntax(`\`\`\`\`mdx
 <Tabs>

--- a/tests-node/markdown/remark-card-directive.test.ts
+++ b/tests-node/markdown/remark-card-directive.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { remarkCardDirective } from '../../resources/js/lib/remark-card-directive.ts';
+
+test('remarkCardDirective maps cardgroup directive to renderable node', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'cardgroup',
+                attributes: { cols: '2' },
+                children: [
+                    {
+                        type: 'containerDirective',
+                        name: 'card',
+                        attributes: {
+                            title: 'Tabs',
+                            icon: 'folder',
+                            href: '/components/tabs',
+                        },
+                        children: [],
+                    },
+                ],
+            },
+        ],
+    };
+
+    remarkCardDirective()(tree as never);
+
+    const groupNode = tree.children[0] as {
+        data?: { hName?: string; hProperties?: Record<string, unknown> };
+        children: Array<{
+            data?: { hName?: string; hProperties?: Record<string, unknown> };
+        }>;
+    };
+    const cardNode = groupNode.children[0];
+
+    assert.equal(groupNode.data?.hName, 'cardgroup');
+    assert.deepEqual(groupNode.data?.hProperties, {
+        'data-card-group-cols': '2',
+    });
+
+    assert.equal(cardNode.data?.hName, 'card');
+    assert.deepEqual(cardNode.data?.hProperties, {
+        'data-card-title': 'Tabs',
+        'data-card-icon': 'folder',
+        'data-card-href': '/components/tabs',
+    });
+});
+
+test('remarkCardDirective maps standalone card directive', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'card',
+                attributes: {
+                    title: 'Callouts',
+                    icon: 'message-square-warning',
+                    href: '/components/callouts',
+                },
+                children: [],
+            },
+        ],
+    };
+
+    remarkCardDirective()(tree as never);
+
+    const cardNode = tree.children[0] as {
+        data?: { hName?: string; hProperties?: Record<string, unknown> };
+    };
+
+    assert.equal(cardNode.data?.hName, 'card');
+    assert.deepEqual(cardNode.data?.hProperties, {
+        'data-card-title': 'Callouts',
+        'data-card-icon': 'message-square-warning',
+        'data-card-href': '/components/callouts',
+    });
+});
+
+test('remarkCardDirective ignores unrelated directives', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'tabs',
+                attributes: {},
+                children: [],
+            },
+        ],
+    };
+
+    remarkCardDirective()(tree as never);
+
+    assert.equal(
+        (tree.children[0] as { data?: unknown }).data,
+        undefined,
+    );
+});

--- a/tests/Feature/PostSeederTest.php
+++ b/tests/Feature/PostSeederTest.php
@@ -43,7 +43,7 @@ test('post seeder creates the zenn syntax guide with code block examples', funct
     expect($post->published_at)->not->toBeNull();
 });
 
-test('post seeder creates the mintlify syntax draft page', function () {
+test('post seeder creates the mintlify syntax page', function () {
     $this->seed(PostSeeder::class);
 
     $namespace = PostNamespace::query()
@@ -61,7 +61,8 @@ test('post seeder creates the mintlify syntax draft page', function () {
     expect($post)->not->toBeNull();
     expect($post->title)->toBe('Mintlify Syntax (WIP)');
     expect($post->content)->toContain('# Mintlify Syntax');
-    expect($post->content)->toContain('<Card title="Tabs" icon="folder" href="/components/tabs">');
+    expect($post->content)->toContain('<Card title="Tabs" icon="folder" href="/guides/index">');
+    expect($post->content)->toContain('<CardGroup cols={2}>');
     expect($post->content)->toContain('Live example:');
     expect($post->content)->toContain('<Tabs>');
     expect($post->content)->toContain('<Tab title="yarn">');

--- a/tsconfig.markdown-tests.json
+++ b/tsconfig.markdown-tests.json
@@ -11,8 +11,10 @@
         "rewriteRelativeImportExtensions": true
     },
     "include": [
+        "resources/js/lib/markdown-card-href.ts",
         "resources/js/lib/markdown-syntax.ts",
         "resources/js/lib/remark-tabs-directive.ts",
+        "resources/js/lib/remark-card-directive.ts",
         "tests-node/**/*.ts"
     ]
 }


### PR DESCRIPTION
## Summary
- add Mintlify `<Card>` and `<CardGroup>` preprocessing, directive mapping, and React rendering
- seed rendered examples and add regression coverage for syntax and directive handling
- sanitize card href values before rendering links to avoid unsafe protocols

## Testing
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build