### PR TITLE
Add Mintlify Tooltip support

### DIFF
--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -1408,6 +1408,26 @@ $data = $response->json();
 
 </CodeGroup>
 ````
+
+---
+
+# Tooltip
+
+`<Tooltip>` wraps inline text and shows a popover on hover. Use `tip` for the tooltip body, `headline` for a bold title, and `cta` + `href` for an optional call-to-action link.
+
+Live example:
+
+Hover over <Tooltip tip="Application Programming Interface: a set of protocols that lets software components communicate." headline="API" cta="Read more" href="/guides/index">API</Tooltip> for a definition.
+
+Simple tooltip: hover over <Tooltip tip="Hypertext Markup Language — the standard language for web pages.">HTML</Tooltip>.
+
+Source:
+
+```mdx
+Hover over <Tooltip tip="Application Programming Interface: a set of protocols that lets software components communicate." headline="API" cta="Read more" href="/guides/index">API</Tooltip> for a definition.
+
+Simple tooltip: hover over <Tooltip tip="Hypertext Markup Language — the standard language for web pages.">HTML</Tooltip>.
+```
 MD),
                 'published_at' => now(),
             ]);

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -28,8 +28,10 @@ import { remarkCardDirective } from '@/lib/remark-card-directive';
 import { remarkApiFieldsDirective } from '@/lib/remark-api-fields-directive';
 import { remarkBadgeDirective } from '@/lib/remark-badge-directive';
 import { remarkCodeGroupDirective } from '@/lib/remark-code-group-directive';
+import { remarkTooltipDirective } from '@/lib/remark-tooltip-directive';
 import { MarkdownBadge } from '@/components/markdown-badge';
 import { MarkdownCodeGroup } from '@/components/markdown-code-group';
+import { MarkdownTooltip } from '@/components/markdown-tooltip';
 import { remarkStepsDirective } from '@/lib/remark-steps-directive';
 import { remarkCodeMeta } from '@/lib/remark-code-meta';
 import { remarkLinkifyToCard } from '@/lib/remark-linkify-to-card';
@@ -157,6 +159,7 @@ export default function MarkdownContent({
         paramfield?: (props: Record<string, unknown>) => React.ReactElement;
         codegroup?: (props: Record<string, unknown>) => React.ReactElement;
         badge?: (props: Record<string, unknown>) => React.ReactElement;
+        tooltip?: (props: Record<string, unknown>) => React.ReactElement;
     } = {
         pre: ({ children }) => <>{children}</>,
         aside: MessageBox,
@@ -198,6 +201,11 @@ export default function MarkdownContent({
         badge: (props: Record<string, unknown>) => (
             <MarkdownBadge
                 {...(props as Parameters<typeof MarkdownBadge>[0])}
+            />
+        ),
+        tooltip: (props: Record<string, unknown>) => (
+            <MarkdownTooltip
+                {...(props as Parameters<typeof MarkdownTooltip>[0])}
             />
         ),
         dl: ({ node, ...props }) => {
@@ -244,6 +252,7 @@ export default function MarkdownContent({
                 remarkStepsDirective,
                 remarkApiFieldsDirective,
                 remarkBadgeDirective,
+                remarkTooltipDirective,
                 remarkCodeGroupDirective,
                 remarkLinkifyToCard,
                 remarkSupersub,

--- a/resources/js/components/markdown-tooltip.tsx
+++ b/resources/js/components/markdown-tooltip.tsx
@@ -39,7 +39,9 @@ export function MarkdownTooltip({
             </TooltipTrigger>
             <TooltipContent className="max-w-xs text-left">
                 <div className="space-y-1">
-                    {headline ? <p className="font-semibold">{headline}</p> : null}
+                    {headline ? (
+                        <p className="font-semibold">{headline}</p>
+                    ) : null}
                     <p>{tip}</p>
                     {cta && safeHref ? (
                         <a

--- a/resources/js/components/markdown-tooltip.tsx
+++ b/resources/js/components/markdown-tooltip.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from 'react';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { sanitizeMarkdownCardHref } from '@/lib/markdown-card-href';
+
+interface MarkdownTooltipProps {
+    'data-tooltip-tip'?: string;
+    'data-tooltip-headline'?: string;
+    'data-tooltip-cta'?: string;
+    'data-tooltip-href'?: string;
+    children?: ReactNode;
+}
+
+export function MarkdownTooltip({
+    'data-tooltip-tip': tip,
+    'data-tooltip-headline': headline,
+    'data-tooltip-cta': cta,
+    'data-tooltip-href': href,
+    children,
+}: MarkdownTooltipProps) {
+    if (!tip) {
+        return <>{children}</>;
+    }
+
+    const safeHref = sanitizeMarkdownCardHref(href);
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <span
+                    className="cursor-help border-b border-dashed border-current"
+                    data-test="markdown-tooltip"
+                >
+                    {children}
+                </span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs text-left">
+                <div className="space-y-1">
+                    {headline ? <p className="font-semibold">{headline}</p> : null}
+                    <p>{tip}</p>
+                    {cta && safeHref ? (
+                        <a
+                            href={safeHref}
+                            className="mt-1 block text-primary-foreground/80 underline hover:text-primary-foreground"
+                        >
+                            {cta}
+                        </a>
+                    ) : null}
+                </div>
+            </TooltipContent>
+        </Tooltip>
+    );
+}

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -151,6 +151,9 @@ function buildDirectiveAttributes(
             'shape',
             'stroke',
             'disabled',
+            'tip',
+            'headline',
+            'cta',
         ].includes(key),
     );
 
@@ -194,6 +197,7 @@ const MULTILINE_JOINABLE_TAGS = [
     'ParamField',
     'CodeGroup',
     'Badge',
+    'Tooltip',
     'Note',
     'Tip',
     'Info',
@@ -814,21 +818,35 @@ function replaceMintlifyBadges(line: string): string {
     );
 }
 
+function replaceMintlifyTooltips(line: string): string {
+    return line.replace(
+        /<Tooltip(?<attributes>[^>]*)>(?<content>.*?)<\/Tooltip>/g,
+        (_, attributesSource: string, content: string) => {
+            const attributes = parseJsxAttributes(attributesSource ?? '');
+            const label = escapeDirectiveLabel(content.trim());
+
+            return `:tooltip[${label}]${buildDirectiveAttributes(attributes)}`;
+        },
+    );
+}
+
 export function preprocessMarkdownSyntax(markdown: string): string {
     return transformOutsideFences(preprocessMintlifySyntax(markdown), (line) =>
-        replaceMintlifyBadges(
-            line
-                // Normalize :::message <type> to the attribute form remark-directive expects.
-                .replace(
-                    /:::message\s+(alert|note|tip|info|check)\b/,
-                    ':::message{.$1}',
-                )
-                // Convert :::details title to the label form remark-directive expects.
-                .replace(/:::details\s+(.+?)$/, ':::details[$1]')
-                // Convert @[card](URL) to a bare URL line so remark-linkify-to-card picks it up.
-                .replace(/^@\[card\]\((https?:\/\/[^\s)]+)\)$/, '$1')
-                // Convert @[github](URL) to a bare URL line so remark-linkify-to-card picks it up.
-                .replace(/^@\[github\]\((https?:\/\/[^\s)]+)\)$/, '$1'),
+        replaceMintlifyTooltips(
+            replaceMintlifyBadges(
+                line
+                    // Normalize :::message <type> to the attribute form remark-directive expects.
+                    .replace(
+                        /:::message\s+(alert|note|tip|info|check)\b/,
+                        ':::message{.$1}',
+                    )
+                    // Convert :::details title to the label form remark-directive expects.
+                    .replace(/:::details\s+(.+?)$/, ':::details[$1]')
+                    // Convert @[card](URL) to a bare URL line so remark-linkify-to-card picks it up.
+                    .replace(/^@\[card\]\((https?:\/\/[^\s)]+)\)$/, '$1')
+                    // Convert @[github](URL) to a bare URL line so remark-linkify-to-card picks it up.
+                    .replace(/^@\[github\]\((https?:\/\/[^\s)]+)\)$/, '$1'),
+            ),
         ),
     );
 }

--- a/resources/js/lib/remark-tooltip-directive.ts
+++ b/resources/js/lib/remark-tooltip-directive.ts
@@ -1,0 +1,38 @@
+import type { Root } from 'mdast';
+import type { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+interface TextDirectiveNode extends Node {
+    type: 'textDirective';
+    name: string;
+    attributes?: Record<string, string | boolean | undefined>;
+    data?: {
+        hName?: string;
+        hProperties?: Record<string, unknown>;
+    };
+}
+
+export function remarkTooltipDirective() {
+    return (tree: Root) => {
+        visit(tree, (node: Node) => {
+            if (node.type !== 'textDirective') {
+                return;
+            }
+
+            const directiveNode = node as TextDirectiveNode;
+
+            if (directiveNode.name !== 'tooltip') {
+                return;
+            }
+
+            directiveNode.data = directiveNode.data || {};
+            directiveNode.data.hName = 'tooltip';
+            directiveNode.data.hProperties = {
+                'data-tooltip-tip': directiveNode.attributes?.tip,
+                'data-tooltip-headline': directiveNode.attributes?.headline,
+                'data-tooltip-cta': directiveNode.attributes?.cta,
+                'data-tooltip-href': directiveNode.attributes?.href,
+            };
+        });
+    };
+}

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -328,6 +328,29 @@ test('preprocessMarkdownSyntax leaves Badge tags untouched inside fenced code bl
     assert.match(output, /<Badge color="green" icon="circle-check">Stable<\/Badge>/);
 });
 
+test('preprocessMarkdownSyntax converts Mintlify Tooltip tags to text directives', () => {
+    const output = preprocessMarkdownSyntax(
+        'Hover over <Tooltip tip="Application Programming Interface" headline="API" cta="Read more" href="/guides/index">API</Tooltip> for a definition.',
+    );
+
+    assert.match(
+        output,
+        /Hover over :tooltip\[API\]\{tip="Application Programming Interface" headline="API" cta="Read more" href="\/guides\/index"\} for a definition\./,
+    );
+});
+
+test('preprocessMarkdownSyntax leaves Tooltip tags untouched inside fenced code blocks', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`mdx
+<Tooltip tip="Application Programming Interface">API</Tooltip>
+\`\`\``);
+
+    assert.doesNotMatch(output, /:tooltip\[/);
+    assert.match(
+        output,
+        /<Tooltip tip="Application Programming Interface">API<\/Tooltip>/,
+    );
+});
+
 test('preprocessMarkdownSyntax preserves code indentation inside CodeGroup fences', () => {
     const output = preprocessMarkdownSyntax(`<CodeGroup>
 

--- a/tests-node/markdown/remark-tooltip-directive.test.ts
+++ b/tests-node/markdown/remark-tooltip-directive.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { remarkTooltipDirective } from '../../resources/js/lib/remark-tooltip-directive.ts';
+
+test('remarkTooltipDirective maps tooltip text directives to renderable nodes', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'paragraph',
+                children: [
+                    {
+                        type: 'textDirective',
+                        name: 'tooltip',
+                        attributes: {
+                            tip: 'Application Programming Interface',
+                            headline: 'API',
+                            cta: 'Read more',
+                            href: '/guides/index',
+                        },
+                        children: [{ type: 'text', value: 'API' }],
+                    },
+                ],
+            },
+        ],
+    };
+
+    remarkTooltipDirective()(tree as never);
+
+    const node = (tree.children[0] as {
+        children: Array<{
+            data?: { hName?: string; hProperties?: Record<string, unknown> };
+        }>;
+    }).children[0];
+
+    assert.equal(node.data?.hName, 'tooltip');
+    assert.deepEqual(node.data?.hProperties, {
+        'data-tooltip-tip': 'Application Programming Interface',
+        'data-tooltip-headline': 'API',
+        'data-tooltip-cta': 'Read more',
+        'data-tooltip-href': '/guides/index',
+    });
+});
+
+test('remarkTooltipDirective ignores unrelated directives', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'paragraph',
+                children: [
+                    {
+                        type: 'textDirective',
+                        name: 'badge',
+                        attributes: {},
+                        children: [{ type: 'text', value: 'Ignore me' }],
+                    },
+                ],
+            },
+        ],
+    };
+
+    remarkTooltipDirective()(tree as never);
+
+    const node = (tree.children[0] as { children: Array<{ data?: unknown }> })
+        .children[0];
+
+    assert.equal(node.data, undefined);
+});

--- a/tests/Browser/MintlifyTabsRenderingTest.php
+++ b/tests/Browser/MintlifyTabsRenderingTest.php
@@ -197,3 +197,25 @@ MARKDOWN,
         ->assertSee('Premium')
         ->assertSee('subscription.');
 });
+
+test('mintlify-style tooltips render inline triggers', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Tooltip
+
+Hover over <Tooltip tip="Application Programming Interface" headline="API" cta="Read more" href="/guides/index">API</Tooltip> for a definition.
+
+Simple tooltip: hover over <Tooltip tip="Hypertext Markup Language">HTML</Tooltip>.
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="markdown-tooltip"]')
+        ->assertSee('Hover over')
+        ->assertSee('API')
+        ->assertSee('HTML');
+});

--- a/tests/Feature/PostSeederTest.php
+++ b/tests/Feature/PostSeederTest.php
@@ -76,6 +76,9 @@ test('post seeder creates the mintlify syntax page', function () {
     expect($post->content)->toContain('# Badge');
     expect($post->content)->toContain('<Badge color="green" icon="circle-check">Stable</Badge>');
     expect($post->content)->toContain('This feature requires a <Badge color="orange" size="sm">Premium</Badge> subscription.');
+    expect($post->content)->toContain('# Tooltip');
+    expect($post->content)->toContain('<Tooltip tip="Application Programming Interface: a set of protocols that lets software components communicate." headline="API" cta="Read more" href="/guides/index">API</Tooltip>');
+    expect($post->content)->toContain('Simple tooltip: hover over <Tooltip tip="Hypertext Markup Language — the standard language for web pages.">HTML</Tooltip>.');
     expect($post->content)->toContain('<ResponseField name="id" type="string" required>');
     expect($post->content)->toContain('<ParamField path="slug" type="string" required>');
     expect($post->content)->toContain('```javascript JavaScript icon="javascript"');


### PR DESCRIPTION
## Summary
- add Mintlify-style `<Tooltip>` support to the markdown pipeline
- render inline tooltip triggers through a dedicated markdown component and directive plugin
- document tooltip usage in the syntax guide and add regression coverage

## Testing
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail artisan test --compact tests/Browser/MintlifyTabsRenderingTest.php tests/Feature/PostSeederTest.php
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build