### PR TITLE
Add Mintlify API fields markdown rendering

### DIFF
--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -917,7 +917,10 @@ MD),
                 'content' => trim(<<<'MD'
 # Mintlify Syntax
 
-> Reference: https://starter.mintlify.com/essentials/markdown / https://mintlify.wiki/motleyai/docs/essentials/markdown
+> References:
+> - https://starter.mintlify.com/essentials/markdown
+> - https://mintlify.wiki/motleyai/docs/essentials/markdown
+> - https://www.mintlify.com/docs/components/index
 
 Mintlify ships with MDX-flavored components for docs sites. This page covers the components supported by the ThinkStream Markdown pipeline.
 
@@ -1193,33 +1196,79 @@ Source:
 
 ---
 
-# API Blocks
+# API Fields
 
-Mintlify also provides API-oriented components.
+## ResponseField
+
+Use `<ResponseField>` to describe the fields of an API response. Supports `name`, `type`, `required`, `default`, and `deprecated`.
+
+Live example:
+
+<ResponseField name="id" type="string" required>
+  Unique identifier for the resource.
+</ResponseField>
+
+<ResponseField name="title" type="string" required>
+  The post title.
+</ResponseField>
+
+<ResponseField name="published_at" type="string | null">
+  ISO 8601 timestamp, or `null` if the post is unpublished.
+</ResponseField>
+
+<ResponseField name="slug" type="string" required deprecated>
+  URL slug. Use `handle` instead.
+</ResponseField>
+
+Source:
 
 ```mdx
 <ResponseField name="id" type="string" required>
   Unique identifier for the resource.
 </ResponseField>
+
+<ResponseField name="published_at" type="string | null">
+  ISO 8601 timestamp, or `null` if the post is unpublished.
+</ResponseField>
+
+<ResponseField name="slug" type="string" required deprecated>
+  URL slug. Use `handle` instead.
+</ResponseField>
 ```
+
+## ParamField
+
+Use `<ParamField>` to describe request parameters. The attribute key (`path`, `query`, or `body`) indicates where the parameter appears, and its value is the parameter name.
+
+Live example:
+
+<ParamField path="slug" type="string" required>
+  Slug used to resolve the page.
+</ParamField>
+
+<ParamField query="include" type="string">
+  Comma-separated list of relations to include in the response.
+</ParamField>
+
+<ParamField body="title" type="string" required>
+  The post title.
+</ParamField>
+
+Source:
 
 ```mdx
 <ParamField path="slug" type="string" required>
   Slug used to resolve the page.
 </ParamField>
+
+<ParamField query="include" type="string">
+  Comma-separated list of relations to include in the response.
+</ParamField>
+
+<ParamField body="title" type="string" required>
+  The post title.
+</ParamField>
 ```
-
-These are good candidates for a later conversion layer if we want richer API docs inside ThinkStream.
-
----
-
-# Temporary Notes
-
-- Keep importing example syntax from Mintlify docs.
-- Decide which components should render natively versus stay as literal code samples.
-- Add transformation rules only after we have a clear supported subset.
-
-> **WIP:** Next pass can include Banner, Badge, CodeGroup, Frame, and Mermaid examples.
 MD),
                 'published_at' => now(),
             ]);

--- a/resources/js/components/markdown-api-fields.tsx
+++ b/resources/js/components/markdown-api-fields.tsx
@@ -1,0 +1,164 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+interface ApiFieldBaseProps {
+    name?: string;
+    type?: string;
+    required?: string | boolean;
+    deprecated?: string | boolean;
+    defaultValue?: string;
+    locationKind?: string;
+    children?: ReactNode;
+}
+
+function resolveBoolean(value: string | boolean | undefined): boolean {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    if (typeof value === 'string') {
+        return value !== '' && value !== 'false' && value !== '0';
+    }
+
+    return false;
+}
+
+function ApiFieldBase({
+    name,
+    type,
+    required,
+    deprecated,
+    defaultValue,
+    locationKind,
+    children,
+}: ApiFieldBaseProps) {
+    const isRequired = resolveBoolean(required);
+    const isDeprecated = resolveBoolean(deprecated);
+
+    return (
+        <div className="not-prose border-t border-border py-4 last:border-b">
+            <div className="mb-2 flex flex-wrap items-center gap-2">
+                {name && (
+                    <span className="font-mono text-sm font-semibold text-sky-600 dark:text-sky-400">
+                        {name}
+                    </span>
+                )}
+                {locationKind && (
+                    <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                        {locationKind}
+                    </span>
+                )}
+                {type && (
+                    <span className="rounded-full bg-orange-50 px-2 py-0.5 text-xs font-medium text-orange-700 dark:bg-orange-950/40 dark:text-orange-300">
+                        {type}
+                    </span>
+                )}
+                {isRequired && (
+                    <span className="rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-600 dark:bg-red-950/40 dark:text-red-400">
+                        required
+                    </span>
+                )}
+                {isDeprecated && (
+                    <span className="rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-600 dark:bg-amber-950/40 dark:text-amber-400">
+                        deprecated
+                    </span>
+                )}
+                {defaultValue !== undefined && (
+                    <span className="text-xs text-muted-foreground">
+                        default:{' '}
+                        <code className="rounded bg-muted px-1 py-0.5 font-mono">
+                            {defaultValue}
+                        </code>
+                    </span>
+                )}
+            </div>
+            {children && (
+                <div
+                    className={cn(
+                        'prose prose-sm text-muted-foreground dark:prose-invert',
+                        '[&>p]:my-1 [&>p:first-child]:mt-0 [&>p:last-child]:mb-0',
+                    )}
+                >
+                    {children}
+                </div>
+            )}
+        </div>
+    );
+}
+
+interface MarkdownResponseFieldProps {
+    'data-field-name'?: string;
+    'data-field-type'?: string;
+    'data-field-required'?: string | boolean;
+    'data-field-default'?: string;
+    'data-field-deprecated'?: string | boolean;
+    children?: ReactNode;
+}
+
+export function MarkdownResponseField({
+    'data-field-name': name,
+    'data-field-type': type,
+    'data-field-required': required,
+    'data-field-default': defaultValue,
+    'data-field-deprecated': deprecated,
+    children,
+}: MarkdownResponseFieldProps) {
+    return (
+        <ApiFieldBase
+            name={name}
+            type={type}
+            required={required}
+            deprecated={deprecated}
+            defaultValue={defaultValue}
+        >
+            {children}
+        </ApiFieldBase>
+    );
+}
+
+interface MarkdownParamFieldProps {
+    'data-field-name'?: string;
+    'data-field-type'?: string;
+    'data-field-required'?: string | boolean;
+    'data-field-default'?: string;
+    'data-field-deprecated'?: string | boolean;
+    'data-field-path'?: string;
+    'data-field-query'?: string;
+    'data-field-body'?: string;
+    children?: ReactNode;
+}
+
+export function MarkdownParamField({
+    'data-field-name': name,
+    'data-field-type': type,
+    'data-field-required': required,
+    'data-field-default': defaultValue,
+    'data-field-deprecated': deprecated,
+    'data-field-path': path,
+    'data-field-query': query,
+    'data-field-body': body,
+    children,
+}: MarkdownParamFieldProps) {
+    // path/query/body attribute value IS the parameter name; the key is the location
+    const locationKind = path
+        ? 'path'
+        : query
+          ? 'query'
+          : body
+            ? 'body'
+            : undefined;
+    const fieldName = name ?? path ?? query ?? body;
+
+    return (
+        <ApiFieldBase
+            name={fieldName}
+            type={type}
+            required={required}
+            deprecated={deprecated}
+            defaultValue={defaultValue}
+            locationKind={locationKind}
+        >
+            {children}
+        </ApiFieldBase>
+    );
+}

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -14,6 +14,10 @@ import {
     MarkdownCard,
     MarkdownCardGroup,
 } from '@/components/markdown-card-group';
+import {
+    MarkdownParamField,
+    MarkdownResponseField,
+} from '@/components/markdown-api-fields';
 import { MarkdownStep, MarkdownSteps } from '@/components/markdown-steps';
 import { MarkdownTab, MarkdownTabs } from '@/components/markdown-tabs';
 import {
@@ -21,6 +25,7 @@ import {
     preprocessMarkdownSyntax,
 } from '@/lib/markdown-syntax';
 import { remarkCardDirective } from '@/lib/remark-card-directive';
+import { remarkApiFieldsDirective } from '@/lib/remark-api-fields-directive';
 import { remarkStepsDirective } from '@/lib/remark-steps-directive';
 import { remarkCodeMeta } from '@/lib/remark-code-meta';
 import { remarkLinkifyToCard } from '@/lib/remark-linkify-to-card';
@@ -144,6 +149,8 @@ export default function MarkdownContent({
         cardgroup?: (props: Record<string, unknown>) => React.ReactElement;
         steps?: (props: Record<string, unknown>) => React.ReactElement;
         step?: (props: Record<string, unknown>) => React.ReactElement;
+        responsefield?: (props: Record<string, unknown>) => React.ReactElement;
+        paramfield?: (props: Record<string, unknown>) => React.ReactElement;
     } = {
         pre: ({ children }) => <>{children}</>,
         aside: MessageBox,
@@ -166,6 +173,16 @@ export default function MarkdownContent({
         ),
         step: (props: Record<string, unknown>) => (
             <MarkdownStep {...(props as Parameters<typeof MarkdownStep>[0])} />
+        ),
+        responsefield: (props: Record<string, unknown>) => (
+            <MarkdownResponseField
+                {...(props as Parameters<typeof MarkdownResponseField>[0])}
+            />
+        ),
+        paramfield: (props: Record<string, unknown>) => (
+            <MarkdownParamField
+                {...(props as Parameters<typeof MarkdownParamField>[0])}
+            />
         ),
         dl: ({ node, ...props }) => {
             void node;
@@ -209,6 +226,7 @@ export default function MarkdownContent({
                 remarkTabsDirective,
                 remarkCardDirective,
                 remarkStepsDirective,
+                remarkApiFieldsDirective,
                 remarkLinkifyToCard,
                 remarkSupersub,
                 remarkDefinitionList,

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -131,7 +131,22 @@ function buildDirectiveAttributes(
     attributes: Record<string, string | boolean>,
 ): string {
     const supportedEntries = Object.entries(attributes).filter(([key]) =>
-        ['title', 'icon', 'sync', 'borderBottom', 'href', 'cols'].includes(key),
+        [
+            'title',
+            'icon',
+            'sync',
+            'borderBottom',
+            'href',
+            'cols',
+            'name',
+            'type',
+            'required',
+            'default',
+            'deprecated',
+            'path',
+            'query',
+            'body',
+        ].includes(key),
     );
 
     if (supportedEntries.length === 0) {
@@ -174,6 +189,8 @@ export function preprocessMintlifySyntax(markdown: string): string {
         | 'Accordion'
         | 'Steps'
         | 'Step'
+        | 'ResponseField'
+        | 'ParamField'
         | MintlifyCalloutTag
     > = [];
 
@@ -440,6 +457,77 @@ export function preprocessMintlifySyntax(markdown: string): string {
 
         if (trimmedLine === '</Step>') {
             if (mintlifyTagStack.at(-1) === 'Step') {
+                mintlifyTagStack.pop();
+            }
+
+            pushBlankLineIfNeeded();
+            pushLine(':::');
+
+            continue;
+        }
+
+        const responseFieldTagMatch =
+            /^<ResponseField(?<attributes>[^>]*)>$/.exec(trimmedLine);
+
+        if (responseFieldTagMatch) {
+            const rawAttrs = responseFieldTagMatch.groups?.attributes ?? '';
+            const isSelfClosing = rawAttrs.trimEnd().endsWith('/');
+            const cleanAttrs = isSelfClosing
+                ? rawAttrs.trimEnd().slice(0, -1)
+                : rawAttrs;
+            const attributes = parseJsxAttributes(cleanAttrs);
+
+            pushBlankLineIfNeeded();
+            pushLine(`:::responsefield${buildDirectiveAttributes(attributes)}`);
+            pushLine('');
+
+            if (isSelfClosing) {
+                pushLine(':::');
+            } else {
+                mintlifyTagStack.push('ResponseField');
+            }
+
+            continue;
+        }
+
+        if (trimmedLine === '</ResponseField>') {
+            if (mintlifyTagStack.at(-1) === 'ResponseField') {
+                mintlifyTagStack.pop();
+            }
+
+            pushBlankLineIfNeeded();
+            pushLine(':::');
+
+            continue;
+        }
+
+        const paramFieldTagMatch = /^<ParamField(?<attributes>[^>]*)>$/.exec(
+            trimmedLine,
+        );
+
+        if (paramFieldTagMatch) {
+            const rawAttrs = paramFieldTagMatch.groups?.attributes ?? '';
+            const isSelfClosing = rawAttrs.trimEnd().endsWith('/');
+            const cleanAttrs = isSelfClosing
+                ? rawAttrs.trimEnd().slice(0, -1)
+                : rawAttrs;
+            const attributes = parseJsxAttributes(cleanAttrs);
+
+            pushBlankLineIfNeeded();
+            pushLine(`:::paramfield${buildDirectiveAttributes(attributes)}`);
+            pushLine('');
+
+            if (isSelfClosing) {
+                pushLine(':::');
+            } else {
+                mintlifyTagStack.push('ParamField');
+            }
+
+            continue;
+        }
+
+        if (trimmedLine === '</ParamField>') {
+            if (mintlifyTagStack.at(-1) === 'ParamField') {
                 mintlifyTagStack.pop();
             }
 

--- a/resources/js/lib/remark-api-fields-directive.ts
+++ b/resources/js/lib/remark-api-fields-directive.ts
@@ -1,0 +1,54 @@
+import type { Root } from 'mdast';
+import type { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+interface ContainerDirectiveNode extends Node {
+    type: 'containerDirective';
+    name: string;
+    attributes?: Record<string, string | boolean | undefined>;
+    data?: {
+        hName?: string;
+        hProperties?: Record<string, unknown>;
+    };
+}
+
+export function remarkApiFieldsDirective() {
+    return (tree: Root) => {
+        visit(tree, (node: Node) => {
+            if (node.type !== 'containerDirective') {
+                return;
+            }
+
+            const directiveNode = node as ContainerDirectiveNode;
+
+            if (directiveNode.name === 'responsefield') {
+                directiveNode.data = directiveNode.data || {};
+                directiveNode.data.hName = 'responsefield';
+                directiveNode.data.hProperties = {
+                    'data-field-name': directiveNode.attributes?.name,
+                    'data-field-type': directiveNode.attributes?.type,
+                    'data-field-required': directiveNode.attributes?.required,
+                    'data-field-default': directiveNode.attributes?.default,
+                    'data-field-deprecated':
+                        directiveNode.attributes?.deprecated,
+                };
+            }
+
+            if (directiveNode.name === 'paramfield') {
+                directiveNode.data = directiveNode.data || {};
+                directiveNode.data.hName = 'paramfield';
+                directiveNode.data.hProperties = {
+                    'data-field-name': directiveNode.attributes?.name,
+                    'data-field-type': directiveNode.attributes?.type,
+                    'data-field-required': directiveNode.attributes?.required,
+                    'data-field-default': directiveNode.attributes?.default,
+                    'data-field-deprecated':
+                        directiveNode.attributes?.deprecated,
+                    'data-field-path': directiveNode.attributes?.path,
+                    'data-field-query': directiveNode.attributes?.query,
+                    'data-field-body': directiveNode.attributes?.body,
+                };
+            }
+        });
+    };
+}

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -45,10 +45,7 @@ Hidden content
     assert.match(output, /:::details\[More Info\]/);
     assert.match(output, /^https:\/\/example\.com$/m);
     assert.match(output, /^https:\/\/github\.com\/owner\/repo$/m);
-    assert.match(
-        output,
-        /::::tabs\{sync="false" borderBottom="true"\}/,
-    );
+    assert.match(output, /::::tabs\{sync="false" borderBottom="true"\}/);
     assert.match(output, /:::tab\{title="npm" icon="package"\}/);
 });
 
@@ -61,16 +58,26 @@ test('preprocessMarkdownSyntax converts Mintlify CardGroup and Card to directive
 </CardGroup>`);
 
     assert.match(output, /::::cardgroup\{cols="2"\}/);
-    assert.match(output, /:::card\{title="Tabs" icon="folder" href="\/components\/tabs"\}/);
-    assert.match(output, /:::card\{title="Steps" icon="list-ordered" href="\/components\/steps"\}/);
+    assert.match(
+        output,
+        /:::card\{title="Tabs" icon="folder" href="\/components\/tabs"\}/,
+    );
+    assert.match(
+        output,
+        /:::card\{title="Steps" icon="list-ordered" href="\/components\/steps"\}/,
+    );
 });
 
 test('preprocessMarkdownSyntax converts standalone Mintlify Card to directive syntax', () => {
-    const output = preprocessMarkdownSyntax(`<Card title="Callouts" icon="message-square-warning" href="/components/callouts">
+    const output =
+        preprocessMarkdownSyntax(`<Card title="Callouts" icon="message-square-warning" href="/components/callouts">
   Highlight important information with styled alerts.
 </Card>`);
 
-    assert.match(output, /:::card\{title="Callouts" icon="message-square-warning" href="\/components\/callouts"\}/);
+    assert.match(
+        output,
+        /:::card\{title="Callouts" icon="message-square-warning" href="\/components\/callouts"\}/,
+    );
 });
 
 test('preprocessMarkdownSyntax converts Mintlify callout tags to message directives', () => {
@@ -136,15 +143,13 @@ test('preprocessMarkdownSyntax leaves inline code literals untouched', () => {
     assert.match(output, /`:::message alert`/);
     assert.match(output, /`:::details More Info`/);
     assert.match(output, /`@\[card\]\(https:\/\/example\.com\)`/);
-    assert.match(
-        output,
-        /`@\[github\]\(https:\/\/github\.com\/owner\/repo\)`/,
-    );
+    assert.match(output, /`@\[github\]\(https:\/\/github\.com\/owner\/repo\)`/);
     assert.doesNotMatch(output, /:::message\{\.alert\}/);
 });
 
 test('preprocessMarkdownSyntax converts Mintlify Accordion to details directive', () => {
-    const output = preprocessMarkdownSyntax(`<Accordion title="What is Mintlify?">
+    const output =
+        preprocessMarkdownSyntax(`<Accordion title="What is Mintlify?">
   Mintlify is a documentation platform.
 </Accordion>
 
@@ -200,8 +205,59 @@ test('preprocessMarkdownSyntax leaves Accordion tags untouched inside fenced cod
     assert.match(output, /<Accordion title="What is Mintlify\?">/);
 });
 
+test('preprocessMarkdownSyntax converts ResponseField to directive syntax', () => {
+    const output =
+        preprocessMarkdownSyntax(`<ResponseField name="id" type="string" required>
+  Unique identifier for the resource.
+</ResponseField>
+
+<ResponseField name="slug" type="string" required deprecated>
+  URL slug.
+</ResponseField>`);
+
+    assert.match(
+        output,
+        /:::responsefield\{name="id" type="string" required="true"\}/,
+    );
+    assert.match(
+        output,
+        /:::responsefield\{name="slug" type="string" required="true" deprecated="true"\}/,
+    );
+    assert.match(output, /Unique identifier for the resource\./);
+});
+
+test('preprocessMarkdownSyntax converts self-closing ResponseField correctly', () => {
+    const output = preprocessMarkdownSyntax(
+        `<ResponseField name="count" type="number" />`,
+    );
+
+    assert.match(output, /:::responsefield\{name="count" type="number"\}/);
+});
+
+test('preprocessMarkdownSyntax converts ParamField to directive syntax', () => {
+    const output =
+        preprocessMarkdownSyntax(`<ParamField path="slug" type="string" required>
+  Slug used to resolve the page.
+</ParamField>
+
+<ParamField query="include" type="string" default="author" deprecated>
+  Relations to include.
+</ParamField>`);
+
+    assert.match(
+        output,
+        /:::paramfield\{path="slug" type="string" required="true"\}/,
+    );
+    assert.match(
+        output,
+        /:::paramfield\{query="include" type="string" default="author" deprecated="true"\}/,
+    );
+    assert.match(output, /Slug used to resolve the page\./);
+});
+
 test('preprocessMarkdownContent encodes image metadata outside fences only', () => {
-    const output = preprocessMarkdownContent(`![Guide cover](/storage/guide.png =250x)
+    const output =
+        preprocessMarkdownContent(`![Guide cover](/storage/guide.png =250x)
 *Guide cover image*
 
 \`\`\`md

--- a/tests-node/markdown/remark-api-fields-directive.test.ts
+++ b/tests-node/markdown/remark-api-fields-directive.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { remarkApiFieldsDirective } from '../../resources/js/lib/remark-api-fields-directive.ts';
+
+test('remarkApiFieldsDirective maps responsefield directive to renderable node', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'responsefield',
+                attributes: {
+                    name: 'id',
+                    type: 'string',
+                    required: 'true',
+                    deprecated: 'false',
+                    default: undefined,
+                },
+                children: [],
+            },
+        ],
+    };
+
+    remarkApiFieldsDirective()(tree as never);
+
+    const node = tree.children[0] as {
+        data?: { hName?: string; hProperties?: Record<string, unknown> };
+    };
+
+    assert.equal(node.data?.hName, 'responsefield');
+    assert.deepEqual(node.data?.hProperties, {
+        'data-field-name': 'id',
+        'data-field-type': 'string',
+        'data-field-required': 'true',
+        'data-field-default': undefined,
+        'data-field-deprecated': 'false',
+    });
+});
+
+test('remarkApiFieldsDirective maps paramfield directive to renderable node', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'paramfield',
+                attributes: {
+                    path: 'slug',
+                    type: 'string',
+                    required: 'true',
+                    default: 'author',
+                    deprecated: 'true',
+                },
+                children: [],
+            },
+        ],
+    };
+
+    remarkApiFieldsDirective()(tree as never);
+
+    const node = tree.children[0] as {
+        data?: { hName?: string; hProperties?: Record<string, unknown> };
+    };
+
+    assert.equal(node.data?.hName, 'paramfield');
+    assert.deepEqual(node.data?.hProperties, {
+        'data-field-name': undefined,
+        'data-field-type': 'string',
+        'data-field-required': 'true',
+        'data-field-default': 'author',
+        'data-field-deprecated': 'true',
+        'data-field-path': 'slug',
+        'data-field-query': undefined,
+        'data-field-body': undefined,
+    });
+});
+
+test('remarkApiFieldsDirective ignores unrelated directives', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'message',
+                attributes: { className: 'alert' },
+                children: [],
+            },
+        ],
+    };
+
+    remarkApiFieldsDirective()(tree as never);
+
+    assert.equal((tree.children[0] as { data?: unknown }).data, undefined);
+});

--- a/tests/Feature/PostSeederTest.php
+++ b/tests/Feature/PostSeederTest.php
@@ -73,5 +73,6 @@ test('post seeder creates the mintlify syntax page', function () {
     expect($post->content)->toContain('<Warning>');
     expect($post->content)->toContain('<Check>');
     expect($post->content)->toContain('<ResponseField name="id" type="string" required>');
+    expect($post->content)->toContain('<ParamField path="slug" type="string" required>');
     expect($post->published_at)->not->toBeNull();
 });


### PR DESCRIPTION
## Summary
- add Mintlify ResponseField and ParamField preprocessing plus a remark directive mapper for markdown rendering
- render API field directives in React with badges for type, location, required, default, and deprecated states
- expand the seeded Mintlify syntax examples and cover the new syntax with markdown regression and feature tests

## Testing
- vendor/bin/sail npm run format:check
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail artisan test --compact tests/Feature/PostSeederTest.php
- vendor/bin/sail npm run build