### PR TITLE
Add Mintlify steps markdown rendering

### DIFF
--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -1153,18 +1153,40 @@ Mintlify is a documentation platform.
 
 # Steps
 
-Step-based walkthroughs can be expressed like this:
+Step-based walkthroughs use `<Steps>` and `<Step title="...">` to produce a numbered sequential guide.
+
+Live example:
+
+<Steps>
+  <Step title="Create a file">
+    Create a new MDX file in your docs directory.
+  </Step>
+  <Step title="Add frontmatter">
+    Add YAML frontmatter with `title` and `description`.
+  </Step>
+  <Step title="Write content">
+    Write your documentation using MDX syntax.
+  </Step>
+  <Step title="Preview">
+    Run `mint dev` to preview your changes.
+  </Step>
+</Steps>
+
+Source:
 
 ```mdx
 <Steps>
-  <Step title="Install dependencies">
-    Run your package manager.
+  <Step title="Create a file">
+    Create a new MDX file in your docs directory.
   </Step>
-  <Step title="Create content">
-    Add an `.mdx` page and frontmatter.
+  <Step title="Add frontmatter">
+    Add YAML frontmatter with `title` and `description`.
   </Step>
-  <Step title="Publish">
-    Verify navigation and deploy.
+  <Step title="Write content">
+    Write your documentation using MDX syntax.
+  </Step>
+  <Step title="Preview">
+    Run `mint dev` to preview your changes.
   </Step>
 </Steps>
 ```

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -14,12 +14,14 @@ import {
     MarkdownCard,
     MarkdownCardGroup,
 } from '@/components/markdown-card-group';
+import { MarkdownStep, MarkdownSteps } from '@/components/markdown-steps';
 import { MarkdownTab, MarkdownTabs } from '@/components/markdown-tabs';
 import {
     preprocessMarkdownContent,
     preprocessMarkdownSyntax,
 } from '@/lib/markdown-syntax';
 import { remarkCardDirective } from '@/lib/remark-card-directive';
+import { remarkStepsDirective } from '@/lib/remark-steps-directive';
 import { remarkCodeMeta } from '@/lib/remark-code-meta';
 import { remarkLinkifyToCard } from '@/lib/remark-linkify-to-card';
 import { remarkMark } from '@/lib/remark-mark';
@@ -140,6 +142,8 @@ export default function MarkdownContent({
         tab?: (props: Record<string, unknown>) => React.ReactElement;
         card?: (props: Record<string, unknown>) => React.ReactElement;
         cardgroup?: (props: Record<string, unknown>) => React.ReactElement;
+        steps?: (props: Record<string, unknown>) => React.ReactElement;
+        step?: (props: Record<string, unknown>) => React.ReactElement;
     } = {
         pre: ({ children }) => <>{children}</>,
         aside: MessageBox,
@@ -154,6 +158,12 @@ export default function MarkdownContent({
             <MarkdownCardGroup
                 {...(props as Parameters<typeof MarkdownCardGroup>[0])}
             />
+        ),
+        steps: (props: Record<string, unknown>) => (
+            <MarkdownSteps {...(props as Parameters<typeof MarkdownSteps>[0])} />
+        ),
+        step: (props: Record<string, unknown>) => (
+            <MarkdownStep {...(props as Parameters<typeof MarkdownStep>[0])} />
         ),
         dl: ({ node, ...props }) => {
             void node;
@@ -196,6 +206,7 @@ export default function MarkdownContent({
                 remarkZennDirective,
                 remarkTabsDirective,
                 remarkCardDirective,
+                remarkStepsDirective,
                 remarkLinkifyToCard,
                 remarkSupersub,
                 remarkDefinitionList,

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -160,7 +160,9 @@ export default function MarkdownContent({
             />
         ),
         steps: (props: Record<string, unknown>) => (
-            <MarkdownSteps {...(props as Parameters<typeof MarkdownSteps>[0])} />
+            <MarkdownSteps
+                {...(props as Parameters<typeof MarkdownSteps>[0])}
+            />
         ),
         step: (props: Record<string, unknown>) => (
             <MarkdownStep {...(props as Parameters<typeof MarkdownStep>[0])} />

--- a/resources/js/components/markdown-steps.tsx
+++ b/resources/js/components/markdown-steps.tsx
@@ -29,11 +29,8 @@ export function MarkdownStep({
     return (
         <div
             role="listitem"
-            className="step-item relative flex items-start pb-5 last:pb-0 [counter-increment:step]"
+            className="step-item relative flex items-start pb-5 last:pb-0 [counter-increment:step] after:absolute after:top-[2.75rem] after:left-0 after:h-[calc(100%-2.75rem)] after:w-px after:bg-border after:content-[''] last:after:hidden"
         >
-            {/* Vertical connector line — hidden on the last step */}
-            <div className="absolute w-px h-[calc(100%-2.75rem)] top-[2.75rem] bg-border last:hidden" />
-
             {/* Number badge */}
             <div className="absolute ml-[-13px] py-2">
                 <div className="relative size-7 shrink-0 rounded-full bg-muted text-xs font-semibold text-foreground flex items-center justify-center before:content-[counter(step)]" />

--- a/resources/js/components/markdown-steps.tsx
+++ b/resources/js/components/markdown-steps.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from 'react';
+
+interface MarkdownStepsProps {
+    children?: ReactNode;
+}
+
+interface MarkdownStepProps {
+    'data-step-title'?: string;
+    'data-step-icon'?: string;
+    children?: ReactNode;
+}
+
+export function MarkdownSteps({ children }: MarkdownStepsProps) {
+    return (
+        <div
+            role="list"
+            className="steps-block not-prose ml-3.5 my-6 [counter-reset:step]"
+            data-test="steps-block"
+        >
+            {children}
+        </div>
+    );
+}
+
+export function MarkdownStep({
+    'data-step-title': title,
+    children,
+}: MarkdownStepProps) {
+    return (
+        <div
+            role="listitem"
+            className="step-item relative flex items-start pb-5 last:pb-0 [counter-increment:step]"
+        >
+            {/* Vertical connector line — hidden on the last step */}
+            <div className="absolute w-px h-[calc(100%-2.75rem)] top-[2.75rem] bg-border last:hidden" />
+
+            {/* Number badge */}
+            <div className="absolute ml-[-13px] py-2">
+                <div className="relative size-7 shrink-0 rounded-full bg-muted text-xs font-semibold text-foreground flex items-center justify-center before:content-[counter(step)]" />
+            </div>
+
+            {/* Content */}
+            <div className="w-full overflow-hidden pl-8">
+                {title && (
+                    <p className="mt-2 font-semibold text-sm text-foreground">
+                        {title}
+                    </p>
+                )}
+                <div className="prose prose-sm dark:prose-invert mt-1 text-muted-foreground [&>p]:my-1">
+                    {children}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/markdown-steps.tsx
+++ b/resources/js/components/markdown-steps.tsx
@@ -14,7 +14,7 @@ export function MarkdownSteps({ children }: MarkdownStepsProps) {
     return (
         <div
             role="list"
-            className="steps-block not-prose ml-3.5 my-6 [counter-reset:step]"
+            className="steps-block not-prose my-6 ml-3.5 [counter-reset:step]"
             data-test="steps-block"
         >
             {children}
@@ -29,21 +29,21 @@ export function MarkdownStep({
     return (
         <div
             role="listitem"
-            className="step-item relative flex items-start pb-5 last:pb-0 [counter-increment:step] after:absolute after:top-[2.75rem] after:left-0 after:h-[calc(100%-2.75rem)] after:w-px after:bg-border after:content-[''] last:after:hidden"
+            className="step-item relative flex items-start pb-5 [counter-increment:step] after:absolute after:top-[2.75rem] after:left-0 after:h-[calc(100%-2.75rem)] after:w-px after:bg-border after:content-[''] last:pb-0 last:after:hidden"
         >
             {/* Number badge */}
             <div className="absolute ml-[-13px] py-2">
-                <div className="relative size-7 shrink-0 rounded-full bg-muted text-xs font-semibold text-foreground flex items-center justify-center before:content-[counter(step)]" />
+                <div className="relative flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold text-foreground before:content-[counter(step)]" />
             </div>
 
             {/* Content */}
             <div className="w-full overflow-hidden pl-8">
                 {title && (
-                    <p className="mt-2 font-semibold text-sm text-foreground">
+                    <p className="mt-2 text-sm font-semibold text-foreground">
                         {title}
                     </p>
                 )}
-                <div className="prose prose-sm dark:prose-invert mt-1 text-muted-foreground [&>p]:my-1">
+                <div className="prose prose-sm mt-1 text-muted-foreground dark:prose-invert [&>p]:my-1">
                     {children}
                 </div>
             </div>

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -167,7 +167,14 @@ export function preprocessMintlifySyntax(markdown: string): string {
     let activeFence: string | null = null;
     let mintlifyTabsDepth = 0;
     const mintlifyTagStack: Array<
-        'Tabs' | 'Tab' | 'Card' | 'CardGroup' | 'Accordion' | MintlifyCalloutTag
+        | 'Tabs'
+        | 'Tab'
+        | 'Card'
+        | 'CardGroup'
+        | 'Accordion'
+        | 'Steps'
+        | 'Step'
+        | MintlifyCalloutTag
     > = [];
 
     const pushLine = (value: string): void => {
@@ -383,6 +390,56 @@ export function preprocessMintlifySyntax(markdown: string): string {
 
         if (trimmedLine === '</Accordion>') {
             if (mintlifyTagStack.at(-1) === 'Accordion') {
+                mintlifyTagStack.pop();
+            }
+
+            pushBlankLineIfNeeded();
+            pushLine(':::');
+
+            continue;
+        }
+
+        const stepsOpenMatch = /^<Steps(?<attributes>[^>]*)>$/.exec(
+            trimmedLine,
+        );
+
+        if (stepsOpenMatch) {
+            pushBlankLineIfNeeded();
+            pushLine('::::steps');
+            pushLine('');
+            mintlifyTagStack.push('Steps');
+
+            continue;
+        }
+
+        if (trimmedLine === '</Steps>') {
+            if (mintlifyTagStack.at(-1) === 'Steps') {
+                mintlifyTagStack.pop();
+            }
+
+            pushBlankLineIfNeeded();
+            pushLine('::::');
+
+            continue;
+        }
+
+        const stepOpenMatch = /^<Step(?<attributes>[^>]*)>$/.exec(trimmedLine);
+
+        if (stepOpenMatch) {
+            const attributes = parseJsxAttributes(
+                stepOpenMatch.groups?.attributes ?? '',
+            );
+
+            pushBlankLineIfNeeded();
+            pushLine(`:::step${buildDirectiveAttributes(attributes)}`);
+            pushLine('');
+            mintlifyTagStack.push('Step');
+
+            continue;
+        }
+
+        if (trimmedLine === '</Step>') {
+            if (mintlifyTagStack.at(-1) === 'Step') {
                 mintlifyTagStack.pop();
             }
 

--- a/resources/js/lib/remark-steps-directive.ts
+++ b/resources/js/lib/remark-steps-directive.ts
@@ -1,0 +1,40 @@
+import type { Root } from 'mdast';
+import type { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+interface ContainerDirectiveNode extends Node {
+    type: 'containerDirective';
+    name: string;
+    attributes?: Record<string, string | boolean | undefined>;
+    data?: {
+        hName?: string;
+        hProperties?: Record<string, unknown>;
+    };
+}
+
+export function remarkStepsDirective() {
+    return (tree: Root) => {
+        visit(tree, (node: Node) => {
+            if (node.type !== 'containerDirective') {
+                return;
+            }
+
+            const directiveNode = node as ContainerDirectiveNode;
+
+            if (directiveNode.name === 'steps') {
+                directiveNode.data = directiveNode.data || {};
+                directiveNode.data.hName = 'steps';
+                directiveNode.data.hProperties = {};
+            }
+
+            if (directiveNode.name === 'step') {
+                directiveNode.data = directiveNode.data || {};
+                directiveNode.data.hName = 'step';
+                directiveNode.data.hProperties = {
+                    'data-step-title': directiveNode.attributes?.title,
+                    'data-step-icon': directiveNode.attributes?.icon,
+                };
+            }
+        });
+    };
+}

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -158,6 +158,37 @@ test('preprocessMarkdownSyntax converts Mintlify Accordion to details directive'
     assert.match(output, /Follow our quickstart guide\./);
 });
 
+test('preprocessMarkdownSyntax converts Mintlify Steps/Step to directive syntax', () => {
+    const output = preprocessMarkdownSyntax(`<Steps>
+  <Step title="Create a file">
+    Create a new MDX file in your docs directory.
+  </Step>
+  <Step title="Add frontmatter">
+    Add YAML frontmatter with title and description.
+  </Step>
+</Steps>`);
+
+    assert.match(output, /::::steps/);
+    assert.match(output, /:::step\{title="Create a file"\}/);
+    assert.match(output, /:::step\{title="Add frontmatter"\}/);
+    assert.match(output, /Create a new MDX file/);
+    assert.match(output, /Add YAML frontmatter/);
+});
+
+test('preprocessMarkdownSyntax leaves Steps tags untouched inside fenced code blocks', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`mdx
+<Steps>
+  <Step title="Create a file">
+    Create a new MDX file.
+  </Step>
+</Steps>
+\`\`\``);
+
+    assert.doesNotMatch(output, /::::steps/);
+    assert.match(output, /<Steps>/);
+    assert.match(output, /<Step title="Create a file">/);
+});
+
 test('preprocessMarkdownSyntax leaves Accordion tags untouched inside fenced code blocks', () => {
     const output = preprocessMarkdownSyntax(`\`\`\`mdx
 <Accordion title="What is Mintlify?">

--- a/tests-node/markdown/remark-steps-directive.test.ts
+++ b/tests-node/markdown/remark-steps-directive.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { remarkStepsDirective } from '../../resources/js/lib/remark-steps-directive.ts';
+
+test('remarkStepsDirective maps steps and step directives to renderable nodes', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'steps',
+                attributes: {},
+                children: [
+                    {
+                        type: 'containerDirective',
+                        name: 'step',
+                        attributes: {
+                            title: 'Create a file',
+                            icon: 'file',
+                        },
+                        children: [],
+                    },
+                ],
+            },
+        ],
+    };
+
+    remarkStepsDirective()(tree as never);
+
+    const stepsNode = tree.children[0] as {
+        data?: { hName?: string; hProperties?: Record<string, unknown> };
+        children: Array<{
+            data?: { hName?: string; hProperties?: Record<string, unknown> };
+        }>;
+    };
+    const stepNode = stepsNode.children[0];
+
+    assert.equal(stepsNode.data?.hName, 'steps');
+    assert.deepEqual(stepsNode.data?.hProperties, {});
+
+    assert.equal(stepNode.data?.hName, 'step');
+    assert.deepEqual(stepNode.data?.hProperties, {
+        'data-step-title': 'Create a file',
+        'data-step-icon': 'file',
+    });
+});
+
+test('remarkStepsDirective ignores unrelated directives', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'message',
+                attributes: {
+                    className: 'alert',
+                },
+                children: [],
+            },
+        ],
+    };
+
+    remarkStepsDirective()(tree as never);
+
+    assert.equal(
+        (tree.children[0] as { data?: unknown }).data,
+        undefined,
+    );
+});


### PR DESCRIPTION
## Summary
- add Mintlify Steps and Step preprocessing plus a remark directive mapper for markdown rendering
- render steps in the React markdown components with a dedicated numbered step UI
- expand the seeded Mintlify syntax examples and cover the new syntax with markdown regression tests

## Testing
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail artisan test --compact tests/Feature/PostSeederTest.php
- vendor/bin/sail npm run build