### PR TITLE
Restore Prism language registrations

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -64,4 +64,4 @@ jobs:
         run: npm run build
 
       - name: Markdown Browser Tests
-        run: ./vendor/bin/pest --ci tests/Browser/ZennMarkdownRenderingTest.php tests/Browser/MintlifyTabsRenderingTest.php
+        run: ./vendor/bin/pest --ci tests/Browser/ZennMarkdownRenderingTest.php tests/Browser/MintlifyTabsRenderingTest.php tests/Browser/CodeBlockHighlightingTest.php

--- a/resources/js/lib/prism.ts
+++ b/resources/js/lib/prism.ts
@@ -1,3 +1,13 @@
 import Prism from 'prismjs';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-jsx';
+import 'prismjs/components/prism-markup-templating'; // required by prism-php
+import 'prismjs/components/prism-php';
+import 'prismjs/components/prism-python';
+import 'prismjs/components/prism-tsx';
+import 'prismjs/components/prism-typescript';
 
 export default Prism;

--- a/tests/Browser/CodeBlockHighlightingTest.php
+++ b/tests/Browser/CodeBlockHighlightingTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('code blocks with filenames keep Prism syntax highlighting', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Syntax Highlighting
+
+```php:index.php
+<?php
+
+function add(int $a, int $b): int
+{
+    return $a + $b;
+}
+```
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertSee('index.php')
+        ->assertPresent('code.language-php')
+        ->assertPresent('code.language-php .token.keyword');
+});


### PR DESCRIPTION
## Summary
- restore the Prism language registrations needed by the markdown code block renderer
- add a browser regression test that verifies filename code blocks keep Prism token markup
- include the new browser test in the browser workflow so the regression is covered in CI

## Testing
- vendor/bin/sail npm run build
- vendor/bin/sail artisan test --compact tests/Browser/ZennMarkdownRenderingTest.php tests/Browser/MintlifyTabsRenderingTest.php tests/Browser/CodeBlockHighlightingTest.php

## Related
- Closes #23