### PR TITLE
Add Mintlify Columns card group support

### DIFF
--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -8,6 +8,12 @@ use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Storage;
 
+/**
+ * Seeds the example markdown guide posts used in local development.
+ *
+ * Usage:
+ * `vendor/bin/sail artisan db:seed --class=Database\\Seeders\\PostSeeder --no-interaction`
+ */
 class PostSeeder extends Seeder
 {
     public function run(): void

--- a/resources/js/components/markdown-card-group.tsx
+++ b/resources/js/components/markdown-card-group.tsx
@@ -139,7 +139,10 @@ export function MarkdownCardGroup({
     const gridColsClass = GRID_COLS_CLASS[cols] ?? 'md:grid-cols-2';
 
     return (
-        <div className={`not-prose my-6 grid gap-4 ${gridColsClass}`}>
+        <div
+            className={`not-prose my-6 grid gap-4 ${gridColsClass}`}
+            data-test="markdown-card-group"
+        >
             {children}
         </div>
     );

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -186,6 +186,7 @@ export function preprocessMintlifySyntax(markdown: string): string {
         | 'Tab'
         | 'Card'
         | 'CardGroup'
+        | 'Columns'
         | 'Accordion'
         | 'Steps'
         | 'Step'
@@ -289,6 +290,34 @@ export function preprocessMintlifySyntax(markdown: string): string {
 
         if (trimmedLine === '</CardGroup>') {
             if (mintlifyTagStack.at(-1) === 'CardGroup') {
+                mintlifyTagStack.pop();
+            }
+
+            pushBlankLineIfNeeded();
+            pushLine('::::');
+
+            continue;
+        }
+
+        const columnsOpenMatch = /^<Columns(?<attributes>[^>]*)>$/.exec(
+            trimmedLine,
+        );
+
+        if (columnsOpenMatch) {
+            const attributes = parseJsxAttributes(
+                columnsOpenMatch.groups?.attributes ?? '',
+            );
+
+            pushBlankLineIfNeeded();
+            pushLine(`::::cardgroup${buildDirectiveAttributes(attributes)}`);
+            pushLine('');
+            mintlifyTagStack.push('Columns');
+
+            continue;
+        }
+
+        if (trimmedLine === '</Columns>') {
+            if (mintlifyTagStack.at(-1) === 'Columns') {
                 mintlifyTagStack.pop();
             }
 

--- a/tests/Browser/MintlifyTabsRenderingTest.php
+++ b/tests/Browser/MintlifyTabsRenderingTest.php
@@ -106,3 +106,29 @@ MARKDOWN,
         ->assertSee('Warning details.')
         ->assertSee('Success state.');
 });
+
+test('mintlify-style Columns renders as a card group grid', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Columns
+
+<Columns cols={2}>
+    <Card title="Vite Plugin" href="/v3/installation" icon="bolt">
+        Automatic page resolution and SSR setup.
+    </Card>
+    <Card title="HTTP Requests" href="/v3/the-basics" icon="globe">
+        Make standalone HTTP requests.
+    </Card>
+</Columns>
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="markdown-card-group"]')
+        ->assertSee('Vite Plugin')
+        ->assertSee('HTTP Requests');
+});


### PR DESCRIPTION
## Summary
- add Mintlify `<Columns>` preprocessing so it maps to the existing card group directive
- expose a stable `markdown-card-group` test hook for the rendered grid
- cover the new browser flow and document how to run `PostSeeder` directly

## Testing
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail artisan test --compact tests/Browser/MintlifyTabsRenderingTest.php