### PR TITLE
Add Mintlify accordion markdown preprocessing

### DIFF
--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -1117,17 +1117,37 @@ Possible fallback if tabs are unsupported: split content into headings such as `
 
 # Accordions
 
-Expandable sections are typically written like this:
+Accordion components create collapsible sections. The `title` attribute sets the visible label. An optional `icon` attribute is accepted but ignored by this renderer.
+
+Live examples:
+
+<Accordion title="What is Mintlify?">
+  Mintlify is a documentation platform that helps you create beautiful, performant documentation sites.
+</Accordion>
+
+<Accordion title="How do I get started?" icon="rocket">
+  Follow our [quickstart guide](/quickstart) to set up your documentation site in minutes.
+</Accordion>
+
+Source:
 
 ```mdx
-<Accordion title="Supported formats">
-  - Markdown
-  - MDX
-  - HTML snippets
+<Accordion title="What is Mintlify?">
+  Mintlify is a documentation platform that helps you create beautiful, performant documentation sites.
+</Accordion>
+
+<Accordion title="How do I get started?" icon="rocket">
+  Follow our [quickstart guide](/quickstart) to set up your documentation site in minutes.
 </Accordion>
 ```
 
-This page keeps the original Mintlify syntax visible so we can decide later how to transform it.
+You can also use the underlying Zenn `:::details` syntax directly:
+
+```md
+:::details What is Mintlify?
+Mintlify is a documentation platform.
+:::
+```
 
 ---
 

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -167,7 +167,7 @@ export function preprocessMintlifySyntax(markdown: string): string {
     let activeFence: string | null = null;
     let mintlifyTabsDepth = 0;
     const mintlifyTagStack: Array<
-        'Tabs' | 'Tab' | 'Card' | 'CardGroup' | MintlifyCalloutTag
+        'Tabs' | 'Tab' | 'Card' | 'CardGroup' | 'Accordion' | MintlifyCalloutTag
     > = [];
 
     const pushLine = (value: string): void => {
@@ -358,6 +358,36 @@ export function preprocessMintlifySyntax(markdown: string): string {
             pushBlankLineIfNeeded();
             pushLine(mintlifyTabsDepth > 0 ? '::::' : ':::');
             mintlifyTabsDepth = Math.max(0, mintlifyTabsDepth - 1);
+
+            continue;
+        }
+
+        const accordionOpenMatch = /^<Accordion(?<attributes>[^>]*)>$/.exec(
+            trimmedLine,
+        );
+
+        if (accordionOpenMatch) {
+            const attributes = parseJsxAttributes(
+                accordionOpenMatch.groups?.attributes ?? '',
+            );
+            const title =
+                typeof attributes.title === 'string' ? attributes.title : '';
+
+            pushBlankLineIfNeeded();
+            pushLine(`:::details ${title}`);
+            pushLine('');
+            mintlifyTagStack.push('Accordion');
+
+            continue;
+        }
+
+        if (trimmedLine === '</Accordion>') {
+            if (mintlifyTagStack.at(-1) === 'Accordion') {
+                mintlifyTagStack.pop();
+            }
+
+            pushBlankLineIfNeeded();
+            pushLine(':::');
 
             continue;
         }

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -143,6 +143,32 @@ test('preprocessMarkdownSyntax leaves inline code literals untouched', () => {
     assert.doesNotMatch(output, /:::message\{\.alert\}/);
 });
 
+test('preprocessMarkdownSyntax converts Mintlify Accordion to details directive', () => {
+    const output = preprocessMarkdownSyntax(`<Accordion title="What is Mintlify?">
+  Mintlify is a documentation platform.
+</Accordion>
+
+<Accordion title="How do I get started?" icon="rocket">
+  Follow our quickstart guide.
+</Accordion>`);
+
+    assert.match(output, /:::details\[What is Mintlify\?\]/);
+    assert.match(output, /:::details\[How do I get started\?\]/);
+    assert.match(output, /Mintlify is a documentation platform\./);
+    assert.match(output, /Follow our quickstart guide\./);
+});
+
+test('preprocessMarkdownSyntax leaves Accordion tags untouched inside fenced code blocks', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`mdx
+<Accordion title="What is Mintlify?">
+  Mintlify is a documentation platform.
+</Accordion>
+\`\`\``);
+
+    assert.doesNotMatch(output, /:::details/);
+    assert.match(output, /<Accordion title="What is Mintlify\?">/);
+});
+
 test('preprocessMarkdownContent encodes image metadata outside fences only', () => {
     const output = preprocessMarkdownContent(`![Guide cover](/storage/guide.png =250x)
 *Guide cover image*

--- a/tests/Feature/PostSeederTest.php
+++ b/tests/Feature/PostSeederTest.php
@@ -67,7 +67,8 @@ test('post seeder creates the mintlify syntax page', function () {
     expect($post->content)->toContain('<Tabs>');
     expect($post->content)->toContain('<Tab title="yarn">');
     expect($post->content)->toContain('yarn install');
-    expect($post->content)->toContain('<Accordion title="Supported formats">');
+    expect($post->content)->toContain('<Accordion title="What is Mintlify?">');
+    expect($post->content)->toContain('<Accordion title="How do I get started?" icon="rocket">');
     expect($post->content)->toContain('<Note>');
     expect($post->content)->toContain('<Warning>');
     expect($post->content)->toContain('<Check>');


### PR DESCRIPTION
## Summary
- add Mintlify Accordion to markdown preprocessing so it renders as Zenn details directives
- expand the seeded markdown example with live Accordion usage and the equivalent details syntax
- cover Accordion conversion and fenced-code preservation in the markdown regression tests

## Testing
- vendor/bin/sail npm run markdown:test