### PR TITLE
Fix Prism runtime in browser builds

### DIFF
--- a/resources/js/components/code-block.tsx
+++ b/resources/js/components/code-block.tsx
@@ -1,10 +1,20 @@
 import { Check, Copy, MoveHorizontal, WrapText } from 'lucide-react';
+import Prism from 'prismjs';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-jsx';
+import 'prismjs/components/prism-markup-templating'; // required by prism-php
+import 'prismjs/components/prism-php';
+import 'prismjs/components/prism-python';
+import 'prismjs/components/prism-tsx';
+import 'prismjs/components/prism-typescript';
 import type { ComponentPropsWithoutRef } from 'react';
 import { useState } from 'react';
 import type { ExtraProps } from 'react-markdown';
 import { MermaidBlock } from '@/components/mermaid-block';
 import { useClipboard } from '@/hooks/use-clipboard';
-import Prism from '@/lib/prism';
 
 type CodeBlockProps = ComponentPropsWithoutRef<'code'> & ExtraProps;
 

--- a/resources/js/components/github-embed.tsx
+++ b/resources/js/components/github-embed.tsx
@@ -1,6 +1,16 @@
 import { ExternalLink, FileCode } from 'lucide-react';
+import Prism from 'prismjs';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-jsx';
+import 'prismjs/components/prism-markup-templating';
+import 'prismjs/components/prism-php';
+import 'prismjs/components/prism-python';
+import 'prismjs/components/prism-tsx';
+import 'prismjs/components/prism-typescript';
 import React from 'react';
-import Prism from '@/lib/prism';
 import { parseGithubUrl } from '@/lib/url-matcher';
 
 /** Maximum number of lines to display when no line range is specified. */


### PR DESCRIPTION
## Summary
- restore direct Prism component imports in the browser-highlighted components
- avoid the runtime `Prism is not defined` error introduced by the shared wrapper approach
- keep the browser markdown test suite green after merging the highlighting fix

## Testing
- vendor/bin/sail npm exec -- eslint resources/js/components/code-block.tsx resources/js/components/github-embed.tsx
- vendor/bin/sail npm run build
- vendor/bin/sail artisan test --compact tests/Browser/ZennMarkdownRenderingTest.php tests/Browser/MintlifyTabsRenderingTest.php tests/Browser/CodeBlockHighlightingTest.php

## Notes
- clean-build workflow direction was documented in issue #8 comments rather than a repo markdown note