### PR TITLE
Add Mintlify CodeGroup support

### DIFF
--- a/database/factories/PostNamespaceFactory.php
+++ b/database/factories/PostNamespaceFactory.php
@@ -18,11 +18,11 @@ class PostNamespaceFactory extends Factory
      */
     public function definition(): array
     {
-        $name = fake()->word();
+        $name = fake()->words(2, true);
 
         return [
-            'slug' => Str::slug($name),
-            'name' => ucfirst($name),
+            'slug' => fake()->unique()->slug(),
+            'name' => Str::title($name),
             'description' => fake()->sentence(),
             'is_published' => true,
         ];

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -1269,6 +1269,88 @@ Source:
   The post title.
 </ParamField>
 ```
+
+---
+
+# CodeGroup
+
+`<CodeGroup>` displays multiple code blocks as a tabbed interface. The tab title comes from the meta string after the language identifier. Selecting a tab persists the choice across all CodeGroup instances on the page.
+
+Live example:
+
+<CodeGroup>
+
+```javascript JavaScript
+const response = await fetch('https://api.example.com/users', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ name: 'Alice', email: 'alice@example.com' }),
+});
+const data = await response.json();
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    'https://api.example.com/users',
+    json={'name': 'Alice', 'email': 'alice@example.com'},
+)
+data = response.json()
+```
+
+```php PHP
+$response = Http::post('https://api.example.com/users', [
+    'name' => 'Alice',
+    'email' => 'alice@example.com',
+]);
+$data = $response->json();
+```
+
+</CodeGroup>
+
+A second CodeGroup syncs with the first — selecting Python above will also activate Python here:
+
+<CodeGroup>
+
+```javascript JavaScript
+console.log('Hello from JavaScript');
+```
+
+```python Python
+print('Hello from Python')
+```
+
+```php PHP
+echo 'Hello from PHP';
+```
+
+</CodeGroup>
+
+Source:
+
+````mdx
+<CodeGroup>
+
+```javascript JavaScript
+const response = await fetch('https://api.example.com/users', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ name: 'Alice', email: 'alice@example.com' }),
+});
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    'https://api.example.com/users',
+    json={'name': 'Alice', 'email': 'alice@example.com'},
+)
+```
+
+</CodeGroup>
+````
 MD),
                 'published_at' => now(),
             ]);

--- a/resources/js/components/code-block.tsx
+++ b/resources/js/components/code-block.tsx
@@ -28,7 +28,10 @@ function parseCodeMeta(
     className: string | undefined,
     metastring: string | undefined,
 ): { language: string; filename: string | null; isDiff: boolean } {
-    const rawLang = /language-(\w+)/.exec(className ?? '')?.[1] ?? '';
+    const normalizeLanguage = (value: string): string => value.toLowerCase();
+    const rawLang = normalizeLanguage(
+        /language-([\w-]+)/.exec(className ?? '')?.[1] ?? '',
+    );
     let language = rawLang;
     let filename: string | null = null;
     let isDiff = false;
@@ -39,32 +42,49 @@ function parseCodeMeta(
         const langPart = metastring?.split(/\s+/)[0] ?? '';
 
         if (langPart.includes(':')) {
-            [language, filename] = langPart.split(':') as [string, string];
+            const [metaLanguage, metaFilename] = langPart.split(':') as [
+                string,
+                string,
+            ];
+
+            language = normalizeLanguage(metaLanguage);
+            filename = metaFilename;
         } else {
-            language = langPart;
+            language = normalizeLanguage(langPart);
         }
     } else if (className?.includes(':')) {
         // className is "language-php:index.php" — colon separates lang from filename
         const afterPrefix = (className ?? '').replace(/^.*language-/, '');
         const colonIdx = afterPrefix.indexOf(':');
 
-        language = afterPrefix.slice(0, colonIdx);
+        language = normalizeLanguage(afterPrefix.slice(0, colonIdx));
         filename = afterPrefix.slice(colonIdx + 1);
     } else if (metastring) {
         // Fallback: meta carries "lang[:filename]"
         const langPart = metastring.split(/\s+/)[0] ?? '';
 
         if (langPart.includes(':')) {
-            [language, filename] = langPart.split(':') as [string, string];
+            const [metaLanguage, metaFilename] = langPart.split(':') as [
+                string,
+                string,
+            ];
+
+            language = normalizeLanguage(metaLanguage);
+            filename = metaFilename;
         } else if (langPart) {
-            language = langPart;
+            language = normalizeLanguage(langPart);
         }
     }
 
     return { language, filename, isDiff };
 }
 
-export function CodeBlock({ className, children, node }: CodeBlockProps) {
+export function CodeBlock({
+    className,
+    children,
+    node,
+    metastring,
+}: CodeBlockProps & { metastring?: string }) {
     const [wrap, setWrap] = useState(isMobileViewport);
     const [copied, setCopied] = useState(false);
     const [prismReady, setPrismReady] = useState(() =>
@@ -104,8 +124,9 @@ export function CodeBlock({ className, children, node }: CodeBlockProps) {
         );
     }
 
-    const metastring = node?.properties?.metastring as string | undefined;
-    const { language, filename, isDiff } = parseCodeMeta(className, metastring);
+    const codeMeta =
+        metastring ?? (node?.properties?.metastring as string | undefined);
+    const { language, filename, isDiff } = parseCodeMeta(className, codeMeta);
     const highlightLang = language === 'blade' ? 'html' : language;
 
     if (highlightLang === 'mermaid') {

--- a/resources/js/components/markdown-code-group.tsx
+++ b/resources/js/components/markdown-code-group.tsx
@@ -1,0 +1,157 @@
+import type { ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+import { CodeBlock } from '@/components/code-block';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
+
+interface TabInfo {
+    lang: string;
+    title: string;
+    index: number;
+    meta?: string | null;
+    value?: string;
+}
+
+interface MarkdownCodeGroupProps {
+    'data-codegroup-tabs'?: string;
+    children?: ReactNode;
+}
+
+const CODE_GROUP_STORAGE_KEY = 'code';
+const CODE_GROUP_CHANGE_EVENT = 'code-group:tab-change';
+
+function getStoredTitle(): string | null {
+    if (typeof window === 'undefined') {
+        return null;
+    }
+
+    try {
+        const raw = window.localStorage.getItem(CODE_GROUP_STORAGE_KEY);
+
+        if (!raw) {
+            return null;
+        }
+
+        return JSON.parse(raw) as string;
+    } catch {
+        return null;
+    }
+}
+
+function setStoredTitle(title: string): void {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        window.localStorage.setItem(
+            CODE_GROUP_STORAGE_KEY,
+            JSON.stringify(title),
+        );
+    } catch {
+        // Ignore storage failures in restricted environments.
+    }
+}
+
+function parseTabs(json: string | undefined): TabInfo[] {
+    try {
+        return json ? (JSON.parse(json) as TabInfo[]) : [];
+    } catch {
+        return [];
+    }
+}
+
+export function MarkdownCodeGroup({
+    'data-codegroup-tabs': tabsJson,
+}: MarkdownCodeGroupProps) {
+    const tabs = parseTabs(tabsJson);
+
+    const [activeTitle, setActiveTitle] = useState<string>(() => {
+        const stored = getStoredTitle();
+
+        if (stored && tabs.some((t) => t.title === stored)) {
+            return stored;
+        }
+
+        return tabs[0]?.title ?? '';
+    });
+
+    useEffect(() => {
+        if (typeof window === 'undefined') {
+            return undefined;
+        }
+
+        const handleChange = () => {
+            const stored = getStoredTitle();
+
+            if (stored && tabs.some((t) => t.title === stored)) {
+                setActiveTitle(stored);
+            }
+        };
+
+        window.addEventListener(CODE_GROUP_CHANGE_EVENT, handleChange);
+
+        return () => {
+            window.removeEventListener(CODE_GROUP_CHANGE_EVENT, handleChange);
+        };
+    }, [tabs]);
+
+    if (tabs.length === 0) {
+        return null;
+    }
+
+    return (
+        <div
+            className="not-prose my-6 overflow-hidden rounded-lg border border-gray-700 bg-[#282c34]"
+            data-test="code-group"
+        >
+            <Tabs
+                value={activeTitle}
+                onValueChange={(title) => {
+                    setActiveTitle(title);
+                    setStoredTitle(title);
+
+                    if (typeof window !== 'undefined') {
+                        window.dispatchEvent(new Event(CODE_GROUP_CHANGE_EVENT));
+                    }
+                }}
+            >
+                <TabsList className="h-auto w-full justify-start gap-0 rounded-none border-b border-gray-700 bg-gray-800 p-0">
+                    {tabs.map((tab) => (
+                        <TabsTrigger
+                            key={tab.title}
+                            value={tab.title}
+                            data-test={`code-group-tab-${tab.title}`}
+                            className={cn(
+                                'rounded-none border-r border-gray-700 px-4 py-2.5 font-mono text-sm font-medium text-gray-400',
+                                'hover:bg-gray-700 hover:text-gray-200',
+                                'data-[state=active]:bg-[#282c34] data-[state=active]:text-gray-200 data-[state=active]:shadow-none',
+                            )}
+                        >
+                            {tab.title}
+                        </TabsTrigger>
+                    ))}
+                </TabsList>
+
+                {tabs.map((tab) => (
+                    <TabsContent
+                        key={tab.title}
+                        value={tab.title}
+                        className="mt-0 [&_.not-prose]:my-0 [&_.not-prose]:rounded-none [&_.not-prose]:border-0"
+                    >
+                        <CodeBlock
+                            className={
+                                tab.lang
+                                    ? `language-${tab.lang.toLowerCase()}`
+                                    : undefined
+                            }
+                            metastring={tab.meta ?? undefined}
+                        >
+                            {tab.value ?? ''}
+                        </CodeBlock>
+                    </TabsContent>
+                ))}
+            </Tabs>
+        </div>
+    );
+}

--- a/resources/js/components/markdown-code-group.tsx
+++ b/resources/js/components/markdown-code-group.tsx
@@ -112,7 +112,9 @@ export function MarkdownCodeGroup({
                     setStoredTitle(title);
 
                     if (typeof window !== 'undefined') {
-                        window.dispatchEvent(new Event(CODE_GROUP_CHANGE_EVENT));
+                        window.dispatchEvent(
+                            new Event(CODE_GROUP_CHANGE_EVENT),
+                        );
                     }
                 }}
             >

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -26,6 +26,8 @@ import {
 } from '@/lib/markdown-syntax';
 import { remarkCardDirective } from '@/lib/remark-card-directive';
 import { remarkApiFieldsDirective } from '@/lib/remark-api-fields-directive';
+import { remarkCodeGroupDirective } from '@/lib/remark-code-group-directive';
+import { MarkdownCodeGroup } from '@/components/markdown-code-group';
 import { remarkStepsDirective } from '@/lib/remark-steps-directive';
 import { remarkCodeMeta } from '@/lib/remark-code-meta';
 import { remarkLinkifyToCard } from '@/lib/remark-linkify-to-card';
@@ -151,6 +153,7 @@ export default function MarkdownContent({
         step?: (props: Record<string, unknown>) => React.ReactElement;
         responsefield?: (props: Record<string, unknown>) => React.ReactElement;
         paramfield?: (props: Record<string, unknown>) => React.ReactElement;
+        codegroup?: (props: Record<string, unknown>) => React.ReactElement;
     } = {
         pre: ({ children }) => <>{children}</>,
         aside: MessageBox,
@@ -182,6 +185,11 @@ export default function MarkdownContent({
         paramfield: (props: Record<string, unknown>) => (
             <MarkdownParamField
                 {...(props as Parameters<typeof MarkdownParamField>[0])}
+            />
+        ),
+        codegroup: (props: Record<string, unknown>) => (
+            <MarkdownCodeGroup
+                {...(props as Parameters<typeof MarkdownCodeGroup>[0])}
             />
         ),
         dl: ({ node, ...props }) => {
@@ -227,6 +235,7 @@ export default function MarkdownContent({
                 remarkCardDirective,
                 remarkStepsDirective,
                 remarkApiFieldsDirective,
+                remarkCodeGroupDirective,
                 remarkLinkifyToCard,
                 remarkSupersub,
                 remarkDefinitionList,

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -180,6 +180,7 @@ export function preprocessMintlifySyntax(markdown: string): string {
     const lines = markdown.split('\n');
     const processedLines: string[] = [];
     let activeFence: string | null = null;
+    let activeFenceIndent = 0;
     let mintlifyTabsDepth = 0;
     const mintlifyTagStack: Array<
         | 'Tabs'
@@ -191,6 +192,7 @@ export function preprocessMintlifySyntax(markdown: string): string {
         | 'Step'
         | 'ResponseField'
         | 'ParamField'
+        | 'CodeGroup'
         | MintlifyCalloutTag
     > = [];
 
@@ -206,10 +208,15 @@ export function preprocessMintlifySyntax(markdown: string): string {
 
     for (const line of lines) {
         const trimmedLine = line.trim();
+        const leadingSpaces = line.match(/^ */)?.[0].length ?? 0;
         const indentWidth = mintlifyTagStack.length * 2;
         const effectiveLine =
             mintlifyTagStack.length > 0
                 ? line.replace(new RegExp(`^ {0,${indentWidth}}`), '')
+                : line;
+        const fenceContentLine =
+            activeFence !== null && activeFenceIndent > 0
+                ? line.replace(new RegExp(`^ {0,${activeFenceIndent}}`), '')
                 : line;
         const fenceMatch = /^(`{3,}|~{3,})/.exec(trimmedLine);
 
@@ -219,21 +226,25 @@ export function preprocessMintlifySyntax(markdown: string): string {
 
             if (activeFence === null) {
                 activeFence = fence;
+                activeFenceIndent = leadingSpaces;
             } else if (
                 fence[0] === activeFence[0] &&
                 fence.length >= activeFence.length &&
                 remainder.trim() === ''
             ) {
                 activeFence = null;
+                activeFenceIndent = 0;
             }
 
-            processedLines.push(effectiveLine);
+            processedLines.push(
+                activeFence === null ? fenceContentLine : effectiveLine,
+            );
 
             continue;
         }
 
         if (activeFence !== null) {
-            processedLines.push(effectiveLine);
+            processedLines.push(fenceContentLine);
 
             continue;
         }
@@ -528,6 +539,26 @@ export function preprocessMintlifySyntax(markdown: string): string {
 
         if (trimmedLine === '</ParamField>') {
             if (mintlifyTagStack.at(-1) === 'ParamField') {
+                mintlifyTagStack.pop();
+            }
+
+            pushBlankLineIfNeeded();
+            pushLine(':::');
+
+            continue;
+        }
+
+        if (trimmedLine === '<CodeGroup>') {
+            pushBlankLineIfNeeded();
+            pushLine(':::codegroup');
+            pushLine('');
+            mintlifyTagStack.push('CodeGroup');
+
+            continue;
+        }
+
+        if (trimmedLine === '</CodeGroup>') {
+            if (mintlifyTagStack.at(-1) === 'CodeGroup') {
                 mintlifyTagStack.pop();
             }
 

--- a/resources/js/lib/remark-code-group-directive.ts
+++ b/resources/js/lib/remark-code-group-directive.ts
@@ -21,9 +21,7 @@ interface CodeGroupTabInfo {
 }
 
 function capitalize(value: string): string {
-    return value.length > 0
-        ? value[0].toUpperCase() + value.slice(1)
-        : value;
+    return value.length > 0 ? value[0].toUpperCase() + value.slice(1) : value;
 }
 
 export function remarkCodeGroupDirective() {
@@ -49,8 +47,7 @@ export function remarkCodeGroupDirective() {
 
                 const codeNode = child as Code;
                 const lang = codeNode.lang ?? '';
-                const title =
-                    codeNode.meta?.trim() || capitalize(lang) || lang;
+                const title = codeNode.meta?.trim() || capitalize(lang) || lang;
 
                 tabs.push({
                     lang,

--- a/resources/js/lib/remark-code-group-directive.ts
+++ b/resources/js/lib/remark-code-group-directive.ts
@@ -1,0 +1,72 @@
+import type { Code, Root } from 'mdast';
+import type { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+interface ContainerDirectiveNode extends Node {
+    type: 'containerDirective';
+    name: string;
+    children: Node[];
+    data?: {
+        hName?: string;
+        hProperties?: Record<string, unknown>;
+    };
+}
+
+interface CodeGroupTabInfo {
+    lang: string;
+    title: string;
+    index: number;
+    meta?: string | null;
+    value: string;
+}
+
+function capitalize(value: string): string {
+    return value.length > 0
+        ? value[0].toUpperCase() + value.slice(1)
+        : value;
+}
+
+export function remarkCodeGroupDirective() {
+    return (tree: Root) => {
+        visit(tree, (node: Node) => {
+            if (node.type !== 'containerDirective') {
+                return;
+            }
+
+            const directiveNode = node as ContainerDirectiveNode;
+
+            if (directiveNode.name !== 'codegroup') {
+                return;
+            }
+
+            const tabs: CodeGroupTabInfo[] = [];
+            let tabIndex = 0;
+
+            for (const child of directiveNode.children) {
+                if (child.type !== 'code') {
+                    continue;
+                }
+
+                const codeNode = child as Code;
+                const lang = codeNode.lang ?? '';
+                const title =
+                    codeNode.meta?.trim() || capitalize(lang) || lang;
+
+                tabs.push({
+                    lang,
+                    title,
+                    index: tabIndex,
+                    meta: codeNode.meta ?? null,
+                    value: codeNode.value,
+                });
+                tabIndex++;
+            }
+
+            const data = directiveNode.data ?? (directiveNode.data = {});
+            data.hName = 'codegroup';
+            data.hProperties = {
+                'data-codegroup-tabs': JSON.stringify(tabs),
+            };
+        });
+    };
+}

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -255,6 +255,54 @@ test('preprocessMarkdownSyntax converts ParamField to directive syntax', () => {
     assert.match(output, /Slug used to resolve the page\./);
 });
 
+test('preprocessMarkdownSyntax converts CodeGroup to directive syntax', () => {
+    const output = preprocessMarkdownSyntax(`<CodeGroup>
+
+\`\`\`javascript JavaScript
+const x = 1;
+\`\`\`
+
+\`\`\`python Python
+x = 1
+\`\`\`
+
+</CodeGroup>`);
+
+    assert.match(output, /:::codegroup/);
+    assert.match(output, /^:::\s*$/m);
+    assert.match(output, /```javascript JavaScript/);
+    assert.match(output, /```python Python/);
+});
+
+test('preprocessMarkdownSyntax preserves code indentation inside CodeGroup fences', () => {
+    const output = preprocessMarkdownSyntax(`<CodeGroup>
+
+\`\`\`javascript JavaScript
+const response = await fetch('https://api.example.com/users', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+});
+\`\`\`
+
+</CodeGroup>`);
+
+    assert.match(output, /\n  method: 'POST',/);
+    assert.match(output, /\n  headers: \{ 'Content-Type': 'application\/json' \},/);
+});
+
+test('preprocessMarkdownSyntax leaves CodeGroup tags untouched inside fenced code blocks', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`mdx
+<CodeGroup>
+\`\`\`javascript JavaScript
+const x = 1;
+\`\`\`
+</CodeGroup>
+\`\`\``);
+
+    assert.doesNotMatch(output, /:::codegroup/);
+    assert.match(output, /<CodeGroup>/);
+});
+
 test('preprocessMarkdownContent encodes image metadata outside fences only', () => {
     const output =
         preprocessMarkdownContent(`![Guide cover](/storage/guide.png =250x)

--- a/tests-node/markdown/remark-code-group-directive.test.ts
+++ b/tests-node/markdown/remark-code-group-directive.test.ts
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { remarkCodeGroupDirective } from '../../resources/js/lib/remark-code-group-directive.ts';
+
+test('remarkCodeGroupDirective maps codegroup directive to renderable node', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'codegroup',
+                children: [
+                    {
+                        type: 'code',
+                        lang: 'javascript',
+                        meta: 'JavaScript',
+                        value: 'const x = 1;',
+                    },
+                    {
+                        type: 'code',
+                        lang: 'python',
+                        meta: 'Python',
+                        value: 'x = 1',
+                    },
+                ],
+            },
+        ],
+    };
+
+    remarkCodeGroupDirective()(tree as never);
+
+    const node = tree.children[0] as {
+        data?: { hName?: string; hProperties?: Record<string, unknown> };
+    };
+
+    assert.equal(node.data?.hName, 'codegroup');
+
+    const tabs = JSON.parse(
+        node.data?.hProperties?.['data-codegroup-tabs'] as string,
+    ) as {
+        lang: string;
+        title: string;
+        index: number;
+        meta?: string | null;
+        value: string;
+    }[];
+
+    assert.equal(tabs.length, 2);
+    assert.deepEqual(tabs[0], {
+        lang: 'javascript',
+        title: 'JavaScript',
+        index: 0,
+        meta: 'JavaScript',
+        value: 'const x = 1;',
+    });
+    assert.deepEqual(tabs[1], {
+        lang: 'python',
+        title: 'Python',
+        index: 1,
+        meta: 'Python',
+        value: 'x = 1',
+    });
+});
+
+test('remarkCodeGroupDirective falls back to capitalized lang when meta is absent', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'codegroup',
+                children: [
+                    {
+                        type: 'code',
+                        lang: 'bash',
+                        meta: null,
+                        value: 'npm install',
+                    },
+                ],
+            },
+        ],
+    };
+
+    remarkCodeGroupDirective()(tree as never);
+
+    const node = tree.children[0] as {
+        data?: { hProperties?: Record<string, unknown> };
+    };
+
+    const tabs = JSON.parse(
+        node.data?.hProperties?.['data-codegroup-tabs'] as string,
+    ) as { title: string; meta?: string | null; value: string }[];
+
+    assert.equal(tabs[0]?.title, 'Bash');
+    assert.equal(tabs[0]?.meta, null);
+    assert.equal(tabs[0]?.value, 'npm install');
+});
+
+test('remarkCodeGroupDirective ignores non-code children', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'codegroup',
+                children: [
+                    { type: 'paragraph', children: [] },
+                    {
+                        type: 'code',
+                        lang: 'ts',
+                        meta: 'TypeScript',
+                        value: 'const x: number = 1;',
+                    },
+                ],
+            },
+        ],
+    };
+
+    remarkCodeGroupDirective()(tree as never);
+
+    const node = tree.children[0] as {
+        data?: { hProperties?: Record<string, unknown> };
+    };
+
+    const tabs = JSON.parse(
+        node.data?.hProperties?.['data-codegroup-tabs'] as string,
+    ) as { lang: string; title: string; index: number }[];
+
+    assert.equal(tabs.length, 1);
+    assert.equal(tabs[0]?.index, 0);
+});
+
+test('remarkCodeGroupDirective ignores unrelated directives', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'tabs',
+                children: [],
+            },
+        ],
+    };
+
+    remarkCodeGroupDirective()(tree as never);
+
+    assert.equal((tree.children[0] as { data?: unknown }).data, undefined);
+});


### PR DESCRIPTION
## Summary
- add Mintlify CodeGroup preprocessing, remark handling, and React tab rendering
- preserve code block highlighting and indentation when CodeGroup tabs change
- extend the seeded Mintlify syntax guide and markdown regression coverage for CodeGroup

## Validation
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build