### PR TITLE
Port Mintlify Badge component

### DIFF
--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -1072,6 +1072,17 @@ Source:
 </CardGroup>
 ```
 
+Rendered result for the same source:
+
+<CardGroup cols={2}>
+  <Card title="Tabs" icon="folder" href="/guides/index">
+    Organize related content into a switchable tab UI.
+  </Card>
+  <Card title="Steps" icon="list-ordered" href="/guides/zenn-syntax">
+    Sequential steps guide the reader through a process.
+  </Card>
+</CardGroup>
+
 ---
 
 # Tabs
@@ -1202,6 +1213,36 @@ Source:
 
 ---
 
+# Badge
+
+Use `<Badge>` to display status indicators, labels, and metadata inline within prose or as standalone elements.
+
+Live examples:
+
+<Badge>Badge</Badge>
+<Badge color="blue">New</Badge>
+<Badge color="green" icon="circle-check">Stable</Badge>
+<Badge stroke color="orange">Beta</Badge>
+<Badge disabled icon="lock" color="gray">Locked</Badge>
+
+Inline usage:
+
+This feature requires a <Badge color="orange" size="sm">Premium</Badge> subscription, and this endpoint returns <Badge color="blue" shape="pill">JSON</Badge> format.
+
+Source:
+
+```mdx
+<Badge>Badge</Badge>
+<Badge color="blue">New</Badge>
+<Badge color="green" icon="circle-check">Stable</Badge>
+<Badge stroke color="orange">Beta</Badge>
+<Badge disabled icon="lock" color="gray">Locked</Badge>
+
+This feature requires a <Badge color="orange" size="sm">Premium</Badge> subscription.
+```
+
+---
+
 # API Fields
 
 ## ResponseField
@@ -1280,13 +1321,13 @@ Source:
 
 # CodeGroup
 
-`<CodeGroup>` displays multiple code blocks as a tabbed interface. The tab title comes from the meta string after the language identifier. Selecting a tab persists the choice across all CodeGroup instances on the page.
+`<CodeGroup>` displays multiple code blocks as a tabbed interface. The tab title comes from the meta string after the language identifier. Add `icon="..."` to the meta string when you want an icon in the tab label. Selecting a tab persists the choice across all CodeGroup instances on the page.
 
 Live example:
 
 <CodeGroup>
 
-```javascript JavaScript
+```javascript JavaScript icon="javascript"
 const response = await fetch('https://api.example.com/users', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
@@ -1295,7 +1336,7 @@ const response = await fetch('https://api.example.com/users', {
 const data = await response.json();
 ```
 
-```python Python
+```python Python icon="python"
 import requests
 
 response = requests.post(
@@ -1305,7 +1346,7 @@ response = requests.post(
 data = response.json()
 ```
 
-```php PHP
+```php PHP icon="php"
 $response = Http::post('https://api.example.com/users', [
     'name' => 'Alice',
     'email' => 'alice@example.com',
@@ -1319,15 +1360,15 @@ A second CodeGroup syncs with the first — selecting Python above will also act
 
 <CodeGroup>
 
-```javascript JavaScript
+```javascript JavaScript icon="javascript"
 console.log('Hello from JavaScript');
 ```
 
-```python Python
+```python Python icon="python"
 print('Hello from Python')
 ```
 
-```php PHP
+```php PHP icon="php"
 echo 'Hello from PHP';
 ```
 
@@ -1338,21 +1379,31 @@ Source:
 ````mdx
 <CodeGroup>
 
-```javascript JavaScript
+```javascript JavaScript icon="javascript"
 const response = await fetch('https://api.example.com/users', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({ name: 'Alice', email: 'alice@example.com' }),
 });
+const data = await response.json();
 ```
 
-```python Python
+```python Python icon="python"
 import requests
 
 response = requests.post(
     'https://api.example.com/users',
     json={'name': 'Alice', 'email': 'alice@example.com'},
 )
+data = response.json()
+```
+
+```php PHP icon="php"
+$response = Http::post('https://api.example.com/users', [
+    'name' => 'Alice',
+    'email' => 'alice@example.com',
+]);
+$data = $response->json();
 ```
 
 </CodeGroup>

--- a/resources/js/components/markdown-badge.tsx
+++ b/resources/js/components/markdown-badge.tsx
@@ -1,0 +1,131 @@
+import type { ReactNode } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { getLucideIcon, SimpleIconSvg } from '@/components/markdown-card-group';
+import { Icon } from '@/components/ui/icon';
+import { getSimpleIcon } from '@/lib/simple-icon-lookup';
+import { cn } from '@/lib/utils';
+
+const BADGE_COLOR_STYLES = {
+    gray: {
+        solid: 'border-transparent bg-muted text-foreground',
+        stroke: 'border-border bg-transparent text-muted-foreground',
+    },
+    blue: {
+        solid: 'border-transparent bg-blue-100 text-blue-800 dark:bg-blue-950/50 dark:text-blue-200',
+        stroke: 'border-blue-200 bg-transparent text-blue-700 dark:border-blue-800 dark:text-blue-300',
+    },
+    green: {
+        solid: 'border-transparent bg-green-100 text-green-800 dark:bg-green-950/50 dark:text-green-200',
+        stroke: 'border-green-200 bg-transparent text-green-700 dark:border-green-800 dark:text-green-300',
+    },
+    yellow: {
+        solid: 'border-transparent bg-yellow-100 text-yellow-900 dark:bg-yellow-950/40 dark:text-yellow-200',
+        stroke: 'border-yellow-200 bg-transparent text-yellow-800 dark:border-yellow-800 dark:text-yellow-300',
+    },
+    orange: {
+        solid: 'border-transparent bg-orange-100 text-orange-900 dark:bg-orange-950/40 dark:text-orange-200',
+        stroke: 'border-orange-200 bg-transparent text-orange-700 dark:border-orange-800 dark:text-orange-300',
+    },
+    red: {
+        solid: 'border-transparent bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-200',
+        stroke: 'border-red-200 bg-transparent text-red-700 dark:border-red-800 dark:text-red-300',
+    },
+    purple: {
+        solid: 'border-transparent bg-purple-100 text-purple-800 dark:bg-purple-950/50 dark:text-purple-200',
+        stroke: 'border-purple-200 bg-transparent text-purple-700 dark:border-purple-800 dark:text-purple-300',
+    },
+    white: {
+        solid: 'border-slate-200 bg-white text-slate-900',
+        stroke: 'border-slate-300 bg-transparent text-slate-100 dark:text-slate-200',
+    },
+    surface: {
+        solid: 'border-border bg-background text-foreground',
+        stroke: 'border-border bg-transparent text-foreground',
+    },
+    'white-destructive': {
+        solid: 'border-red-200 bg-white text-red-700',
+        stroke: 'border-red-300 bg-transparent text-red-600 dark:text-red-300',
+    },
+    'surface-destructive': {
+        solid: 'border-red-200 bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-300',
+        stroke: 'border-red-300 bg-transparent text-red-700 dark:text-red-300',
+    },
+} as const;
+
+const BADGE_SIZE_STYLES = {
+    xs: 'px-1.5 py-0 text-[10px]',
+    sm: 'px-2 py-0.5 text-[11px]',
+    md: 'px-2.5 py-0.5 text-xs',
+    lg: 'px-3 py-1 text-sm',
+} as const;
+
+const BADGE_SHAPE_STYLES = {
+    rounded: 'rounded-md',
+    pill: 'rounded-full',
+} as const;
+
+function resolveBoolean(value: string | boolean | undefined): boolean {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    if (typeof value === 'string') {
+        return value !== '' && value !== 'false' && value !== '0';
+    }
+
+    return false;
+}
+
+interface MarkdownBadgeProps {
+    'data-badge-color'?: string;
+    'data-badge-size'?: string;
+    'data-badge-shape'?: string;
+    'data-badge-icon'?: string;
+    'data-badge-stroke'?: string | boolean;
+    'data-badge-disabled'?: string | boolean;
+    children?: ReactNode;
+}
+
+export function MarkdownBadge({
+    'data-badge-color': color = 'gray',
+    'data-badge-size': size = 'md',
+    'data-badge-shape': shape = 'rounded',
+    'data-badge-icon': icon,
+    'data-badge-stroke': stroke,
+    'data-badge-disabled': disabled,
+    children,
+}: MarkdownBadgeProps) {
+    const badgeColor =
+        BADGE_COLOR_STYLES[color as keyof typeof BADGE_COLOR_STYLES] ??
+        BADGE_COLOR_STYLES.gray;
+    const badgeSize =
+        BADGE_SIZE_STYLES[size as keyof typeof BADGE_SIZE_STYLES] ??
+        BADGE_SIZE_STYLES.md;
+    const badgeShape =
+        BADGE_SHAPE_STYLES[shape as keyof typeof BADGE_SHAPE_STYLES] ??
+        BADGE_SHAPE_STYLES.rounded;
+    const isStroke = resolveBoolean(stroke);
+    const isDisabled = resolveBoolean(disabled);
+    const lucideIcon = getLucideIcon(icon);
+    const simpleIcon = !lucideIcon ? getSimpleIcon(icon) : undefined;
+
+    return (
+        <Badge
+            data-test="markdown-badge"
+            className={cn(
+                'not-prose align-middle font-medium shadow-none',
+                badgeSize,
+                badgeShape,
+                isStroke ? badgeColor.stroke : badgeColor.solid,
+                isDisabled && 'cursor-not-allowed opacity-50',
+            )}
+        >
+            {lucideIcon ? (
+                <Icon iconNode={lucideIcon} className="size-3.5" />
+            ) : simpleIcon ? (
+                <SimpleIconSvg icon={simpleIcon} className="size-3.5" />
+            ) : null}
+            {children}
+        </Badge>
+    );
+}

--- a/resources/js/components/markdown-card-group.tsx
+++ b/resources/js/components/markdown-card-group.tsx
@@ -2,9 +2,12 @@ import {
     AlertCircle,
     ArrowRight,
     Award,
+    BadgeAlert,
+    Ban,
     Bell,
     Brain,
     Calendar,
+    Check,
     CheckCircle,
     ChevronDown,
     Clock,
@@ -36,6 +39,7 @@ import {
     Settings,
     Smile,
     Sparkles,
+    Star,
     TextCursorInput,
     Timer,
     Upload,
@@ -66,8 +70,14 @@ const ICON_MAP: Record<string, LucideIcon> = {
     info: Info,
     'alert-circle': AlertCircle,
     alertcircle: AlertCircle,
+    ban: Ban,
+    'badge-alert': BadgeAlert,
+    badgealert: BadgeAlert,
+    check: Check,
     'check-circle': CheckCircle,
     checkcircle: CheckCircle,
+    'circle-check': CheckCircle,
+    circlecheck: CheckCircle,
     'x-circle': XCircle,
     xcircle: XCircle,
     'help-circle': HelpCircle,
@@ -106,6 +116,7 @@ const ICON_MAP: Record<string, LucideIcon> = {
     flag: Flag,
     award: Award,
     smile: Smile,
+    star: Star,
     'git-branch': GitBranch,
     gitbranch: GitBranch,
     'text-cursor-input': TextCursorInput,
@@ -132,7 +143,9 @@ export function SimpleIconSvg({
     );
 }
 
-function getLucideIcon(iconName: string | undefined): LucideIcon | undefined {
+export function getLucideIcon(
+    iconName: string | undefined,
+): LucideIcon | undefined {
     if (!iconName) {
         return undefined;
     }

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -26,7 +26,9 @@ import {
 } from '@/lib/markdown-syntax';
 import { remarkCardDirective } from '@/lib/remark-card-directive';
 import { remarkApiFieldsDirective } from '@/lib/remark-api-fields-directive';
+import { remarkBadgeDirective } from '@/lib/remark-badge-directive';
 import { remarkCodeGroupDirective } from '@/lib/remark-code-group-directive';
+import { MarkdownBadge } from '@/components/markdown-badge';
 import { MarkdownCodeGroup } from '@/components/markdown-code-group';
 import { remarkStepsDirective } from '@/lib/remark-steps-directive';
 import { remarkCodeMeta } from '@/lib/remark-code-meta';
@@ -154,6 +156,7 @@ export default function MarkdownContent({
         responsefield?: (props: Record<string, unknown>) => React.ReactElement;
         paramfield?: (props: Record<string, unknown>) => React.ReactElement;
         codegroup?: (props: Record<string, unknown>) => React.ReactElement;
+        badge?: (props: Record<string, unknown>) => React.ReactElement;
     } = {
         pre: ({ children }) => <>{children}</>,
         aside: MessageBox,
@@ -190,6 +193,11 @@ export default function MarkdownContent({
         codegroup: (props: Record<string, unknown>) => (
             <MarkdownCodeGroup
                 {...(props as Parameters<typeof MarkdownCodeGroup>[0])}
+            />
+        ),
+        badge: (props: Record<string, unknown>) => (
+            <MarkdownBadge
+                {...(props as Parameters<typeof MarkdownBadge>[0])}
             />
         ),
         dl: ({ node, ...props }) => {
@@ -235,6 +243,7 @@ export default function MarkdownContent({
                 remarkCardDirective,
                 remarkStepsDirective,
                 remarkApiFieldsDirective,
+                remarkBadgeDirective,
                 remarkCodeGroupDirective,
                 remarkLinkifyToCard,
                 remarkSupersub,

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -146,6 +146,11 @@ function buildDirectiveAttributes(
             'path',
             'query',
             'body',
+            'color',
+            'size',
+            'shape',
+            'stroke',
+            'disabled',
         ].includes(key),
     );
 
@@ -188,6 +193,7 @@ const MULTILINE_JOINABLE_TAGS = [
     'ResponseField',
     'ParamField',
     'CodeGroup',
+    'Badge',
     'Note',
     'Tip',
     'Info',
@@ -792,20 +798,38 @@ function transformOutsideFences(
         .join('\n');
 }
 
+function escapeDirectiveLabel(label: string): string {
+    return label.replaceAll('\\', '\\\\').replaceAll(']', '\\]');
+}
+
+function replaceMintlifyBadges(line: string): string {
+    return line.replace(
+        /<Badge(?<attributes>[^>]*)>(?<content>.*?)<\/Badge>/g,
+        (_, attributesSource: string, content: string) => {
+            const attributes = parseJsxAttributes(attributesSource ?? '');
+            const label = escapeDirectiveLabel(content.trim());
+
+            return `:badge[${label}]${buildDirectiveAttributes(attributes)}`;
+        },
+    );
+}
+
 export function preprocessMarkdownSyntax(markdown: string): string {
     return transformOutsideFences(preprocessMintlifySyntax(markdown), (line) =>
-        line
-            // Normalize :::message <type> to the attribute form remark-directive expects.
-            .replace(
-                /:::message\s+(alert|note|tip|info|check)\b/,
-                ':::message{.$1}',
-            )
-            // Convert :::details title to the label form remark-directive expects.
-            .replace(/:::details\s+(.+?)$/, ':::details[$1]')
-            // Convert @[card](URL) to a bare URL line so remark-linkify-to-card picks it up.
-            .replace(/^@\[card\]\((https?:\/\/[^\s)]+)\)$/, '$1')
-            // Convert @[github](URL) to a bare URL line so remark-linkify-to-card picks it up.
-            .replace(/^@\[github\]\((https?:\/\/[^\s)]+)\)$/, '$1'),
+        replaceMintlifyBadges(
+            line
+                // Normalize :::message <type> to the attribute form remark-directive expects.
+                .replace(
+                    /:::message\s+(alert|note|tip|info|check)\b/,
+                    ':::message{.$1}',
+                )
+                // Convert :::details title to the label form remark-directive expects.
+                .replace(/:::details\s+(.+?)$/, ':::details[$1]')
+                // Convert @[card](URL) to a bare URL line so remark-linkify-to-card picks it up.
+                .replace(/^@\[card\]\((https?:\/\/[^\s)]+)\)$/, '$1')
+                // Convert @[github](URL) to a bare URL line so remark-linkify-to-card picks it up.
+                .replace(/^@\[github\]\((https?:\/\/[^\s)]+)\)$/, '$1'),
+        ),
     );
 }
 

--- a/resources/js/lib/remark-badge-directive.ts
+++ b/resources/js/lib/remark-badge-directive.ts
@@ -1,0 +1,40 @@
+import type { Root } from 'mdast';
+import type { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+interface TextDirectiveNode extends Node {
+    type: 'textDirective';
+    name: string;
+    attributes?: Record<string, string | boolean | undefined>;
+    data?: {
+        hName?: string;
+        hProperties?: Record<string, unknown>;
+    };
+}
+
+export function remarkBadgeDirective() {
+    return (tree: Root) => {
+        visit(tree, (node: Node) => {
+            if (node.type !== 'textDirective') {
+                return;
+            }
+
+            const directiveNode = node as TextDirectiveNode;
+
+            if (directiveNode.name !== 'badge') {
+                return;
+            }
+
+            directiveNode.data = directiveNode.data || {};
+            directiveNode.data.hName = 'badge';
+            directiveNode.data.hProperties = {
+                'data-badge-color': directiveNode.attributes?.color,
+                'data-badge-size': directiveNode.attributes?.size,
+                'data-badge-shape': directiveNode.attributes?.shape,
+                'data-badge-icon': directiveNode.attributes?.icon,
+                'data-badge-stroke': directiveNode.attributes?.stroke,
+                'data-badge-disabled': directiveNode.attributes?.disabled,
+            };
+        });
+    };
+}

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -304,6 +304,30 @@ x = 1
     assert.match(output, /```python Python/);
 });
 
+test('preprocessMarkdownSyntax converts Mintlify Badge tags to text directives', () => {
+    const output = preprocessMarkdownSyntax(
+        'This feature requires a <Badge color="orange" size="sm">Premium</Badge> subscription.\n\n<Badge color="green" icon="circle-check">Stable</Badge>',
+    );
+
+    assert.match(
+        output,
+        /This feature requires a :badge\[Premium\]\{color="orange" size="sm"\} subscription\./,
+    );
+    assert.match(
+        output,
+        /:badge\[Stable\]\{color="green" icon="circle-check"\}/,
+    );
+});
+
+test('preprocessMarkdownSyntax leaves Badge tags untouched inside fenced code blocks', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`mdx
+<Badge color="green" icon="circle-check">Stable</Badge>
+\`\`\``);
+
+    assert.doesNotMatch(output, /:badge\[/);
+    assert.match(output, /<Badge color="green" icon="circle-check">Stable<\/Badge>/);
+});
+
 test('preprocessMarkdownSyntax preserves code indentation inside CodeGroup fences', () => {
     const output = preprocessMarkdownSyntax(`<CodeGroup>
 

--- a/tests-node/markdown/remark-badge-directive.test.ts
+++ b/tests-node/markdown/remark-badge-directive.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { remarkBadgeDirective } from '../../resources/js/lib/remark-badge-directive.ts';
+
+test('remarkBadgeDirective maps badge text directives to renderable nodes', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'paragraph',
+                children: [
+                    {
+                        type: 'textDirective',
+                        name: 'badge',
+                        attributes: {
+                            color: 'green',
+                            size: 'sm',
+                            shape: 'pill',
+                            icon: 'circle-check',
+                            stroke: 'false',
+                            disabled: 'false',
+                        },
+                        children: [{ type: 'text', value: 'Stable' }],
+                    },
+                ],
+            },
+        ],
+    };
+
+    remarkBadgeDirective()(tree as never);
+
+    const node = (tree.children[0] as { children: Array<{
+        data?: { hName?: string; hProperties?: Record<string, unknown> };
+    }> }).children[0];
+
+    assert.equal(node.data?.hName, 'badge');
+    assert.deepEqual(node.data?.hProperties, {
+        'data-badge-color': 'green',
+        'data-badge-size': 'sm',
+        'data-badge-shape': 'pill',
+        'data-badge-icon': 'circle-check',
+        'data-badge-stroke': 'false',
+        'data-badge-disabled': 'false',
+    });
+});
+
+test('remarkBadgeDirective ignores unrelated directives', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'paragraph',
+                children: [
+                    {
+                        type: 'textDirective',
+                        name: 'tip',
+                        attributes: {},
+                        children: [{ type: 'text', value: 'Ignore me' }],
+                    },
+                ],
+            },
+        ],
+    };
+
+    remarkBadgeDirective()(tree as never);
+
+    const node = (tree.children[0] as { children: Array<{ data?: unknown }> })
+        .children[0];
+
+    assert.equal(node.data, undefined);
+});

--- a/tests/Browser/MintlifyTabsRenderingTest.php
+++ b/tests/Browser/MintlifyTabsRenderingTest.php
@@ -132,3 +132,68 @@ MARKDOWN,
         ->assertSee('Vite Plugin')
         ->assertSee('HTTP Requests');
 });
+
+test('mintlify-style codegroup renders icons declared in code meta', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# CodeGroup Icons
+
+<CodeGroup>
+
+```javascript JavaScript icon="javascript"
+console.log('Hello from JavaScript');
+```
+
+```python Python icon="python"
+print('Hello from Python')
+```
+
+```php PHP icon="php"
+echo 'Hello from PHP';
+```
+
+</CodeGroup>
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent(
+            '[data-test="code-group-tab-JavaScript"] svg[aria-label="JavaScript"]',
+        )
+        ->assertPresent(
+            '[data-test="code-group-tab-Python"] svg[aria-label="Python"]',
+        )
+        ->assertPresent('[data-test="code-group-tab-PHP"] svg[aria-label="PHP"]');
+});
+
+test('mintlify-style badges render inline and with supported variants', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Badge
+
+<Badge>Badge</Badge>
+<Badge color="green" icon="circle-check">Stable</Badge>
+<Badge stroke color="orange">Beta</Badge>
+<Badge disabled icon="lock" color="gray">Locked</Badge>
+
+This feature requires a <Badge color="orange" size="sm">Premium</Badge> subscription.
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="markdown-badge"]')
+        ->assertPresent('[data-test="markdown-badge"] svg')
+        ->assertSee('Stable')
+        ->assertSee('Beta')
+        ->assertSee('Locked')
+        ->assertSee('Premium')
+        ->assertSee('subscription.');
+});

--- a/tests/Feature/PostSeederTest.php
+++ b/tests/Feature/PostSeederTest.php
@@ -63,6 +63,7 @@ test('post seeder creates the mintlify syntax page', function () {
     expect($post->content)->toContain('# Mintlify Syntax');
     expect($post->content)->toContain('<Card title="Tabs" icon="folder" href="/guides/index">');
     expect($post->content)->toContain('<CardGroup cols={2}>');
+    expect($post->content)->toContain('Rendered result for the same source:');
     expect($post->content)->toContain('Live example:');
     expect($post->content)->toContain('<Tabs>');
     expect($post->content)->toContain('<Tab title="yarn">');
@@ -72,7 +73,13 @@ test('post seeder creates the mintlify syntax page', function () {
     expect($post->content)->toContain('<Note>');
     expect($post->content)->toContain('<Warning>');
     expect($post->content)->toContain('<Check>');
+    expect($post->content)->toContain('# Badge');
+    expect($post->content)->toContain('<Badge color="green" icon="circle-check">Stable</Badge>');
+    expect($post->content)->toContain('This feature requires a <Badge color="orange" size="sm">Premium</Badge> subscription.');
     expect($post->content)->toContain('<ResponseField name="id" type="string" required>');
     expect($post->content)->toContain('<ParamField path="slug" type="string" required>');
+    expect($post->content)->toContain('```javascript JavaScript icon="javascript"');
+    expect($post->content)->toContain('```python Python icon="python"');
+    expect($post->content)->toContain('```php PHP icon="php"');
     expect($post->published_at)->not->toBeNull();
 });


### PR DESCRIPTION
## Summary
- add Mintlify-style `<Badge>` support to the markdown pipeline
- render badges through a dedicated React component backed by the shared UI badge primitive
- document badge usage in the Mintlify syntax guide and add regression coverage

## Testing
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail artisan test --compact tests/Browser/MintlifyTabsRenderingTest.php tests/Feature/PostSeederTest.php
- vendor/bin/sail npm run build
- vendor/bin/sail npm run types:check