### PR TITLE
Improve Mintlify and Zenn markdown support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Run Pint
         run: composer lint
 
-      - name: Format Frontend
-        run: npm run format
+      - name: Check Frontend Formatting
+        run: npm run format:check
 
       - name: Lint Frontend
         run: npm run lint

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -643,6 +643,8 @@ MD),
                 'content' => trim(<<<'MD'
 # Zenn Syntax
 
+> Reference: https://zenn.dev/zenn/articles/markdown-guide
+
 Zenn supports a few convenient image patterns on top of regular Markdown.
 
 ## Basic Image
@@ -715,6 +717,34 @@ Your warning here
 
 :::message alert
 Your warning here
+:::
+
+This system also supports extended variants as a non-standard extension. These are not part of the Zenn spec but work here.
+
+```md
+:::message note
+Neutral note.
+:::
+
+:::message tip
+Helpful tip.
+:::
+
+:::message check
+Success or confirmation.
+:::
+```
+
+:::message note
+Neutral note.
+:::
+
+:::message tip
+Helpful tip.
+:::
+
+:::message check
+Success or confirmation.
 :::
 
 ## Details (Collapsible)
@@ -887,7 +917,83 @@ MD),
                 'content' => trim(<<<'MD'
 # Mintlify Syntax
 
+> Reference: https://starter.mintlify.com/essentials/markdown / https://mintlify.wiki/motleyai/docs/essentials/markdown
+
 Mintlify ships with MDX-flavored components for docs sites. This page covers the components supported by the ThinkStream Markdown pipeline.
+
+---
+
+# Callouts
+
+Mintlify provides five callout types. Each maps to a Zenn-style `:::message` directive internally.
+
+<Note>
+  This is a note callout. Use it for neutral information.
+</Note>
+
+<Tip>
+  This is a tip callout. Use it for helpful advice.
+</Tip>
+
+<Info>
+  This is an info callout. Use it for additional context.
+</Info>
+
+<Warning>
+  This is a warning callout. Use it for cautionary information.
+</Warning>
+
+<Check>
+  This is a check callout. Use it for success states or confirmations.
+</Check>
+
+Source:
+
+```mdx
+<Note>
+  This is a note callout. Use it for neutral information.
+</Note>
+
+<Tip>
+  This is a tip callout. Use it for helpful advice.
+</Tip>
+
+<Info>
+  This is an info callout. Use it for additional context.
+</Info>
+
+<Warning>
+  This is a warning callout. Use it for cautionary information.
+</Warning>
+
+<Check>
+  This is a check callout. Use it for success states or confirmations.
+</Check>
+```
+
+You can also use the underlying Zenn-style directive syntax directly:
+
+```md
+:::message note
+Note content here.
+:::
+
+:::message tip
+Tip content here.
+:::
+
+:::message
+Info content here.
+:::
+
+:::message alert
+Warning content here.
+:::
+
+:::message check
+Check content here.
+:::
+```
 
 ---
 
@@ -1022,24 +1128,6 @@ Expandable sections are typically written like this:
 ```
 
 This page keeps the original Mintlify syntax visible so we can decide later how to transform it.
-
----
-
-# Callouts
-
-Callouts are useful for note, warning, and info states.
-
-```mdx
-<Callout type="info">
-  This syntax is still under review.
-</Callout>
-```
-
-```mdx
-<Callout type="warning">
-  Rendering support may require custom component mapping.
-</Callout>
-```
 
 ---
 

--- a/resources/js/components/code-block.tsx
+++ b/resources/js/components/code-block.tsx
@@ -67,7 +67,9 @@ function parseCodeMeta(
 export function CodeBlock({ className, children, node }: CodeBlockProps) {
     const [wrap, setWrap] = useState(isMobileViewport);
     const [copied, setCopied] = useState(false);
-    const [prismReady, setPrismReady] = useState(() => Boolean(Prism.languages.php));
+    const [prismReady, setPrismReady] = useState(() =>
+        Boolean(Prism.languages.php),
+    );
     const [, copy] = useClipboard();
 
     useEffect(() => {
@@ -271,13 +273,13 @@ export function CodeBlock({ className, children, node }: CodeBlockProps) {
                         }
                         style={{ background: 'transparent' }}
                         dangerouslySetInnerHTML={{
-                             __html:
-                                 prismReady &&
-                                 highlightLang &&
-                                 Prism.languages[highlightLang]
-                                     ? Prism.highlight(
-                                           content,
-                                           Prism.languages[highlightLang],
+                            __html:
+                                prismReady &&
+                                highlightLang &&
+                                Prism.languages[highlightLang]
+                                    ? Prism.highlight(
+                                          content,
+                                          Prism.languages[highlightLang],
                                           highlightLang,
                                       )
                                     : escapeHtml(content),
@@ -339,13 +341,13 @@ export function CodeBlock({ className, children, node }: CodeBlockProps) {
                             : {}),
                     }}
                     dangerouslySetInnerHTML={{
-                         __html:
-                             prismReady &&
-                             highlightLang &&
-                             Prism.languages[highlightLang]
-                                 ? Prism.highlight(
-                                       content,
-                                       Prism.languages[highlightLang],
+                        __html:
+                            prismReady &&
+                            highlightLang &&
+                            Prism.languages[highlightLang]
+                                ? Prism.highlight(
+                                      content,
+                                      Prism.languages[highlightLang],
                                       highlightLang,
                                   )
                                 : escapeHtml(content),

--- a/resources/js/components/github-embed.tsx
+++ b/resources/js/components/github-embed.tsx
@@ -46,7 +46,9 @@ export function GithubEmbed({ url }: GithubEmbedProps) {
     const [lines, setLines] = React.useState<string[] | null>(null);
     const [loading, setLoading] = React.useState(true);
     const [error, setError] = React.useState(false);
-    const [prismReady, setPrismReady] = React.useState(() => Boolean(Prism.languages.php));
+    const [prismReady, setPrismReady] = React.useState(() =>
+        Boolean(Prism.languages.php),
+    );
 
     React.useEffect(() => {
         if (prismReady) {

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, Info } from 'lucide-react';
+import { AlertTriangle, CircleCheck, Info, Lightbulb } from 'lucide-react';
 import type { Components } from 'react-markdown';
 import ReactMarkdown from 'react-markdown';
 import {
@@ -56,13 +56,46 @@ function SummaryEl({
     );
 }
 
+const CALLOUT_CONFIG = {
+    note: {
+        Icon: Info,
+        bg: 'bg-gray-50 dark:bg-gray-900/40',
+        text: 'text-gray-800 dark:text-gray-200',
+        iconColor: 'text-gray-500',
+    },
+    tip: {
+        Icon: Lightbulb,
+        bg: 'bg-green-50 dark:bg-green-950/40',
+        text: 'text-green-900 dark:text-green-100',
+        iconColor: 'text-green-500',
+    },
+    info: {
+        Icon: Info,
+        bg: 'bg-blue-50 dark:bg-blue-950/40',
+        text: 'text-blue-900 dark:text-blue-100',
+        iconColor: 'text-blue-500',
+    },
+    alert: {
+        Icon: AlertTriangle,
+        bg: 'bg-amber-50 dark:bg-amber-950/40',
+        text: 'text-amber-900 dark:text-amber-100',
+        iconColor: 'text-amber-500',
+    },
+    check: {
+        Icon: CircleCheck,
+        bg: 'bg-green-50 dark:bg-green-950/40',
+        text: 'text-green-900 dark:text-green-100',
+        iconColor: 'text-green-500',
+    },
+} as const;
+
+type CalloutType = keyof typeof CALLOUT_CONFIG;
+
 function MessageBox({
     children,
     className,
     ...props
 }: React.ComponentPropsWithoutRef<'aside'>) {
-    const isAlert = className?.includes('alert');
-
     if (!className?.includes('msg')) {
         return (
             <aside className={className} {...props}>
@@ -71,25 +104,23 @@ function MessageBox({
         );
     }
 
-    const Icon = isAlert ? AlertCircle : Info;
+    const classes = className.split(/\s+/);
+    const typeKey =
+        (classes.find((c) => c in CALLOUT_CONFIG) as CalloutType | undefined) ??
+        'info';
+    const { Icon, bg, text, iconColor } = CALLOUT_CONFIG[typeKey];
 
     return (
         <aside
             className={cn(
                 'not-prose my-6 flex items-start gap-3 rounded-md px-4 py-4 text-sm leading-relaxed',
-                isAlert
-                    ? 'bg-amber-50 text-amber-900 dark:bg-amber-950/40 dark:text-amber-100'
-                    : 'bg-blue-50 text-blue-900 dark:bg-blue-950/40 dark:text-blue-100',
+                bg,
+                text,
+                className,
             )}
             {...props}
         >
-            <Icon
-                className={cn(
-                    'mt-0.5 shrink-0',
-                    isAlert ? 'text-amber-500' : 'text-blue-500',
-                )}
-                size={18}
-            />
+            <Icon className={cn('mt-0.5 shrink-0', iconColor)} size={18} />
             <div className="min-w-0 flex-1">{children}</div>
         </aside>
     );
@@ -110,6 +141,7 @@ export default function MarkdownContent({
         card?: (props: Record<string, unknown>) => React.ReactElement;
         cardgroup?: (props: Record<string, unknown>) => React.ReactElement;
     } = {
+        pre: ({ children }) => <>{children}</>,
         aside: MessageBox,
         details: DetailsBox,
         summary: SummaryEl,

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -117,6 +117,7 @@ function parseJsxAttributes(
                 // Numeric value — store as string
                 attributes[key] = jsxValue;
             }
+
             continue;
         }
 
@@ -150,12 +151,24 @@ function buildDirectiveAttributes(
     return `{${serialized}}`;
 }
 
+const MINTLIFY_CALLOUT_TAGS = {
+    Note: ':::message{.note}',
+    Tip: ':::message{.tip}',
+    Info: ':::message',
+    Warning: ':::message{.alert}',
+    Check: ':::message{.check}',
+} as const;
+
+type MintlifyCalloutTag = keyof typeof MINTLIFY_CALLOUT_TAGS;
+
 export function preprocessMintlifySyntax(markdown: string): string {
     const lines = markdown.split('\n');
     const processedLines: string[] = [];
     let activeFence: string | null = null;
     let mintlifyTabsDepth = 0;
-    const mintlifyTagStack: Array<'Tabs' | 'Tab' | 'Card' | 'CardGroup'> = [];
+    const mintlifyTagStack: Array<
+        'Tabs' | 'Tab' | 'Card' | 'CardGroup' | MintlifyCalloutTag
+    > = [];
 
     const pushLine = (value: string): void => {
         processedLines.push(value);
@@ -197,6 +210,38 @@ export function preprocessMintlifySyntax(markdown: string): string {
 
         if (activeFence !== null) {
             processedLines.push(effectiveLine);
+
+            continue;
+        }
+
+        // Mintlify callout open tag: <Note>, <Tip>, <Info>, <Warning>, <Check>
+        const calloutOpenMatch = /^<(?<tag>Note|Tip|Info|Warning|Check)>$/.exec(
+            trimmedLine,
+        );
+
+        if (calloutOpenMatch) {
+            const tag = calloutOpenMatch.groups!.tag as MintlifyCalloutTag;
+
+            pushBlankLineIfNeeded();
+            pushLine(MINTLIFY_CALLOUT_TAGS[tag]);
+            pushLine('');
+            mintlifyTagStack.push(tag);
+
+            continue;
+        }
+
+        const calloutCloseMatch =
+            /^<\/(?<tag>Note|Tip|Info|Warning|Check)>$/.exec(trimmedLine);
+
+        if (calloutCloseMatch) {
+            const tag = calloutCloseMatch.groups!.tag as MintlifyCalloutTag;
+
+            if (mintlifyTagStack.at(-1) === tag) {
+                mintlifyTagStack.pop();
+            }
+
+            pushBlankLineIfNeeded();
+            pushLine(':::');
 
             continue;
         }
@@ -329,17 +374,76 @@ export function preprocessMintlifySyntax(markdown: string): string {
     return processedLines.join('\n');
 }
 
+function transformOutsideInlineCode(
+    line: string,
+    transform: (segment: string) => string,
+): string {
+    let result = '';
+    let lastIndex = 0;
+
+    for (const match of line.matchAll(/`+[^`]*`+/g)) {
+        result += transform(line.slice(lastIndex, match.index));
+        result += match[0];
+        lastIndex = match.index! + match[0].length;
+    }
+
+    result += transform(line.slice(lastIndex));
+
+    return result;
+}
+
+function transformOutsideFences(
+    markdown: string,
+    transform: (line: string) => string,
+): string {
+    const lines = markdown.split('\n');
+    let activeFence: string | null = null;
+
+    return lines
+        .map((line) => {
+            const trimmed = line.trim();
+            const fenceMatch = /^(`{3,}|~{3,})/.exec(trimmed);
+
+            if (fenceMatch) {
+                const fence = fenceMatch[1];
+                const remainder = trimmed.slice(fence.length);
+
+                if (activeFence === null) {
+                    activeFence = fence;
+                } else if (
+                    fence[0] === activeFence[0] &&
+                    fence.length >= activeFence.length &&
+                    remainder.trim() === ''
+                ) {
+                    activeFence = null;
+                }
+
+                return line;
+            }
+
+            if (activeFence !== null) {
+                return line;
+            }
+
+            return transformOutsideInlineCode(line, transform);
+        })
+        .join('\n');
+}
+
 export function preprocessMarkdownSyntax(markdown: string): string {
-    return (
-        preprocessMintlifySyntax(markdown)
-            // Normalize :::message alert to the attribute form remark-directive expects.
-            .replace(/:::message\s+alert\b/g, ':::message{.alert}')
+    return transformOutsideFences(preprocessMintlifySyntax(markdown), (line) =>
+        line
+            // Normalize :::message <type> to the attribute form remark-directive expects.
+            .replace(
+                /:::message\s+(alert|note|tip|info|check)\b/,
+                ':::message{.$1}',
+            )
             // Convert :::details title to the label form remark-directive expects.
-            .replace(/:::details\s+(.+?)(\r?\n)/g, ':::details[$1]$2')
+            .replace(/:::details\s+(.+?)$/, ':::details[$1]')
             // Convert @[card](URL) to a bare URL line so remark-linkify-to-card picks it up.
-            .replace(/^@\[card\]\((https?:\/\/[^\s)]+)\)$/gm, '$1')
+            .replace(/^@\[card\]\((https?:\/\/[^\s)]+)\)$/, '$1')
             // Convert @[github](URL) to a bare URL line so remark-linkify-to-card picks it up.
-            .replace(/^@\[github\]\((https?:\/\/[^\s)]+)\)$/gm, '$1')
+            .replace(/^@\[github\]\((https?:\/\/[^\s)]+)\)$/, '$1'),
     );
 }
 

--- a/resources/js/lib/remark-zenn-directive.ts
+++ b/resources/js/lib/remark-zenn-directive.ts
@@ -26,14 +26,16 @@ export function remarkZennDirective() {
                 const attributes = directiveNode.attributes ?? {};
                 const className =
                     attributes.className ?? attributes.class ?? '';
-                const isAlert =
-                    className.includes('alert') ||
-                    attributes.alert !== undefined;
+                const classes = className.split(/\s+/).filter(Boolean);
+                const typeClass =
+                    (['alert', 'note', 'tip', 'check'] as const).find((c) =>
+                        classes.includes(c),
+                    ) ?? (attributes.alert !== undefined ? 'alert' : 'info');
 
                 const data = directiveNode.data ?? (directiveNode.data = {});
                 data.hName = 'aside';
                 data.hProperties = {
-                    className: `msg ${isAlert ? 'alert' : 'message'}`,
+                    className: `msg ${typeClass}`,
                 };
             }
 

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -11,6 +11,18 @@ test('preprocessMarkdownSyntax normalizes Zenn shorthand and Mintlify tabs', () 
 Watch out
 :::
 
+:::message note
+Take note
+:::
+
+:::message tip
+Pro tip
+:::
+
+:::message check
+All done
+:::
+
 :::details More Info
 Hidden content
 :::
@@ -27,6 +39,9 @@ Hidden content
 </Tabs>`);
 
     assert.match(output, /:::message\{\.alert\}/);
+    assert.match(output, /:::message\{\.note\}/);
+    assert.match(output, /:::message\{\.tip\}/);
+    assert.match(output, /:::message\{\.check\}/);
     assert.match(output, /:::details\[More Info\]/);
     assert.match(output, /^https:\/\/example\.com$/m);
     assert.match(output, /^https:\/\/github\.com\/owner\/repo$/m);
@@ -58,7 +73,46 @@ test('preprocessMarkdownSyntax converts standalone Mintlify Card to directive sy
     assert.match(output, /:::card\{title="Callouts" icon="message-square-warning" href="\/components\/callouts"\}/);
 });
 
-test('preprocessMarkdownSyntax leaves Mintlify tags untouched inside fenced code blocks', () => {
+test('preprocessMarkdownSyntax converts Mintlify callout tags to message directives', () => {
+    const output = preprocessMarkdownSyntax(`<Note>
+  This is a note.
+</Note>
+
+<Tip>
+  This is a tip.
+</Tip>
+
+<Info>
+  This is info.
+</Info>
+
+<Warning>
+  This is a warning.
+</Warning>
+
+<Check>
+  This is a check.
+</Check>`);
+
+    assert.match(output, /:::message\{\.note\}/);
+    assert.match(output, /:::message\{\.tip\}/);
+    assert.match(output, /:::message\n/);
+    assert.match(output, /:::message\{\.alert\}/);
+    assert.match(output, /:::message\{\.check\}/);
+});
+
+test('preprocessMarkdownSyntax leaves Mintlify callout tags untouched inside fenced code blocks', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`mdx
+<Note>This is a note.</Note>
+<Warning>This is a warning.</Warning>
+\`\`\``);
+
+    assert.doesNotMatch(output, /:::message/);
+    assert.match(output, /<Note>/);
+    assert.match(output, /<Warning>/);
+});
+
+test('preprocessMarkdownSyntax leaves Mintlify Tabs tags untouched inside fenced code blocks', () => {
     const output = preprocessMarkdownSyntax(`\`\`\`\`mdx
 <Tabs>
   <Tab title="npm">
@@ -72,6 +126,21 @@ test('preprocessMarkdownSyntax leaves Mintlify tags untouched inside fenced code
     assert.doesNotMatch(output, /::::tabs/);
     assert.match(output, /<Tabs>/);
     assert.match(output, /<Tab title="npm">/);
+});
+
+test('preprocessMarkdownSyntax leaves inline code literals untouched', () => {
+    const output = preprocessMarkdownSyntax(
+        'Use `:::message alert`, `:::details More Info`, `@[card](https://example.com)`, and `@[github](https://github.com/owner/repo)` literally.',
+    );
+
+    assert.match(output, /`:::message alert`/);
+    assert.match(output, /`:::details More Info`/);
+    assert.match(output, /`@\[card\]\(https:\/\/example\.com\)`/);
+    assert.match(
+        output,
+        /`@\[github\]\(https:\/\/github\.com\/owner\/repo\)`/,
+    );
+    assert.doesNotMatch(output, /:::message\{\.alert\}/);
 });
 
 test('preprocessMarkdownContent encodes image metadata outside fences only', () => {

--- a/tests/Browser/MintlifyTabsRenderingTest.php
+++ b/tests/Browser/MintlifyTabsRenderingTest.php
@@ -63,3 +63,46 @@ MARKDOWN,
         ->assertSee('<Tabs>')
         ->assertSee('<Tab title="npm">');
 });
+
+test('mintlify-style callouts render as typed message boxes', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Callouts
+
+<Note>
+  Neutral note.
+</Note>
+
+<Tip>
+  Helpful tip.
+</Tip>
+
+<Info>
+  Additional context.
+</Info>
+
+<Warning>
+  Warning details.
+</Warning>
+
+<Check>
+  Success state.
+</Check>
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('svg.lucide-info')
+        ->assertPresent('svg.lucide-lightbulb')
+        ->assertPresent('svg.lucide-triangle-alert')
+        ->assertPresent('svg.lucide-circle-check')
+        ->assertSee('Neutral note.')
+        ->assertSee('Helpful tip.')
+        ->assertSee('Additional context.')
+        ->assertSee('Warning details.')
+        ->assertSee('Success state.');
+});

--- a/tests/Feature/PostSeederTest.php
+++ b/tests/Feature/PostSeederTest.php
@@ -68,7 +68,9 @@ test('post seeder creates the mintlify syntax page', function () {
     expect($post->content)->toContain('<Tab title="yarn">');
     expect($post->content)->toContain('yarn install');
     expect($post->content)->toContain('<Accordion title="Supported formats">');
-    expect($post->content)->toContain('<Callout type="warning">');
+    expect($post->content)->toContain('<Note>');
+    expect($post->content)->toContain('<Warning>');
+    expect($post->content)->toContain('<Check>');
     expect($post->content)->toContain('<ResponseField name="id" type="string" required>');
     expect($post->published_at)->not->toBeNull();
 });


### PR DESCRIPTION
## Summary
- extend markdown preprocessing and rendering for Mintlify callouts plus richer Zenn message variants
- preserve inline code literals during shorthand normalization and document the new syntax examples in the seeded posts
- add node and browser regression coverage for the new markdown behavior

## Testing
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm run types:check
- vendor/bin/sail npx eslint resources/js/components/code-block.tsx resources/js/components/github-embed.tsx resources/js/components/markdown-content.tsx resources/js/lib/markdown-syntax.ts resources/js/lib/remark-zenn-directive.ts tests-node/markdown/markdown-syntax.test.ts
- vendor/bin/sail artisan test --compact tests/Browser/MintlifyTabsRenderingTest.php tests/Browser/ZennMarkdownRenderingTest.php
- vendor/bin/sail bin pint --dirty --format agent