### PR TITLE
Add markdown tree directive support

### DIFF
--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -634,9 +634,6 @@ GFM renderers (like GitHub) auto-generate IDs from heading text. Explicit IDs ar
 
 Without the plugin these render as literal text. You can always paste the emoji character directly instead: 🚀 ✅ ⚠️ 🎉
 
----
-
-> **WIP:** More examples coming soon.
 MD),
                 'published_at' => now(),
             ]);
@@ -919,7 +916,7 @@ MD),
             ['namespace_id' => $namespace->id, 'slug' => 'mintlify-syntax'],
             [
                 'user_id' => $user->id,
-                'title' => 'Mintlify Syntax (WIP)',
+                'title' => 'Mintlify Syntax',
                 'content' => trim(<<<'MD'
 # Mintlify Syntax
 
@@ -1427,6 +1424,56 @@ Source:
 Hover over <Tooltip tip="Application Programming Interface: a set of protocols that lets software components communicate." headline="API" cta="Read more" href="/guides/index">API</Tooltip> for a definition.
 
 Simple tooltip: hover over <Tooltip tip="Hypertext Markup Language — the standard language for web pages.">HTML</Tooltip>.
+```
+
+---
+
+# Tree
+
+`<Tree>` displays a file-system hierarchy with collapsible folders. Use `<Tree.Folder>` for directories and `<Tree.File>` for files. Add `defaultOpen` to a folder to expand it on load.
+
+Live example:
+
+<Tree>
+  <Tree.Folder name="app" defaultOpen>
+    <Tree.Folder name="components" defaultOpen>
+      <Tree.File name="Button.tsx" />
+      <Tree.File name="Card.tsx" />
+    </Tree.Folder>
+    <Tree.Folder name="pages">
+      <Tree.File name="index.tsx" />
+      <Tree.File name="about.tsx" />
+    </Tree.Folder>
+    <Tree.File name="layout.tsx" />
+  </Tree.Folder>
+  <Tree.Folder name="public">
+    <Tree.File name="favicon.ico" />
+  </Tree.Folder>
+  <Tree.File name="package.json" />
+  <Tree.File name="tsconfig.json" />
+</Tree>
+
+Source:
+
+```mdx
+<Tree>
+  <Tree.Folder name="app" defaultOpen>
+    <Tree.Folder name="components" defaultOpen>
+      <Tree.File name="Button.tsx" />
+      <Tree.File name="Card.tsx" />
+    </Tree.Folder>
+    <Tree.Folder name="pages">
+      <Tree.File name="index.tsx" />
+      <Tree.File name="about.tsx" />
+    </Tree.Folder>
+    <Tree.File name="layout.tsx" />
+  </Tree.Folder>
+  <Tree.Folder name="public">
+    <Tree.File name="favicon.ico" />
+  </Tree.Folder>
+  <Tree.File name="package.json" />
+  <Tree.File name="tsconfig.json" />
+</Tree>
 ```
 
 ---

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -11,34 +11,36 @@ import remarkGfm from 'remark-gfm';
 import remarkSupersub from 'remark-supersub';
 import { EmbedCard } from '@/components/embed-card';
 import {
-    MarkdownCard,
-    MarkdownCardGroup,
-} from '@/components/markdown-card-group';
-import {
     MarkdownParamField,
     MarkdownResponseField,
 } from '@/components/markdown-api-fields';
+import { MarkdownBadge } from '@/components/markdown-badge';
+import {
+    MarkdownCard,
+    MarkdownCardGroup,
+} from '@/components/markdown-card-group';
+import { MarkdownCodeGroup } from '@/components/markdown-code-group';
 import { MarkdownStep, MarkdownSteps } from '@/components/markdown-steps';
 import { MarkdownTab, MarkdownTabs } from '@/components/markdown-tabs';
+import { MarkdownTooltip } from '@/components/markdown-tooltip';
+import { MarkdownTree } from '@/components/markdown-tree';
+import { MarkdownUpdate } from '@/components/markdown-update';
 import {
     preprocessMarkdownContent,
     preprocessMarkdownSyntax,
 } from '@/lib/markdown-syntax';
-import { remarkCardDirective } from '@/lib/remark-card-directive';
 import { remarkApiFieldsDirective } from '@/lib/remark-api-fields-directive';
 import { remarkBadgeDirective } from '@/lib/remark-badge-directive';
+import { remarkCardDirective } from '@/lib/remark-card-directive';
 import { remarkCodeGroupDirective } from '@/lib/remark-code-group-directive';
-import { remarkTooltipDirective } from '@/lib/remark-tooltip-directive';
-import { remarkUpdateDirective } from '@/lib/remark-update-directive';
-import { MarkdownBadge } from '@/components/markdown-badge';
-import { MarkdownCodeGroup } from '@/components/markdown-code-group';
-import { MarkdownTooltip } from '@/components/markdown-tooltip';
-import { MarkdownUpdate } from '@/components/markdown-update';
-import { remarkStepsDirective } from '@/lib/remark-steps-directive';
 import { remarkCodeMeta } from '@/lib/remark-code-meta';
 import { remarkLinkifyToCard } from '@/lib/remark-linkify-to-card';
 import { remarkMark } from '@/lib/remark-mark';
+import { remarkStepsDirective } from '@/lib/remark-steps-directive';
 import { remarkTabsDirective } from '@/lib/remark-tabs-directive';
+import { remarkTooltipDirective } from '@/lib/remark-tooltip-directive';
+import { remarkTreeDirective } from '@/lib/remark-tree-directive';
+import { remarkUpdateDirective } from '@/lib/remark-update-directive';
 import { remarkZennDirective } from '@/lib/remark-zenn-directive';
 import { cn } from '@/lib/utils';
 
@@ -163,6 +165,7 @@ export default function MarkdownContent({
         badge?: (props: Record<string, unknown>) => React.ReactElement;
         tooltip?: (props: Record<string, unknown>) => React.ReactElement;
         update?: (props: Record<string, unknown>) => React.ReactElement;
+        tree?: (props: Record<string, unknown>) => React.ReactElement;
     } = {
         pre: ({ children }) => <>{children}</>,
         aside: MessageBox,
@@ -216,6 +219,9 @@ export default function MarkdownContent({
                 {...(props as Parameters<typeof MarkdownUpdate>[0])}
             />
         ),
+        tree: (props: Record<string, unknown>) => (
+            <MarkdownTree {...(props as Parameters<typeof MarkdownTree>[0])} />
+        ),
         dl: ({ node, ...props }) => {
             void node;
 
@@ -262,6 +268,7 @@ export default function MarkdownContent({
                 remarkBadgeDirective,
                 remarkTooltipDirective,
                 remarkUpdateDirective,
+                remarkTreeDirective,
                 remarkCodeGroupDirective,
                 remarkLinkifyToCard,
                 remarkSupersub,

--- a/resources/js/components/markdown-tree.tsx
+++ b/resources/js/components/markdown-tree.tsx
@@ -1,0 +1,99 @@
+import { ChevronRight, File, Folder, FolderOpen } from 'lucide-react';
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+
+type TreeNode = {
+    type: 'folder' | 'file';
+    name: string;
+    defaultOpen?: boolean;
+    openable?: boolean;
+    children?: TreeNode[];
+};
+
+function parseTree(json: string | undefined): TreeNode[] {
+    try {
+        return json ? (JSON.parse(json) as TreeNode[]) : [];
+    } catch {
+        return [];
+    }
+}
+
+function TreeNodeRow({ node, depth = 0 }: { node: TreeNode; depth?: number }) {
+    const [open, setOpen] = useState(node.defaultOpen ?? false);
+    const canToggle = node.openable !== false;
+    const indent = depth * 16 + 8;
+
+    if (node.type === 'file') {
+        return (
+            <div
+                className="flex items-center gap-2 py-0.5 pr-3 text-sm"
+                style={{ paddingLeft: `${indent + 20}px` }}
+            >
+                <File className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span className="font-mono text-xs text-foreground">
+                    {node.name}
+                </span>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <button
+                type="button"
+                onClick={() => canToggle && setOpen((o) => !o)}
+                className={cn(
+                    'flex w-full items-center gap-1.5 py-0.5 pr-3 text-left',
+                    canToggle
+                        ? 'cursor-pointer rounded-sm hover:bg-muted/50'
+                        : 'cursor-default',
+                )}
+                style={{ paddingLeft: `${indent}px` }}
+            >
+                <ChevronRight
+                    className={cn(
+                        'h-3 w-3 shrink-0 text-muted-foreground/60 transition-transform',
+                        open && 'rotate-90',
+                        !canToggle && 'invisible',
+                    )}
+                />
+                {open ? (
+                    <FolderOpen className="h-3.5 w-3.5 shrink-0 text-blue-500" />
+                ) : (
+                    <Folder className="h-3.5 w-3.5 shrink-0 text-blue-500" />
+                )}
+                <span className="font-mono text-xs font-medium text-foreground">
+                    {node.name}
+                </span>
+            </button>
+            {open &&
+                node.children?.map((child, i) => (
+                    <TreeNodeRow key={i} node={child} depth={depth + 1} />
+                ))}
+        </div>
+    );
+}
+
+interface MarkdownTreeProps {
+    'data-tree'?: string;
+    children?: React.ReactNode;
+}
+
+export function MarkdownTree({ 'data-tree': json }: MarkdownTreeProps) {
+    const nodes = parseTree(json);
+
+    if (nodes.length === 0) {
+        return null;
+    }
+
+    return (
+        <div
+            className="not-prose my-6 overflow-hidden rounded-lg border border-border bg-background py-2"
+            data-test="markdown-tree"
+        >
+            {nodes.map((node, i) => (
+                <TreeNodeRow key={i} node={node} />
+            ))}
+        </div>
+    );
+}

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -323,6 +323,7 @@ export function preprocessMintlifySyntax(markdown: string): string {
         | MintlifyCalloutTag
     > = [];
     const mintlifyTagLeadingSpaces: number[] = [];
+    let treeBuffer: string[] | null = null;
 
     const pushLine = (value: string): void => {
         processedLines.push(value);
@@ -376,6 +377,32 @@ export function preprocessMintlifySyntax(markdown: string): string {
 
         if (activeFence !== null) {
             processedLines.push(fenceContentLine);
+
+            continue;
+        }
+
+        if (treeBuffer !== null) {
+            if (trimmedLine === '</Tree>') {
+                const nodes = parseTreeContent(treeBuffer);
+                const json = JSON.stringify(nodes);
+
+                pushBlankLineIfNeeded();
+                pushLine(':::tree');
+                pushLine('```json');
+                pushLine(json);
+                pushLine('```');
+                pushLine('');
+                pushLine(':::');
+                treeBuffer = null;
+            } else {
+                treeBuffer.push(line);
+            }
+
+            continue;
+        }
+
+        if (trimmedLine === '<Tree>') {
+            treeBuffer = [];
 
             continue;
         }
@@ -847,6 +874,129 @@ function transformOutsideFences(
             return transformOutsideInlineCode(line, transform);
         })
         .join('\n');
+}
+
+interface TreeNode {
+    type: 'folder' | 'file';
+    name: string;
+    defaultOpen?: boolean;
+    openable?: boolean;
+    children?: TreeNode[];
+}
+
+function joinMultilineTreeTags(lines: string[]): string[] {
+    const result: string[] = [];
+    let index = 0;
+
+    while (index < lines.length) {
+        const line = lines[index];
+        const trimmed = line.trim();
+
+        if (
+            /^<Tree\.(Folder|File)(?:\s|$)/.test(trimmed) &&
+            !trimmed.includes('>')
+        ) {
+            let accumulated = trimmed;
+            index++;
+
+            while (index < lines.length) {
+                const nextTrimmed = lines[index].trim();
+                index++;
+                accumulated += ` ${nextTrimmed}`;
+
+                if (
+                    accumulated.trimEnd().endsWith('/>') ||
+                    accumulated.trimEnd().endsWith('>')
+                ) {
+                    break;
+                }
+            }
+
+            result.push(accumulated);
+
+            continue;
+        }
+
+        result.push(line);
+        index++;
+    }
+
+    return result;
+}
+
+function createTreeFolderNode(
+    attrs: Record<string, string | boolean>,
+): TreeNode {
+    const node: TreeNode = {
+        type: 'folder',
+        name: typeof attrs.name === 'string' ? attrs.name : '',
+        children: [],
+    };
+
+    if (attrs.defaultOpen === true) {
+        node.defaultOpen = true;
+    }
+
+    if (attrs.openable === false) {
+        node.openable = false;
+    }
+
+    return node;
+}
+
+function parseTreeContent(lines: string[]): TreeNode[] {
+    const root: TreeNode[] = [];
+    const stack: TreeNode[][] = [root];
+
+    for (const line of joinMultilineTreeTags(lines)) {
+        const trimmed = line.trim();
+
+        if (!trimmed) {
+            continue;
+        }
+
+        const folderSelfClose = /^<Tree\.Folder(?<attrs>[^>]*)\/\s*>$/.exec(
+            trimmed,
+        );
+
+        if (folderSelfClose) {
+            const attrs = parseJsxAttributes(
+                folderSelfClose.groups?.attrs ?? '',
+            );
+            stack.at(-1)!.push(createTreeFolderNode(attrs));
+            continue;
+        }
+
+        const folderOpen = /^<Tree\.Folder(?<attrs>[^>]*)>$/.exec(trimmed);
+
+        if (folderOpen) {
+            const attrs = parseJsxAttributes(folderOpen.groups?.attrs ?? '');
+            const node = createTreeFolderNode(attrs);
+
+            stack.at(-1)!.push(node);
+            stack.push(node.children!);
+            continue;
+        }
+
+        const fileNode = /^<Tree\.File(?<attrs>[^>]*)\/?\s*>$/.exec(trimmed);
+
+        if (fileNode) {
+            const attrs = parseJsxAttributes(fileNode.groups?.attrs ?? '');
+            stack.at(-1)!.push({
+                type: 'file',
+                name: typeof attrs.name === 'string' ? attrs.name : '',
+            });
+            continue;
+        }
+
+        if (trimmed === '</Tree.Folder>') {
+            if (stack.length > 1) {
+                stack.pop();
+            }
+        }
+    }
+
+    return root;
 }
 
 function escapeDirectiveLabel(label: string): string {

--- a/resources/js/lib/remark-tree-directive.ts
+++ b/resources/js/lib/remark-tree-directive.ts
@@ -1,0 +1,38 @@
+import type { Code, Root } from 'mdast';
+import type { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+interface ContainerDirectiveNode extends Node {
+    type: 'containerDirective';
+    name: string;
+    children: Node[];
+    data?: {
+        hName?: string;
+        hProperties?: Record<string, unknown>;
+    };
+}
+
+export function remarkTreeDirective() {
+    return (tree: Root) => {
+        visit(tree, (node: Node) => {
+            if (node.type !== 'containerDirective') {
+                return;
+            }
+
+            const directiveNode = node as ContainerDirectiveNode;
+
+            if (directiveNode.name !== 'tree') {
+                return;
+            }
+
+            const codeChild = directiveNode.children.find(
+                (c) => c.type === 'code',
+            ) as Code | undefined;
+            const json = codeChild?.value ?? '[]';
+
+            directiveNode.data = directiveNode.data || {};
+            directiveNode.data.hName = 'tree';
+            directiveNode.data.hProperties = { 'data-tree': json };
+        });
+    };
+}

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -304,6 +304,59 @@ x = 1
     assert.match(output, /```python Python/);
 });
 
+test('preprocessMarkdownSyntax converts Mintlify Tree to a tree directive with JSON payload', () => {
+    const output = preprocessMarkdownSyntax(`<Tree>
+  <Tree.Folder name="app" defaultOpen>
+    <Tree.Folder name="components" openable={false}>
+      <Tree.File name="Button.tsx" />
+    </Tree.Folder>
+    <Tree.File name="layout.tsx" />
+  </Tree.Folder>
+  <Tree.File name="package.json" />
+</Tree>`);
+
+    assert.match(output, /:::tree/);
+    assert.match(output, /```json/);
+    assert.match(output, /"type":"folder"/);
+    assert.match(output, /"name":"app"/);
+    assert.match(output, /"defaultOpen":true/);
+    assert.match(output, /"openable":false/);
+    assert.match(output, /"name":"Button\.tsx"/);
+    assert.match(output, /"name":"package\.json"/);
+    assert.match(output, /^:::\s*$/m);
+});
+
+test('preprocessMarkdownSyntax joins multiline Tree child tags before encoding JSON', () => {
+    const output = preprocessMarkdownSyntax(`<Tree>
+  <Tree.Folder
+    name="app"
+    defaultOpen
+  >
+    <Tree.File
+      name="index.tsx"
+    />
+  </Tree.Folder>
+</Tree>`);
+
+    assert.match(output, /"name":"app"/);
+    assert.match(output, /"defaultOpen":true/);
+    assert.match(output, /"name":"index\.tsx"/);
+});
+
+test('preprocessMarkdownSyntax leaves Tree tags untouched inside fenced code blocks', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`mdx
+<Tree>
+  <Tree.Folder name="app" defaultOpen>
+    <Tree.File name="index.tsx" />
+  </Tree.Folder>
+</Tree>
+\`\`\``);
+
+    assert.doesNotMatch(output, /:::tree/);
+    assert.match(output, /<Tree>/);
+    assert.match(output, /<Tree\.Folder name="app" defaultOpen>/);
+});
+
 test('preprocessMarkdownSyntax converts Mintlify Badge tags to text directives', () => {
     const output = preprocessMarkdownSyntax(
         'This feature requires a <Badge color="orange" size="sm">Premium</Badge> subscription.\n\n<Badge color="green" icon="circle-check">Stable</Badge>',

--- a/tests-node/markdown/remark-tree-directive.test.ts
+++ b/tests-node/markdown/remark-tree-directive.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { remarkTreeDirective } from '../../resources/js/lib/remark-tree-directive.ts';
+
+test('remarkTreeDirective maps tree container directives to renderable nodes', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'tree',
+                children: [
+                    {
+                        type: 'code',
+                        lang: 'json',
+                        value: '[{"type":"file","name":"package.json"}]',
+                    },
+                ],
+            },
+        ],
+    };
+
+    remarkTreeDirective()(tree as never);
+
+    const node = tree.children[0] as {
+        data?: { hName?: string; hProperties?: Record<string, unknown> };
+    };
+
+    assert.equal(node.data?.hName, 'tree');
+    assert.deepEqual(node.data?.hProperties, {
+        'data-tree': '[{"type":"file","name":"package.json"}]',
+    });
+});
+
+test('remarkTreeDirective falls back to an empty tree when code payload is missing', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'tree',
+                children: [{ type: 'paragraph', children: [] }],
+            },
+        ],
+    };
+
+    remarkTreeDirective()(tree as never);
+
+    const node = tree.children[0] as {
+        data?: { hProperties?: Record<string, unknown> };
+    };
+
+    assert.equal(node.data?.hProperties?.['data-tree'], '[]');
+});
+
+test('remarkTreeDirective ignores unrelated directives', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'update',
+                children: [],
+            },
+        ],
+    };
+
+    remarkTreeDirective()(tree as never);
+
+    assert.equal((tree.children[0] as { data?: unknown }).data, undefined);
+});

--- a/tests/Feature/PostSeederTest.php
+++ b/tests/Feature/PostSeederTest.php
@@ -59,7 +59,7 @@ test('post seeder creates the mintlify syntax page', function () {
         ->first();
 
     expect($post)->not->toBeNull();
-    expect($post->title)->toBe('Mintlify Syntax (WIP)');
+    expect($post->title)->toBe('Mintlify Syntax');
     expect($post->content)->toContain('# Mintlify Syntax');
     expect($post->content)->toContain('<Card title="Tabs" icon="folder" href="/guides/index">');
     expect($post->content)->toContain('<CardGroup cols={2}>');
@@ -82,6 +82,10 @@ test('post seeder creates the mintlify syntax page', function () {
     expect($post->content)->toContain('# Update');
     expect($post->content)->toContain('<Update label="2024-10-11" description="v0.2.0" tags={["Feature", "Improvement"]}>');
     expect($post->content)->toContain('## Improved card icon support');
+    expect($post->content)->toContain('# Tree');
+    expect($post->content)->toContain('<Tree>');
+    expect($post->content)->toContain('<Tree.Folder name="app" defaultOpen>');
+    expect($post->content)->toContain('<Tree.File name="package.json" />');
     expect($post->content)->toContain('<ResponseField name="id" type="string" required>');
     expect($post->content)->toContain('<ParamField path="slug" type="string" required>');
     expect($post->content)->toContain('```javascript JavaScript icon="javascript"');


### PR DESCRIPTION
## Summary
- add markdown tree rendering and remark tree directive support
- convert Mintlify `<Tree>` syntax into a JSON-backed tree directive, including multiline tree tags
- update markdown and seeder regression tests for the new tree content and renamed Mintlify guide

## Testing
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm run types:check
- vendor/bin/sail artisan test --compact tests/Feature/PostSeederTest.php