### PR TITLE
Add Mintlify Update support

### DIFF
--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -1428,6 +1428,50 @@ Hover over <Tooltip tip="Application Programming Interface: a set of protocols t
 
 Simple tooltip: hover over <Tooltip tip="Hypertext Markup Language — the standard language for web pages.">HTML</Tooltip>.
 ```
+
+---
+
+# Update
+
+`<Update>` displays a changelog entry in a timeline layout. Use `label` for the date or version (it also becomes an anchor link), `description` for a subtitle, and `tags` for filter labels.
+
+Live example:
+
+<Update label="2024-10-11" description="v0.2.0" tags={["Feature", "Improvement"]}>
+
+## Improved card icon support
+
+Cards now support brand icons from the `simple-icons` library in addition to Lucide icons. Pass any brand name as the `icon` prop on `<Card>`.
+
+</Update>
+
+<Update label="2024-09-01" description="v0.1.0" tags={["Initial release"]}>
+
+## First release
+
+Initial launch of Thinkstream with support for Markdown, GFM, Zenn syntax, and core Mintlify components including callouts, cards, tabs, steps, and code groups.
+
+</Update>
+
+Source:
+
+```mdx
+<Update label="2024-10-11" description="v0.2.0" tags={["Feature", "Improvement"]}>
+
+## Improved card icon support
+
+Cards now support brand icons from the `simple-icons` library in addition to Lucide icons. Pass any brand name as the `icon` prop on `<Card>`.
+
+</Update>
+
+<Update label="2024-09-01" description="v0.1.0" tags={["Initial release"]}>
+
+## First release
+
+Initial launch of Thinkstream with support for Markdown, GFM, Zenn syntax, and core Mintlify components including callouts, cards, tabs, steps, and code groups.
+
+</Update>
+```
 MD),
                 'published_at' => now(),
             ]);

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -29,9 +29,11 @@ import { remarkApiFieldsDirective } from '@/lib/remark-api-fields-directive';
 import { remarkBadgeDirective } from '@/lib/remark-badge-directive';
 import { remarkCodeGroupDirective } from '@/lib/remark-code-group-directive';
 import { remarkTooltipDirective } from '@/lib/remark-tooltip-directive';
+import { remarkUpdateDirective } from '@/lib/remark-update-directive';
 import { MarkdownBadge } from '@/components/markdown-badge';
 import { MarkdownCodeGroup } from '@/components/markdown-code-group';
 import { MarkdownTooltip } from '@/components/markdown-tooltip';
+import { MarkdownUpdate } from '@/components/markdown-update';
 import { remarkStepsDirective } from '@/lib/remark-steps-directive';
 import { remarkCodeMeta } from '@/lib/remark-code-meta';
 import { remarkLinkifyToCard } from '@/lib/remark-linkify-to-card';
@@ -160,6 +162,7 @@ export default function MarkdownContent({
         codegroup?: (props: Record<string, unknown>) => React.ReactElement;
         badge?: (props: Record<string, unknown>) => React.ReactElement;
         tooltip?: (props: Record<string, unknown>) => React.ReactElement;
+        update?: (props: Record<string, unknown>) => React.ReactElement;
     } = {
         pre: ({ children }) => <>{children}</>,
         aside: MessageBox,
@@ -208,6 +211,11 @@ export default function MarkdownContent({
                 {...(props as Parameters<typeof MarkdownTooltip>[0])}
             />
         ),
+        update: (props: Record<string, unknown>) => (
+            <MarkdownUpdate
+                {...(props as Parameters<typeof MarkdownUpdate>[0])}
+            />
+        ),
         dl: ({ node, ...props }) => {
             void node;
 
@@ -253,6 +261,7 @@ export default function MarkdownContent({
                 remarkApiFieldsDirective,
                 remarkBadgeDirective,
                 remarkTooltipDirective,
+                remarkUpdateDirective,
                 remarkCodeGroupDirective,
                 remarkLinkifyToCard,
                 remarkSupersub,

--- a/resources/js/components/markdown-update.tsx
+++ b/resources/js/components/markdown-update.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from 'react';
+
+interface MarkdownUpdateProps {
+    'data-update-label'?: string;
+    'data-update-description'?: string;
+    'data-update-tags'?: string;
+    children?: ReactNode;
+}
+
+function slugify(value: string): string {
+    return value
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+}
+
+export function MarkdownUpdate({
+    'data-update-label': label,
+    'data-update-description': description,
+    'data-update-tags': tagsStr,
+    children,
+}: MarkdownUpdateProps) {
+    const tags = tagsStr
+        ? tagsStr
+              .split(',')
+              .map((t) => t.trim())
+              .filter(Boolean)
+        : [];
+    const anchorId = label ? slugify(label) : undefined;
+
+    return (
+        <div
+            className="not-prose relative my-8 border-l-2 border-border py-1 pl-8 first:mt-0"
+            data-test="markdown-update"
+        >
+            <div className="absolute top-[7px] -left-[5px] h-2.5 w-2.5 rounded-full bg-primary ring-2 ring-background" />
+
+            <div className="mb-4 flex flex-wrap items-center gap-2">
+                {label ? (
+                    <a
+                        id={anchorId}
+                        href={anchorId ? `#${anchorId}` : undefined}
+                        className="scroll-mt-24 text-sm font-semibold text-foreground no-underline hover:text-primary"
+                    >
+                        {label}
+                    </a>
+                ) : null}
+                {description ? (
+                    <span className="text-sm text-muted-foreground">
+                        {description}
+                    </span>
+                ) : null}
+                {tags.map((tag) => (
+                    <span
+                        key={tag}
+                        className="rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                    >
+                        {tag}
+                    </span>
+                ))}
+            </div>
+
+            <div className="prose prose-sm dark:prose-invert [&>:first-child]:mt-0 [&>:last-child]:mb-0">
+                {children}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -92,6 +92,18 @@ function rewriteImageLine(line: string, caption?: string): string | null {
 function parseJsxAttributes(
     attributeSource: string,
 ): Record<string, string | boolean> {
+    // Normalize JSX array values: tags={["A", "B"]} → tags="A,B"
+    attributeSource = attributeSource.replace(
+        /(\w+)=\{(\[[^\]]*\])\}/g,
+        (_: string, key: string, arrayJson: string) => {
+            const values = [...arrayJson.matchAll(/"([^"]*)"/g)].map(
+                (m) => m[1],
+            );
+
+            return `${key}="${values.join(',')}"`;
+        },
+    );
+
     const attributes: Record<string, string | boolean> = {};
     const attributePattern =
         /(\w+)(?:=(?:"([^"]*)"|\{(true|false|\d+(?:\.\d+)?)\}))?/g;
@@ -154,6 +166,9 @@ function buildDirectiveAttributes(
             'tip',
             'headline',
             'cta',
+            'label',
+            'description',
+            'tags',
         ].includes(key),
     );
 
@@ -196,6 +211,7 @@ const MULTILINE_JOINABLE_TAGS = [
     'ResponseField',
     'ParamField',
     'CodeGroup',
+    'Update',
     'Badge',
     'Tooltip',
     'Note',
@@ -303,6 +319,7 @@ export function preprocessMintlifySyntax(markdown: string): string {
         | 'ResponseField'
         | 'ParamField'
         | 'CodeGroup'
+        | 'Update'
         | MintlifyCalloutTag
     > = [];
     const mintlifyTagLeadingSpaces: number[] = [];
@@ -573,6 +590,36 @@ export function preprocessMintlifySyntax(markdown: string): string {
 
         if (trimmedLine === '</Accordion>') {
             if (mintlifyTagStack.at(-1) === 'Accordion') {
+                mintlifyTagStack.pop();
+                mintlifyTagLeadingSpaces.pop();
+            }
+
+            pushBlankLineIfNeeded();
+            pushLine(':::');
+
+            continue;
+        }
+
+        const updateOpenMatch = /^<Update(?<attributes>[^>]*)>$/.exec(
+            trimmedLine,
+        );
+
+        if (updateOpenMatch) {
+            const attributes = parseJsxAttributes(
+                updateOpenMatch.groups?.attributes ?? '',
+            );
+
+            pushBlankLineIfNeeded();
+            pushLine(`:::update${buildDirectiveAttributes(attributes)}`);
+            pushLine('');
+            mintlifyTagLeadingSpaces.push(leadingSpaces);
+            mintlifyTagStack.push('Update');
+
+            continue;
+        }
+
+        if (trimmedLine === '</Update>') {
+            if (mintlifyTagStack.at(-1) === 'Update') {
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
             }

--- a/resources/js/lib/remark-update-directive.ts
+++ b/resources/js/lib/remark-update-directive.ts
@@ -1,0 +1,38 @@
+import type { Root } from 'mdast';
+import type { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+interface ContainerDirectiveNode extends Node {
+    type: 'containerDirective';
+    name: string;
+    attributes?: Record<string, string | boolean | undefined>;
+    data?: {
+        hName?: string;
+        hProperties?: Record<string, unknown>;
+    };
+}
+
+export function remarkUpdateDirective() {
+    return (tree: Root) => {
+        visit(tree, (node: Node) => {
+            if (node.type !== 'containerDirective') {
+                return;
+            }
+
+            const directiveNode = node as ContainerDirectiveNode;
+
+            if (directiveNode.name !== 'update') {
+                return;
+            }
+
+            directiveNode.data = directiveNode.data || {};
+            directiveNode.data.hName = 'update';
+            directiveNode.data.hProperties = {
+                'data-update-label': directiveNode.attributes?.label,
+                'data-update-description':
+                    directiveNode.attributes?.description,
+                'data-update-tags': directiveNode.attributes?.tags,
+            };
+        });
+    };
+}

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -351,6 +351,33 @@ test('preprocessMarkdownSyntax leaves Tooltip tags untouched inside fenced code 
     );
 });
 
+test('preprocessMarkdownSyntax converts Mintlify Update to directive syntax', () => {
+    const output = preprocessMarkdownSyntax(`<Update label="2024-10-11" description="v0.2.0" tags={["Feature", "Improvement"]}>
+
+## Improved card icon support
+
+Cards now support brand icons from the simple-icons library.
+
+</Update>`);
+
+    assert.match(
+        output,
+        /:::update\{label="2024-10-11" description="v0.2.0" tags="Feature,Improvement"\}/,
+    );
+    assert.match(output, /## Improved card icon support/);
+});
+
+test('preprocessMarkdownSyntax leaves Update tags untouched inside fenced code blocks', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`mdx
+<Update label="2024-10-11" description="v0.2.0" tags={["Feature", "Improvement"]}>
+## Improved card icon support
+</Update>
+\`\`\``);
+
+    assert.doesNotMatch(output, /:::update/);
+    assert.match(output, /<Update label="2024-10-11"/);
+});
+
 test('preprocessMarkdownSyntax preserves code indentation inside CodeGroup fences', () => {
     const output = preprocessMarkdownSyntax(`<CodeGroup>
 

--- a/tests-node/markdown/remark-update-directive.test.ts
+++ b/tests-node/markdown/remark-update-directive.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { remarkUpdateDirective } from '../../resources/js/lib/remark-update-directive.ts';
+
+test('remarkUpdateDirective maps update container directives to renderable nodes', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'update',
+                attributes: {
+                    label: '2024-10-11',
+                    description: 'v0.2.0',
+                    tags: 'Feature,Improvement',
+                },
+                children: [],
+            },
+        ],
+    };
+
+    remarkUpdateDirective()(tree as never);
+
+    const node = tree.children[0] as {
+        data?: { hName?: string; hProperties?: Record<string, unknown> };
+    };
+
+    assert.equal(node.data?.hName, 'update');
+    assert.deepEqual(node.data?.hProperties, {
+        'data-update-label': '2024-10-11',
+        'data-update-description': 'v0.2.0',
+        'data-update-tags': 'Feature,Improvement',
+    });
+});
+
+test('remarkUpdateDirective ignores unrelated directives', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'badge',
+                attributes: {},
+                children: [],
+            },
+        ],
+    };
+
+    remarkUpdateDirective()(tree as never);
+
+    assert.equal(
+        (tree.children[0] as { data?: unknown }).data,
+        undefined,
+    );
+});

--- a/tests/Browser/MintlifyTabsRenderingTest.php
+++ b/tests/Browser/MintlifyTabsRenderingTest.php
@@ -219,3 +219,31 @@ MARKDOWN,
         ->assertSee('API')
         ->assertSee('HTML');
 });
+
+test('mintlify-style updates render as timeline entries', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Update
+
+<Update label="2024-10-11" description="v0.2.0" tags={["Feature", "Improvement"]}>
+
+## Improved card icon support
+
+Cards now support brand icons from the simple-icons library.
+
+</Update>
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.show', [$namespace, $post]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="markdown-update"]')
+        ->assertSee('2024-10-11')
+        ->assertSee('v0.2.0')
+        ->assertSee('Feature')
+        ->assertSee('Improvement')
+        ->assertSee('Improved card icon support');
+});

--- a/tests/Feature/PostSeederTest.php
+++ b/tests/Feature/PostSeederTest.php
@@ -79,6 +79,9 @@ test('post seeder creates the mintlify syntax page', function () {
     expect($post->content)->toContain('# Tooltip');
     expect($post->content)->toContain('<Tooltip tip="Application Programming Interface: a set of protocols that lets software components communicate." headline="API" cta="Read more" href="/guides/index">API</Tooltip>');
     expect($post->content)->toContain('Simple tooltip: hover over <Tooltip tip="Hypertext Markup Language — the standard language for web pages.">HTML</Tooltip>.');
+    expect($post->content)->toContain('# Update');
+    expect($post->content)->toContain('<Update label="2024-10-11" description="v0.2.0" tags={["Feature", "Improvement"]}>');
+    expect($post->content)->toContain('## Improved card icon support');
     expect($post->content)->toContain('<ResponseField name="id" type="string" required>');
     expect($post->content)->toContain('<ParamField path="slug" type="string" required>');
     expect($post->content)->toContain('```javascript JavaScript icon="javascript"');


### PR DESCRIPTION
## Summary
- add Mintlify Update container support to the markdown preprocessing and directive pipeline
- render update entries with a dedicated timeline component and document them in the syntax guide seeder
- add node, browser, and feature regression coverage for Update examples
