### PR TITLE
Extract nested path core

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -4,7 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Models\Post;
 use App\Models\PostNamespace;
-use Illuminate\Http\RedirectResponse;
+use App\Support\ReservedContentPath;
+use Illuminate\Support\Collection;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -14,49 +15,129 @@ class PostController extends Controller
     {
         return Inertia::render('posts/index', [
             'namespaces' => PostNamespace::published()
+                ->whereNull('parent_id')
                 ->withCount(['posts' => fn ($q) => $q->where('is_draft', false)])
                 ->orderBy('name')
-                ->get(['id', 'slug', 'name', 'description', 'cover_image']),
+                ->get(['id', 'slug', 'full_path', 'name', 'description', 'cover_image']),
         ]);
     }
 
-    public function namespace(PostNamespace $namespace): RedirectResponse
+    public function resolve(string $path): Response
     {
-        if (! $namespace->is_published) {
-            abort(404);
-        }
+        $normalizedPath = trim($path, '/');
 
-        $posts = $namespace->posts()
+        abort_if(ReservedContentPath::startsWithReservedSegment($normalizedPath), 404);
+
+        $post = Post::query()
+            ->with('namespace:id,parent_id,slug,full_path,name,cover_image,is_published')
+            ->where('full_path', $normalizedPath)
             ->where('is_draft', false)
-            ->orderBy('published_at')
-            ->orderBy('id')
-            ->get(['id', 'slug']);
+            ->first();
 
-        $firstPost = $namespace->sortPosts($posts)->first();
+        if ($post) {
+            $ancestors = $this->ancestorChain($post->namespace);
 
-        if (! $firstPost) {
-            abort(404);
+            abort_unless($this->namespaceChainIsPublished($post->namespace, $ancestors), 404);
+
+            return $this->renderPost($post, $ancestors);
         }
 
-        return redirect()->route('posts.show', [$namespace->slug, $firstPost->slug]);
+        $namespace = PostNamespace::query()
+            ->where('full_path', $normalizedPath)
+            ->where('is_published', true)
+            ->firstOrFail();
+
+        $ancestors = $this->ancestorChain($namespace);
+
+        abort_unless($this->namespaceChainIsPublished($namespace, $ancestors), 404);
+
+        return $this->renderNamespace($namespace, $ancestors);
     }
 
-    public function show(PostNamespace $namespace, Post $post): Response|RedirectResponse
+    /**
+     * @param  Collection<int, PostNamespace>  $ancestors
+     */
+    private function renderNamespace(PostNamespace $namespace, Collection $ancestors): Response
     {
-        if (! $namespace->is_published) {
-            abort(404);
-        }
+        $children = $namespace->children()
+            ->where('is_published', true)
+            ->withCount(['posts' => fn ($query) => $query->where('is_draft', false)])
+            ->get(['id', 'name', 'slug', 'full_path', 'description', 'cover_image']);
 
         $posts = $namespace->posts()
             ->where('is_draft', false)
             ->orderBy('published_at')
             ->orderBy('id')
-            ->get(['id', 'slug', 'title', 'published_at']);
+            ->get(['id', 'slug', 'full_path', 'title', 'published_at']);
 
-        return Inertia::render('posts/show', [
-            'namespace' => $namespace->only(['id', 'slug', 'name', 'cover_image_url']),
-            'post' => $post,
+        return Inertia::render('posts/namespace', [
+            'breadcrumbs' => $this->breadcrumbs($ancestors),
+            'children' => $namespace->sortNamespaces($children),
+            'namespace' => $namespace->only(['id', 'slug', 'full_path', 'name', 'description', 'cover_image_url']),
             'posts' => $namespace->sortPosts($posts),
         ]);
+    }
+
+    /**
+     * @param  Collection<int, PostNamespace>  $ancestors
+     */
+    private function renderPost(Post $post, Collection $ancestors): Response
+    {
+        $namespace = $post->namespace;
+        $posts = $namespace->posts()
+            ->where('is_draft', false)
+            ->orderBy('published_at')
+            ->orderBy('id')
+            ->get(['id', 'slug', 'full_path', 'title', 'published_at']);
+
+        return Inertia::render('posts/show', [
+            'breadcrumbs' => $this->breadcrumbs($ancestors),
+            'namespace' => $namespace->only(['id', 'slug', 'full_path', 'name', 'cover_image_url']),
+            'post' => $post->only(['id', 'slug', 'full_path', 'title', 'content', 'published_at']),
+            'posts' => $namespace->sortPosts($posts),
+        ]);
+    }
+
+    /**
+     * @return array<int, array{name: string, full_path: string}>
+     */
+    private function breadcrumbs(Collection $ancestors): array
+    {
+        return $ancestors
+            ->map(fn (PostNamespace $ancestor) => [
+                'name' => $ancestor->name,
+                'full_path' => $ancestor->full_path,
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return Collection<int, PostNamespace>
+     */
+    private function ancestorChain(PostNamespace $namespace): Collection
+    {
+        $ancestors = collect();
+        $currentParentId = $namespace->parent_id;
+
+        while ($currentParentId) {
+            $ancestor = PostNamespace::query()
+                ->select(['id', 'parent_id', 'name', 'full_path', 'is_published'])
+                ->findOrFail($currentParentId);
+
+            $ancestors->prepend($ancestor);
+            $currentParentId = $ancestor->parent_id;
+        }
+
+        return $ancestors;
+    }
+
+    /**
+     * @param  Collection<int, PostNamespace>  $ancestors
+     */
+    private function namespaceChainIsPublished(PostNamespace $namespace, Collection $ancestors): bool
+    {
+        return $namespace->is_published
+            && $ancestors->every(fn (PostNamespace $ancestor): bool => $ancestor->is_published);
     }
 }

--- a/app/Http/Requests/Admin/StoreNamespaceRequest.php
+++ b/app/Http/Requests/Admin/StoreNamespaceRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Admin;
 
+use App\Support\ReservedContentPath;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -15,6 +16,12 @@ class StoreNamespaceRequest extends FormRequest
 
     protected function prepareForValidation(): void
     {
+        if ($this->input('parent_id') === '') {
+            $this->merge([
+                'parent_id' => null,
+            ]);
+        }
+
         if ($this->has('is_published')) {
             $this->merge([
                 'is_published' => $this->boolean('is_published'),
@@ -28,7 +35,8 @@ class StoreNamespaceRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'slug' => ['required', 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/', Rule::notIn(['admin']), Rule::unique('namespaces', 'slug')],
+            'parent_id' => ['nullable', 'integer', Rule::exists('namespaces', 'id')],
+            'slug' => ['required', 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/', Rule::notIn(ReservedContentPath::rootSegments()), Rule::unique('namespaces', 'slug')],
             'name' => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
             'cover_image' => ['nullable', 'image', 'max:2048'],

--- a/app/Http/Requests/Admin/UpdateNamespaceRequest.php
+++ b/app/Http/Requests/Admin/UpdateNamespaceRequest.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Requests\Admin;
 
+use App\Models\PostNamespace;
+use App\Support\ReservedContentPath;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -15,6 +17,12 @@ class UpdateNamespaceRequest extends FormRequest
 
     protected function prepareForValidation(): void
     {
+        if ($this->input('parent_id') === '') {
+            $this->merge([
+                'parent_id' => null,
+            ]);
+        }
+
         if ($this->has('is_published')) {
             $this->merge([
                 'is_published' => $this->boolean('is_published'),
@@ -25,10 +33,44 @@ class UpdateNamespaceRequest extends FormRequest
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
      */
+    /**
+     * @return array<int, int>
+     */
+    private function descendantIds(int $namespaceId): array
+    {
+        $childIds = PostNamespace::query()
+            ->where('parent_id', $namespaceId)
+            ->pluck('id')
+            ->all();
+
+        $result = $childIds;
+
+        foreach ($childIds as $childId) {
+            $result = array_merge($result, $this->descendantIds($childId));
+        }
+
+        return $result;
+    }
+
     public function rules(): array
     {
         return [
-            'slug' => ['required', 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/', Rule::notIn(['admin']), Rule::unique('namespaces', 'slug')->ignore($this->route('namespace'))],
+            'parent_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('namespaces', 'id'),
+                Rule::notIn([$this->route('namespace')->getKey()]),
+                function (string $attribute, mixed $value, \Closure $fail): void {
+                    if ($value === null) {
+                        return;
+                    }
+
+                    if (in_array((int) $value, $this->descendantIds($this->route('namespace')->getKey()), true)) {
+                        $fail('The selected parent is a descendant of this namespace.');
+                    }
+                },
+            ],
+            'slug' => ['required', 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/', Rule::notIn(ReservedContentPath::rootSegments()), Rule::unique('namespaces', 'slug')->ignore($this->route('namespace'))],
             'name' => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
             'cover_image' => ['nullable', 'image', 'max:2048'],

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -16,6 +16,7 @@ class Post extends Model
         'namespace_id',
         'title',
         'slug',
+        'full_path',
         'content',
         'user_id',
         'is_draft',

--- a/app/Models/PostNamespace.php
+++ b/app/Models/PostNamespace.php
@@ -6,6 +6,7 @@ use Database\Factories\PostNamespaceFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
@@ -18,7 +19,9 @@ class PostNamespace extends Model
     protected $table = 'namespaces';
 
     protected $fillable = [
+        'parent_id',
         'slug',
+        'full_path',
         'name',
         'description',
         'cover_image',
@@ -67,13 +70,60 @@ class PostNamespace extends Model
         return 'slug';
     }
 
+    /**
+     * Sort child namespaces according to post_order, with unordered namespaces appended last.
+     *
+     * @param  Collection<int, PostNamespace>  $namespaces
+     * @return Collection<int, PostNamespace>
+     */
+    public function sortNamespaces(Collection $namespaces): Collection
+    {
+        $order = $this->post_order ?? [];
+
+        if (empty($order)) {
+            return $namespaces->sortBy('full_path')->values();
+        }
+
+        return $namespaces->sortBy(function (PostNamespace $namespace) use ($order): int {
+            $index = array_search($namespace->slug, $order);
+
+            return $index !== false ? $index : PHP_INT_MAX;
+        })->values();
+    }
+
     public function scopePublished(Builder $query): void
     {
         $query->where('is_published', true);
     }
 
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
+
     public function posts(): HasMany
     {
         return $this->hasMany(Post::class, 'namespace_id');
+    }
+
+    /**
+     * @return Collection<int, PostNamespace>
+     */
+    public function ancestors(): Collection
+    {
+        $ancestors = collect();
+        $currentParent = $this->parent;
+
+        while ($currentParent) {
+            $ancestors->prepend($currentParent);
+            $currentParent = $currentParent->parent;
+        }
+
+        return $ancestors;
     }
 }

--- a/app/Observers/PostNamespaceObserver.php
+++ b/app/Observers/PostNamespaceObserver.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\PostNamespace;
+use App\Services\ContentPathService;
+
+class PostNamespaceObserver
+{
+    public function __construct(
+        private readonly ContentPathService $contentPathService,
+    ) {}
+
+    public function saving(PostNamespace $postNamespace): void
+    {
+        $postNamespace->full_path = $this->contentPathService->buildNamespacePath($postNamespace);
+    }
+
+    public function saved(PostNamespace $postNamespace): void
+    {
+        if ($postNamespace->wasRecentlyCreated || $postNamespace->wasChanged(['slug', 'parent_id', 'full_path'])) {
+            $this->contentPathService->syncNamespaceSubtree($postNamespace);
+        }
+    }
+}

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Post;
+use App\Services\ContentPathService;
+
+class PostObserver
+{
+    public function __construct(
+        private readonly ContentPathService $contentPathService,
+    ) {}
+
+    public function saving(Post $post): void
+    {
+        $post->full_path = $this->contentPathService->buildPostPath($post);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Models\Post;
+use App\Models\PostNamespace;
+use App\Observers\PostNamespaceObserver;
+use App\Observers\PostObserver;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
@@ -24,6 +28,9 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->configureDefaults();
+
+        Post::observe(PostObserver::class);
+        PostNamespace::observe(PostNamespaceObserver::class);
     }
 
     /**

--- a/app/Services/ContentPathService.php
+++ b/app/Services/ContentPathService.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+
+class ContentPathService
+{
+    public function buildNamespacePath(PostNamespace $namespace): string
+    {
+        $parentPath = null;
+
+        if ($namespace->parent_id) {
+            $parentPath = $namespace->relationLoaded('parent')
+                ? $namespace->parent?->full_path
+                : PostNamespace::query()->whereKey($namespace->parent_id)->value('full_path');
+        }
+
+        return trim(implode('/', array_filter([$parentPath, $namespace->slug])), '/');
+    }
+
+    public function buildPostPath(Post $post): string
+    {
+        $namespacePath = $post->relationLoaded('namespace')
+            ? $post->namespace?->full_path
+            : PostNamespace::query()->whereKey($post->namespace_id)->value('full_path');
+
+        return trim(implode('/', array_filter([$namespacePath, $post->slug])), '/');
+    }
+
+    public function syncNamespaceSubtree(PostNamespace $namespace): void
+    {
+        $namespacePaths = [$namespace->id => $namespace->full_path];
+        $currentNamespaceIds = [$namespace->id];
+
+        while ($currentNamespaceIds !== []) {
+            $this->syncPostsForNamespaceIds($currentNamespaceIds, $namespacePaths);
+
+            $children = PostNamespace::query()
+                ->whereIn('parent_id', $currentNamespaceIds)
+                ->orderBy('parent_id')
+                ->orderBy('id')
+                ->get(['id', 'parent_id', 'slug', 'full_path']);
+
+            $nextNamespaceIds = [];
+
+            foreach ($children as $child) {
+                $fullPath = trim(implode('/', array_filter([
+                    $namespacePaths[$child->parent_id] ?? null,
+                    $child->slug,
+                ])), '/');
+
+                if ($child->full_path !== $fullPath) {
+                    $child->forceFill([
+                        'full_path' => $fullPath,
+                    ])->saveQuietly();
+                }
+
+                $namespacePaths[$child->id] = $fullPath;
+                $nextNamespaceIds[] = $child->id;
+            }
+
+            $currentNamespaceIds = $nextNamespaceIds;
+        }
+    }
+
+    /**
+     * @param  array<int, int>  $namespaceIds
+     * @param  array<int, string|null>  $namespacePaths
+     */
+    private function syncPostsForNamespaceIds(array $namespaceIds, array $namespacePaths): void
+    {
+        Post::query()
+            ->whereIn('namespace_id', $namespaceIds)
+            ->orderBy('namespace_id')
+            ->orderBy('id')
+            ->get(['id', 'namespace_id', 'slug', 'full_path'])
+            ->each(function (Post $post) use ($namespacePaths): void {
+                $fullPath = trim(implode('/', array_filter([
+                    $namespacePaths[$post->namespace_id] ?? null,
+                    $post->slug,
+                ])), '/');
+
+                if ($post->full_path !== $fullPath) {
+                    $post->forceFill([
+                        'full_path' => $fullPath,
+                    ])->saveQuietly();
+                }
+            });
+    }
+}

--- a/app/Support/ReservedContentPath.php
+++ b/app/Support/ReservedContentPath.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Support;
+
+class ReservedContentPath
+{
+    public const ROOT_SEGMENTS = [
+        'admin',
+        'api',
+        'login',
+        'register',
+    ];
+
+    /**
+     * @return array<int, string>
+     */
+    public static function rootSegments(): array
+    {
+        /** @var array<int, string> $segments */
+        $segments = config('content.reserved_root_segments', self::ROOT_SEGMENTS);
+
+        return $segments;
+    }
+
+    public static function wildcardConstraint(): string
+    {
+        $segments = implode('|', array_map(
+            static fn (string $segment): string => preg_quote($segment, '/'),
+            self::rootSegments(),
+        ));
+
+        return "^(?!(?:{$segments})(?:/|$)).+";
+    }
+
+    public static function startsWithReservedSegment(string $path): bool
+    {
+        $normalizedPath = trim($path, '/');
+
+        if ($normalizedPath === '') {
+            return false;
+        }
+
+        $rootSegment = explode('/', $normalizedPath)[0];
+
+        return in_array($rootSegment, self::rootSegments(), true);
+    }
+}

--- a/config/content.php
+++ b/config/content.php
@@ -1,0 +1,7 @@
+<?php
+
+use App\Support\ReservedContentPath;
+
+return [
+    'reserved_root_segments' => ReservedContentPath::ROOT_SEGMENTS,
+];

--- a/database/migrations/2026_04_17_091309_add_nested_paths_to_namespaces_and_posts_tables.php
+++ b/database/migrations/2026_04_17_091309_add_nested_paths_to_namespaces_and_posts_tables.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('namespaces', function (Blueprint $table) {
+            $table->foreignId('parent_id')
+                ->nullable()
+                ->after('id')
+                ->constrained('namespaces')
+                ->cascadeOnDelete();
+            $table->string('full_path')->nullable()->after('slug')->unique();
+            $table->index('parent_id');
+        });
+
+        DB::table('namespaces')
+            ->orderBy('id')
+            ->get(['id', 'slug'])
+            ->each(function (object $namespace): void {
+                DB::table('namespaces')
+                    ->where('id', $namespace->id)
+                    ->update(['full_path' => $namespace->slug]);
+            });
+
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('full_path')->nullable()->after('slug')->unique();
+        });
+
+        DB::table('posts')
+            ->orderBy('id')
+            ->get(['id', 'namespace_id', 'slug'])
+            ->each(function (object $post): void {
+                $namespacePath = DB::table('namespaces')
+                    ->where('id', $post->namespace_id)
+                    ->value('full_path');
+
+                DB::table('posts')
+                    ->where('id', $post->id)
+                    ->update([
+                        'full_path' => trim(implode('/', array_filter([$namespacePath, $post->slug])), '/'),
+                    ]);
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropUnique('posts_full_path_unique');
+            $table->dropColumn('full_path');
+        });
+
+        Schema::table('namespaces', function (Blueprint $table) {
+            $table->dropUnique('namespaces_full_path_unique');
+            $table->dropForeign(['parent_id']);
+            $table->dropIndex('namespaces_parent_id_index');
+            $table->dropColumn(['parent_id', 'full_path']);
+        });
+    }
+};

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -1522,5 +1522,49 @@ Initial launch of Thinkstream with support for Markdown, GFM, Zenn syntax, and c
 MD),
                 'published_at' => now(),
             ]);
+
+        $apiaryNamespace = PostNamespace::updateOrCreate(
+            ['slug' => 'apiary'],
+            [
+                'name' => 'Apiary',
+                'description' => 'Reserved-path lookalike content used to verify wildcard routing still accepts non-reserved slugs.',
+            ],
+        );
+
+        Post::updateOrCreate(
+            ['namespace_id' => $apiaryNamespace->id, 'slug' => 'routing-check'],
+            [
+                'user_id' => $user->id,
+                'title' => 'APIary Routing Check',
+                'content' => trim(<<<'MD'
+# APIary Routing Check
+
+This namespace exists so `/apiary` proves the content wildcard still resolves lookalike slugs while `/api/*` stays reserved.
+MD),
+                'published_at' => now(),
+            ],
+        );
+
+        $administratorNamespace = PostNamespace::updateOrCreate(
+            ['slug' => 'administrator'],
+            [
+                'name' => 'Administrator Notes',
+                'description' => 'Reserved-path lookalike content used to verify wildcard routing still accepts non-reserved admin-like slugs.',
+            ],
+        );
+
+        Post::updateOrCreate(
+            ['namespace_id' => $administratorNamespace->id, 'slug' => 'routing-check'],
+            [
+                'user_id' => $user->id,
+                'title' => 'Administrator Routing Check',
+                'content' => trim(<<<'MD'
+# Administrator Routing Check
+
+This namespace exists so `/administrator` proves the content wildcard still resolves lookalike slugs while `/admin/*` stays reserved.
+MD),
+                'published_at' => now(),
+            ],
+        );
     }
 }

--- a/resources/js/pages/posts/index.tsx
+++ b/resources/js/pages/posts/index.tsx
@@ -2,11 +2,12 @@ import { Head, Link, usePage } from '@inertiajs/react';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import { login } from '@/routes';
 import { index as adminPosts } from '@/routes/admin/posts';
-import { namespace as namespaceRoute } from '@/routes/posts';
+import { path as contentPath } from '@/routes/posts';
 
 type PostNamespace = {
     id: number;
     slug: string;
+    full_path: string;
     name: string;
     description: string | null;
     cover_image_url: string | null;
@@ -54,7 +55,7 @@ export default function Index({ namespaces }: { namespaces: PostNamespace[] }) {
                             {namespaces.map((ns) => (
                                 <Link
                                     key={ns.id}
-                                    href={namespaceRoute.url(ns.slug)}
+                                    href={contentPath.url(ns.full_path)}
                                     className="group overflow-hidden rounded-xl border transition-colors hover:bg-muted/50"
                                 >
                                     <div className="relative aspect-video overflow-hidden border-b">
@@ -78,6 +79,9 @@ export default function Index({ namespaces }: { namespaces: PostNamespace[] }) {
                                             </span>
                                         )}
                                         <span className="mt-2 text-xs text-muted-foreground">
+                                            /{ns.full_path}
+                                        </span>
+                                        <span className="text-xs text-muted-foreground">
                                             {ns.posts_count}{' '}
                                             {ns.posts_count === 1
                                                 ? 'post'

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -1,43 +1,45 @@
 import { Head, Link, usePage } from '@inertiajs/react';
-import { PanelRightClose, PanelRightOpen } from 'lucide-react';
-import { useState } from 'react';
-import MarkdownContent from '@/components/markdown-content';
-import TableOfContents from '@/components/table-of-contents';
-import { useMarkdownToc } from '@/hooks/use-markdown-toc';
-import { useIsMobile } from '@/hooks/use-mobile';
+import { ChevronRight } from 'lucide-react';
+import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import { login } from '@/routes';
 import { index as adminPosts } from '@/routes/admin/posts';
-import { show as showRoute } from '@/routes/posts';
+import { path as contentPath } from '@/routes/posts';
 
 type PostNamespace = {
     id: number;
     slug: string;
+    full_path: string;
     name: string;
+    description?: string | null;
     cover_image_url: string | null;
+};
+
+type ChildNamespace = PostNamespace & {
+    posts_count: number;
 };
 
 type Post = {
     id: number;
     slug: string;
     title: string;
-    content: string;
-    published_at: string;
+    full_path: string;
+    published_at: string | null;
 };
 
 export default function Namespace({
+    breadcrumbs,
+    children,
     namespace,
     posts,
 }: {
+    breadcrumbs: Array<{ name: string; full_path: string }>;
+    children: ChildNamespace[];
     namespace: PostNamespace;
     posts: Post[];
 }) {
     const { auth } = usePage<{
         auth: { user: { id: number; name: string } | null };
     }>().props;
-    const toc = useMarkdownToc(posts);
-    const isMobile = useIsMobile();
-    const [tocOverride, setTocOverride] = useState<boolean | null>(null);
-    const tocVisible = tocOverride ?? !isMobile;
 
     return (
         <>
@@ -54,37 +56,40 @@ export default function Namespace({
                     </div>
                 )}
                 <header className="sticky top-0 z-50 border-b bg-background">
-                    <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-6">
-                        <div className="flex items-baseline gap-2">
+                    <div className="mx-auto flex max-w-7xl items-center justify-between gap-6 px-4 py-6">
+                        <div className="space-y-2">
                             <Link
                                 href="/"
                                 className="text-2xl font-bold hover:underline"
                             >
                                 ThinkStream
                             </Link>
-                            <span className="text-muted-foreground">/</span>
-                            <span className="text-lg font-semibold">
-                                {namespace.name}
-                            </span>
+                            <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                                {breadcrumbs.map((breadcrumb) => (
+                                    <div
+                                        key={breadcrumb.full_path}
+                                        className="flex items-center gap-2"
+                                    >
+                                        <ChevronRight className="size-4" />
+                                        <Link
+                                            href={contentPath.url(
+                                                breadcrumb.full_path,
+                                            )}
+                                            className="hover:text-foreground hover:underline"
+                                        >
+                                            {breadcrumb.name}
+                                        </Link>
+                                    </div>
+                                ))}
+                                <div className="flex items-center gap-2">
+                                    <ChevronRight className="size-4" />
+                                    <span className="font-medium text-foreground">
+                                        {namespace.name}
+                                    </span>
+                                </div>
+                            </div>
                         </div>
                         <div className="flex items-center gap-4">
-                            {posts.length > 0 && (
-                                <button
-                                    onClick={() =>
-                                        setTocOverride(
-                                            (prev) => !(prev ?? !isMobile),
-                                        )
-                                    }
-                                    className="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
-                                >
-                                    {tocVisible ? (
-                                        <PanelRightClose size={16} />
-                                    ) : (
-                                        <PanelRightOpen size={16} />
-                                    )}
-                                    Toggle TOC
-                                </button>
-                            )}
                             {auth.user ? (
                                 <Link
                                     href={adminPosts.url()}
@@ -104,88 +109,121 @@ export default function Namespace({
                     </div>
                 </header>
 
-                <div
-                    className={`mx-auto max-w-7xl px-4 py-10 lg:grid lg:gap-12 ${tocVisible && posts.length > 0 ? 'lg:grid-cols-[1fr_240px]' : ''}`}
-                >
-                    {tocVisible && posts.length > 0 && (
-                        <div className="mb-8 block lg:hidden">
-                            <TableOfContents
-                                posts={posts.map((post) => ({
-                                    id: post.id,
-                                    title: post.title,
-                                    slug: post.slug,
-                                    headings: toc.get(post.slug)!.headings,
-                                }))}
-                            />
-                        </div>
-                    )}
-
-                    <main className="min-w-0">
-                        {posts.length === 0 ? (
-                            <p className="text-muted-foreground">
-                                No posts in this namespace yet.
+                <div className="mx-auto max-w-7xl px-4 py-10">
+                    <main className="space-y-12">
+                        <section className="space-y-3">
+                            <p className="text-sm text-muted-foreground">
+                                /{namespace.full_path}
                             </p>
-                        ) : (
-                            <div className="space-y-16">
-                                {posts.map((post) => (
-                                    <article
-                                        key={post.id}
-                                        id={`post-${post.slug}`}
-                                        className="scroll-mt-6 space-y-4"
-                                    >
-                                        <header className="space-y-1">
-                                            <h2 className="text-2xl font-bold">
-                                                <Link
-                                                    href={showRoute.url({
-                                                        namespace:
-                                                            namespace.slug,
-                                                        post: post.slug,
-                                                    })}
-                                                    className="hover:underline"
-                                                >
-                                                    {post.title}
-                                                </Link>
-                                            </h2>
-                                            <time
-                                                dateTime={post.published_at}
-                                                className="text-sm text-muted-foreground"
-                                            >
-                                                {new Date(
-                                                    post.published_at,
-                                                ).toLocaleDateString('en-US', {
-                                                    year: 'numeric',
-                                                    month: 'long',
-                                                    day: 'numeric',
-                                                })}
-                                            </time>
-                                        </header>
-                                        <div className="prose max-w-none prose-neutral dark:prose-invert">
-                                            <MarkdownContent
-                                                content={post.content}
-                                                components={
-                                                    toc.get(post.slug)!
-                                                        .components
-                                                }
-                                            />
-                                        </div>
-                                    </article>
-                                ))}
-                            </div>
-                        )}
-                    </main>
+                            {namespace.description && (
+                                <p className="max-w-3xl text-base leading-7 text-muted-foreground">
+                                    {namespace.description}
+                                </p>
+                            )}
+                        </section>
 
-                    {tocVisible && posts.length > 0 && (
-                        <aside className="hidden lg:block">
-                            <TableOfContents
-                                posts={posts.map((post) => ({
-                                    id: post.id,
-                                    title: post.title,
-                                    slug: post.slug,
-                                    headings: toc.get(post.slug)!.headings,
-                                }))}
-                            />
-                        </aside>
-                    )}
+                        {children.length > 0 && (
+                            <section className="space-y-4">
+                                <div>
+                                    <h2 className="text-xl font-semibold">
+                                        Child Namespaces
+                                    </h2>
+                                    <p className="text-sm text-muted-foreground">
+                                        Browse deeper sections in this branch.
+                                    </p>
+                                </div>
+                                <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+                                    {children.map((child) => (
+                                        <Link
+                                            key={child.id}
+                                            href={contentPath.url(
+                                                child.full_path,
+                                            )}
+                                            className="group overflow-hidden rounded-xl border transition-colors hover:bg-muted/50"
+                                        >
+                                            <div className="relative aspect-video overflow-hidden border-b">
+                                                {child.cover_image_url ? (
+                                                    <img
+                                                        src={
+                                                            child.cover_image_url
+                                                        }
+                                                        alt={child.name}
+                                                        className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                                                    />
+                                                ) : (
+                                                    <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
+                                                )}
+                                            </div>
+                                            <div className="space-y-2 p-5">
+                                                <p className="font-semibold">
+                                                    {child.name}
+                                                </p>
+                                                {child.description && (
+                                                    <p className="line-clamp-2 text-sm text-muted-foreground">
+                                                        {child.description}
+                                                    </p>
+                                                )}
+                                                <p className="text-xs text-muted-foreground">
+                                                    /{child.full_path}
+                                                </p>
+                                                <p className="text-xs text-muted-foreground">
+                                                    {child.posts_count} direct{' '}
+                                                    {child.posts_count === 1
+                                                        ? 'post'
+                                                        : 'posts'}
+                                                </p>
+                                            </div>
+                                        </Link>
+                                    ))}
+                                </div>
+                            </section>
+                        )}
+
+                        <section className="space-y-4">
+                            <div>
+                                <h2 className="text-xl font-semibold">Posts</h2>
+                                <p className="text-sm text-muted-foreground">
+                                    Direct posts published in this namespace.
+                                </p>
+                            </div>
+
+                            {posts.length === 0 ? (
+                                <p className="text-muted-foreground">
+                                    No direct posts in this namespace yet.
+                                </p>
+                            ) : (
+                                <div className="rounded-xl border">
+                                    <div className="divide-y">
+                                        {posts.map((post) => (
+                                            <Link
+                                                key={post.id}
+                                                href={contentPath.url(
+                                                    post.full_path,
+                                                )}
+                                                className="flex items-center justify-between gap-4 px-5 py-4 transition-colors hover:bg-muted/50"
+                                            >
+                                                <div className="space-y-1">
+                                                    <p className="font-medium">
+                                                        {post.title}
+                                                    </p>
+                                                    <p className="text-xs text-muted-foreground">
+                                                        /{post.full_path}
+                                                    </p>
+                                                </div>
+                                                <div className="shrink-0 text-sm text-muted-foreground">
+                                                    {post.published_at
+                                                        ? new Date(
+                                                              post.published_at,
+                                                          ).toLocaleDateString()
+                                                        : 'Draft'}
+                                                </div>
+                                            </Link>
+                                        ))}
+                                    </div>
+                                </div>
+                            )}
+                        </section>
+                    </main>
                 </div>
             </div>
         </>

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -1,6 +1,6 @@
-import { Head, Link } from '@inertiajs/react';
-import { usePage } from '@inertiajs/react';
+import { Head, Link, usePage } from '@inertiajs/react';
 import {
+    ChevronRight,
     PanelLeftClose,
     PanelLeftOpen,
     PanelRightClose,
@@ -13,11 +13,12 @@ import { useMarkdownToc } from '@/hooks/use-markdown-toc';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { login } from '@/routes';
 import { index as adminPosts } from '@/routes/admin/posts';
-import { namespace as namespaceRoute, show as showRoute } from '@/routes/posts';
+import { path as contentPath } from '@/routes/posts';
 
 type PostNamespace = {
     id: number;
     slug: string;
+    full_path: string;
     name: string;
     cover_image_url: string | null;
 };
@@ -25,6 +26,7 @@ type PostNamespace = {
 type Post = {
     id: number;
     slug: string;
+    full_path: string;
     title: string;
     content: string;
     published_at: string;
@@ -33,15 +35,18 @@ type Post = {
 type NavPost = {
     id: number;
     slug: string;
+    full_path: string;
     title: string;
     published_at: string;
 };
 
 export default function Show({
+    breadcrumbs,
     namespace,
     post,
     posts,
 }: {
+    breadcrumbs: Array<{ name: string; full_path: string }>;
     namespace: PostNamespace;
     post: Post;
     posts: NavPost[];
@@ -89,22 +94,38 @@ export default function Show({
                 )}
                 <header className="sticky top-0 z-50 border-b bg-background">
                     <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-6">
-                        <div className="flex items-baseline gap-2">
+                        <div className="flex flex-wrap items-center gap-2">
                             <Link
                                 href="/"
                                 className="text-2xl font-bold hover:underline"
                             >
                                 ThinkStream
                             </Link>
-                            <span className="text-muted-foreground">/</span>
-                            <Link
-                                href={namespaceRoute.url({
-                                    namespace: namespace.slug,
-                                })}
-                                className="text-sm text-muted-foreground hover:underline"
-                            >
-                                {namespace.slug}
-                            </Link>
+                            {breadcrumbs.map((breadcrumb) => (
+                                <div
+                                    key={breadcrumb.full_path}
+                                    className="flex items-center gap-2 text-sm text-muted-foreground"
+                                >
+                                    <ChevronRight className="size-4" />
+                                    <Link
+                                        href={contentPath.url(
+                                            breadcrumb.full_path,
+                                        )}
+                                        className="hover:text-foreground hover:underline"
+                                    >
+                                        {breadcrumb.name}
+                                    </Link>
+                                </div>
+                            ))}
+                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                <ChevronRight className="size-4" />
+                                <Link
+                                    href={contentPath.url(namespace.full_path)}
+                                    className="hover:text-foreground hover:underline"
+                                >
+                                    {namespace.name}
+                                </Link>
+                            </div>
                         </div>
                         <div className="flex items-center gap-4">
                             {hasHeadings && (
@@ -159,10 +180,9 @@ export default function Show({
                                         {posts.map((p) => (
                                             <Link
                                                 key={p.id}
-                                                href={showRoute.url({
-                                                    namespace: namespace.slug,
-                                                    post: p.slug,
-                                                })}
+                                                href={contentPath.url(
+                                                    p.full_path,
+                                                )}
                                                 className={`block rounded px-2 py-1.5 leading-snug transition-colors ${
                                                     p.slug === post.slug
                                                         ? 'bg-accent font-medium text-accent-foreground'

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\OgpController;
 use App\Http\Controllers\PostController;
+use App\Support\ReservedContentPath;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', [PostController::class, 'index'])->name('home');
@@ -17,6 +18,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 require __DIR__.'/settings.php';
 require __DIR__.'/admin.php';
 
-// Wildcard routes — registered last to avoid conflicting with more specific routes
-Route::get('/{namespace:slug}', [PostController::class, 'namespace'])->name('posts.namespace');
-Route::get('/{namespace:slug}/{post:slug}', [PostController::class, 'show'])->name('posts.show')->scopeBindings();
+// Wildcard routes must remain last so admin, auth, and API endpoints take precedence.
+Route::get('/{path}', [PostController::class, 'resolve'])
+    ->where('path', ReservedContentPath::wildcardConstraint())
+    ->name('posts.path');

--- a/tests/Browser/CodeBlockHighlightingTest.php
+++ b/tests/Browser/CodeBlockHighlightingTest.php
@@ -23,7 +23,7 @@ function add(int $a, int $b): int
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page
         ->assertNoJavaScriptErrors()

--- a/tests/Browser/MintlifyTabsRenderingTest.php
+++ b/tests/Browser/MintlifyTabsRenderingTest.php
@@ -27,7 +27,7 @@ test('mintlify-style tabs render as interactive tab controls', function () {
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page
         ->assertNoJavaScriptErrors()
@@ -55,7 +55,7 @@ test('mintlify-style tabs inside fenced code blocks stay as literal code', funct
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page
         ->assertNoJavaScriptErrors()
@@ -92,7 +92,7 @@ test('mintlify-style callouts render as typed message boxes', function () {
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page
         ->assertNoJavaScriptErrors()
@@ -124,7 +124,7 @@ test('mintlify-style Columns renders as a card group grid', function () {
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page
         ->assertNoJavaScriptErrors()
@@ -157,7 +157,7 @@ echo 'Hello from PHP';
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page
         ->assertNoJavaScriptErrors()
@@ -185,7 +185,7 @@ This feature requires a <Badge color="orange" size="sm">Premium</Badge> subscrip
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page
         ->assertNoJavaScriptErrors()
@@ -210,7 +210,7 @@ Simple tooltip: hover over <Tooltip tip="Hypertext Markup Language">HTML</Toolti
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page
         ->assertNoJavaScriptErrors()
@@ -236,7 +236,7 @@ Cards now support brand icons from the simple-icons library.
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page
         ->assertNoJavaScriptErrors()

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -62,7 +62,7 @@ test('post navigation toggle stays within the viewport after page scroll', funct
         'title' => 'Advanced',
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $currentPost]))->resize(1440, 1200);
+    $page = visit(route('posts.path', ['path' => $currentPost->full_path]))->resize(1440, 1200);
 
     $page
         ->assertVisible('[data-test="posts-nav-close"]')

--- a/tests/Browser/ZennMarkdownRenderingTest.php
+++ b/tests/Browser/ZennMarkdownRenderingTest.php
@@ -45,7 +45,7 @@ test('zenn-style markdown image metadata renders width and caption', function ()
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page
         ->assertNoJavaScriptErrors()
@@ -66,7 +66,7 @@ MARKDOWN,
 
     fakeOgpMetadata();
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page
         ->assertNoJavaScriptErrors()
@@ -85,7 +85,7 @@ MARKDOWN,
 
     fakeOgpMetadata();
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page
         ->assertNoJavaScriptErrors()
@@ -104,7 +104,7 @@ Hidden content
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page
         ->assertNoJavaScriptErrors()
@@ -122,7 +122,7 @@ https://www.youtube.com/watch?v=WRVsOCh907o
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page->assertNoJavaScriptErrors()
         ->assertPresent('[data-test="embed-card-youtube"]')
@@ -139,7 +139,7 @@ https://github.com/zenn-dev/zenn-editor/blob/canary/lerna.json
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page->assertNoJavaScriptErrors()
         ->assertPresent('[data-test="embed-github"]');
@@ -155,7 +155,7 @@ test('@[github](URL) directive renders as github embed', function () {
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.show', [$namespace, $post]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page->assertNoJavaScriptErrors()
         ->assertPresent('[data-test="embed-github"]');

--- a/tests/Feature/Admin/NamespaceControllerTest.php
+++ b/tests/Feature/Admin/NamespaceControllerTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\PostNamespace;
 use App\Models\User;
+use App\Support\ReservedContentPath;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
@@ -36,22 +37,58 @@ test('authenticated users can store a namespace', function () {
     ]);
 });
 
-test('storing a namespace rejects reserved slugs', function () {
+test('storing a namespace accepts a valid parent namespace', function () {
+    $user = User::factory()->create();
+    $parent = PostNamespace::factory()->create(['slug' => 'parent']);
+
+    $this->actingAs($user)
+        ->post(route('admin.namespaces.store'), [
+            'parent_id' => $parent->id,
+            'slug' => 'child',
+            'name' => 'Child',
+        ])
+        ->assertRedirect(route('admin.posts.index'));
+
+    $this->assertDatabaseHas('namespaces', [
+        'slug' => 'child',
+        'parent_id' => $parent->id,
+    ]);
+});
+
+test('storing a namespace rejects an unknown parent namespace', function () {
     $user = User::factory()->create();
 
     $this->actingAs($user)
-        ->post(route('admin.namespaces.store'), ['slug' => 'admin', 'name' => 'Admin'])
-        ->assertSessionHasErrors('slug');
+        ->post(route('admin.namespaces.store'), [
+            'parent_id' => 999999,
+            'slug' => 'child',
+            'name' => 'Child',
+        ])
+        ->assertSessionHasErrors('parent_id');
 });
 
-test('updating a namespace rejects reserved slugs', function () {
+test('storing a namespace rejects reserved slugs', function (string $slug) {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('admin.namespaces.store'), ['slug' => $slug, 'name' => ucfirst($slug)])
+        ->assertSessionHasErrors('slug');
+})->with(fn (): array => array_combine(
+    ReservedContentPath::ROOT_SEGMENTS,
+    ReservedContentPath::ROOT_SEGMENTS,
+));
+
+test('updating a namespace rejects reserved slugs', function (string $slug) {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create(['slug' => 'guides']);
 
     $this->actingAs($user)
-        ->put(route('admin.namespaces.update', $namespace), ['slug' => 'admin', 'name' => 'Admin'])
+        ->put(route('admin.namespaces.update', $namespace), ['slug' => $slug, 'name' => ucfirst($slug)])
         ->assertSessionHasErrors('slug');
-});
+})->with(fn (): array => array_combine(
+    ReservedContentPath::ROOT_SEGMENTS,
+    ReservedContentPath::ROOT_SEGMENTS,
+));
 
 test('storing a namespace requires a unique slug', function () {
     $user = User::factory()->create();
@@ -118,6 +155,50 @@ test('updating a namespace allows keeping the same slug', function () {
         ->assertRedirect(route('admin.posts.index'));
 
     expect($namespace->fresh()->slug)->toBe('my-ns');
+});
+
+test('updating a namespace accepts a valid parent namespace', function () {
+    $user = User::factory()->create();
+    $parent = PostNamespace::factory()->create(['slug' => 'parent']);
+    $namespace = PostNamespace::factory()->create(['slug' => 'child']);
+
+    $this->actingAs($user)
+        ->put(route('admin.namespaces.update', $namespace), [
+            'parent_id' => $parent->id,
+            'slug' => $namespace->slug,
+            'name' => $namespace->name,
+        ])
+        ->assertRedirect(route('admin.posts.index'));
+
+    expect($namespace->fresh()->parent_id)->toBe($parent->id);
+    expect($namespace->fresh()->full_path)->toBe('parent/child');
+});
+
+test('updating a namespace rejects setting a descendant as its parent', function () {
+    $user = User::factory()->create();
+    $root = PostNamespace::factory()->create(['slug' => 'root']);
+    $child = PostNamespace::factory()->create(['parent_id' => $root->id, 'slug' => 'child']);
+
+    $this->actingAs($user)
+        ->put(route('admin.namespaces.update', $root), [
+            'parent_id' => $child->id,
+            'slug' => $root->slug,
+            'name' => $root->name,
+        ])
+        ->assertSessionHasErrors('parent_id');
+});
+
+test('updating a namespace rejects using itself as a parent', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create(['slug' => 'guides']);
+
+    $this->actingAs($user)
+        ->put(route('admin.namespaces.update', $namespace), [
+            'parent_id' => $namespace->id,
+            'slug' => $namespace->slug,
+            'name' => $namespace->name,
+        ])
+        ->assertSessionHasErrors('parent_id');
 });
 
 test('authenticated users can delete a namespace', function () {

--- a/tests/Feature/ContentPathTest.php
+++ b/tests/Feature/ContentPathTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('it builds a full path for root namespaces', function () {
+    $namespace = PostNamespace::factory()->create(['slug' => 'guides']);
+
+    expect($namespace->fresh()->full_path)->toBe('guides');
+});
+
+test('it builds a full path for child namespaces', function () {
+    $parent = PostNamespace::factory()->create(['slug' => 'guides']);
+    $child = PostNamespace::factory()->create([
+        'parent_id' => $parent->id,
+        'slug' => 'laravel',
+    ]);
+
+    expect($child->fresh()->full_path)->toBe('guides/laravel');
+});
+
+test('it builds a full path for posts', function () {
+    $namespace = PostNamespace::factory()->create(['slug' => 'guides']);
+    $post = Post::factory()->for($namespace, 'namespace')->create(['slug' => 'routing']);
+
+    expect($post->fresh()->full_path)->toBe('guides/routing');
+});
+
+test('updating a namespace slug syncs descendant namespace and post paths', function () {
+    $root = PostNamespace::factory()->create(['slug' => 'guides']);
+    $child = PostNamespace::factory()->create([
+        'parent_id' => $root->id,
+        'slug' => 'laravel',
+    ]);
+    $post = Post::factory()->for($child, 'namespace')->create(['slug' => 'routing']);
+
+    $root->update(['slug' => 'docs']);
+
+    expect($child->fresh()->full_path)->toBe('docs/laravel');
+    expect($post->fresh()->full_path)->toBe('docs/laravel/routing');
+});
+
+test('moving a namespace syncs its subtree paths', function () {
+    $root = PostNamespace::factory()->create(['slug' => 'guides']);
+    $targetParent = PostNamespace::factory()->create(['slug' => 'reference']);
+    $child = PostNamespace::factory()->create([
+        'parent_id' => $root->id,
+        'slug' => 'laravel',
+    ]);
+    $post = Post::factory()->for($child, 'namespace')->create(['slug' => 'routing']);
+
+    $child->update(['parent_id' => $targetParent->id]);
+
+    expect($child->fresh()->full_path)->toBe('reference/laravel');
+    expect($post->fresh()->full_path)->toBe('reference/laravel/routing');
+});

--- a/tests/Feature/MermaidRenderingTest.php
+++ b/tests/Feature/MermaidRenderingTest.php
@@ -21,7 +21,7 @@ graph TD
 MD,
     ]);
 
-    $response = $this->get(route('posts.show', [$namespace, $post]));
+    $response = $this->get(route('posts.path', ['path' => $post->full_path]));
 
     $response->assertOk();
     $response->assertInertia(fn ($page) => $page

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -2,53 +2,189 @@
 
 use App\Models\Post;
 use App\Models\PostNamespace;
+use App\Support\ReservedContentPath;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
 
 test('homepage lists published namespaces only', function () {
-    PostNamespace::factory()->create([
+    $rootNamespace = PostNamespace::factory()->create([
         'slug' => 'published',
         'description' => 'Published namespace description.',
+        'is_published' => true,
+    ]);
+    PostNamespace::factory()->create([
+        'parent_id' => $rootNamespace->id,
+        'slug' => 'nested',
         'is_published' => true,
     ]);
     PostNamespace::factory()->create(['slug' => 'draft', 'is_published' => false]);
 
     $response = $this->get(route('home'));
 
-    $response->assertOk();
-    $response->assertInertia(fn ($page) => $page
-        ->component('posts/index')
-        ->has('namespaces', 1)
-        ->where('namespaces.0.slug', 'published')
-        ->where('namespaces.0.description', 'Published namespace description.')
-    );
+    $response->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/index')
+            ->has('namespaces', 1)
+            ->where('namespaces.0.slug', 'published')
+            ->where('namespaces.0.full_path', 'published')
+            ->where('namespaces.0.description', 'Published namespace description.')
+        );
 });
 
 test('unpublished namespace returns 404 on namespace page', function () {
     $namespace = PostNamespace::factory()->create(['is_published' => false]);
 
-    $this->get(route('posts.namespace', $namespace))->assertNotFound();
+    $this->get(route('posts.path', ['path' => $namespace->full_path]))->assertNotFound();
 });
 
-test('published namespace redirects to first post', function () {
-    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+test('unpublished ancestor returns 404 on namespace page', function () {
+    $root = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'is_published' => false,
+    ]);
+    $child = PostNamespace::factory()->create([
+        'parent_id' => $root->id,
+        'slug' => 'laravel',
+        'is_published' => true,
+    ]);
+
+    $this->get(route('posts.path', ['path' => $child->full_path]))->assertNotFound();
+});
+
+test('published namespace shows child namespaces and direct posts', function () {
+    $namespace = PostNamespace::factory()->create([
+        'is_published' => true,
+        'slug' => 'guides',
+    ]);
+    $child = PostNamespace::factory()->create([
+        'parent_id' => $namespace->id,
+        'slug' => 'laravel',
+        'name' => 'Laravel',
+        'is_published' => true,
+    ]);
+    PostNamespace::factory()->create([
+        'parent_id' => $namespace->id,
+        'slug' => 'hidden',
+        'is_published' => false,
+    ]);
     $post = Post::factory()->for($namespace, 'namespace')->published()->create();
 
-    $this->get(route('posts.namespace', $namespace))
-        ->assertRedirect(route('posts.show', [$namespace, $post]));
+    $this->get(route('posts.path', ['path' => $namespace->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/namespace')
+            ->where('namespace.full_path', $namespace->full_path)
+            ->has('children', 1)
+            ->where('children.0.full_path', $child->full_path)
+            ->where('posts.0.full_path', $post->full_path)
+        );
 });
 
-test('unpublished namespace returns 404 on post show page', function () {
-    $namespace = PostNamespace::factory()->create(['is_published' => false]);
-    $post = Post::factory()->for($namespace, 'namespace')->published()->create();
+test('published namespace sorts child namespaces by post order', function () {
+    $namespace = PostNamespace::factory()->create([
+        'is_published' => true,
+        'slug' => 'guides',
+        'post_order' => ['beta', 'alpha'],
+    ]);
+    $alpha = PostNamespace::factory()->create([
+        'parent_id' => $namespace->id,
+        'slug' => 'alpha',
+        'is_published' => true,
+    ]);
+    $beta = PostNamespace::factory()->create([
+        'parent_id' => $namespace->id,
+        'slug' => 'beta',
+        'is_published' => true,
+    ]);
 
-    $this->get(route('posts.show', [$namespace, $post]))->assertNotFound();
+    $this->get(route('posts.path', ['path' => $namespace->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->where('children.0.full_path', $beta->full_path)
+            ->where('children.1.full_path', $alpha->full_path)
+        );
 });
 
-test('published namespace shows post', function () {
-    $namespace = PostNamespace::factory()->create(['is_published' => true]);
-    $post = Post::factory()->for($namespace, 'namespace')->published()->create();
+test('unpublished ancestor returns 404 on post show page', function () {
+    $root = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'is_published' => false,
+    ]);
+    $child = PostNamespace::factory()->create([
+        'parent_id' => $root->id,
+        'slug' => 'laravel',
+        'is_published' => true,
+    ]);
+    $post = Post::factory()->for($child, 'namespace')->published()->create([
+        'slug' => 'routing',
+    ]);
 
-    $this->get(route('posts.show', [$namespace, $post]))->assertOk();
+    $this->get(route('posts.path', ['path' => $post->full_path]))->assertNotFound();
 });
+
+test('published namespace shows post with breadcrumbs', function () {
+    $root = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+        'is_published' => true,
+    ]);
+    $child = PostNamespace::factory()->create([
+        'parent_id' => $root->id,
+        'slug' => 'laravel',
+        'name' => 'Laravel',
+        'is_published' => true,
+    ]);
+    $post = Post::factory()->for($child, 'namespace')->published()->create([
+        'slug' => 'routing',
+    ]);
+
+    $this->get(route('posts.path', ['path' => $post->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/show')
+            ->where('namespace.full_path', $child->full_path)
+            ->where('post.full_path', $post->full_path)
+            ->where('breadcrumbs.0.full_path', $root->full_path)
+            ->where('posts.0.full_path', $post->full_path)
+        );
+});
+
+test('admin routes are not caught by the content path wildcard', function () {
+    $this->get('/admin/namespaces/create')->assertRedirect(route('login'));
+});
+
+test('login and register routes are not caught by the content path wildcard', function (string $path) {
+    $this->get("/{$path}")->assertSuccessful();
+})->with([
+    'login' => 'login',
+    'register' => 'register',
+]);
+
+test('api routes are not caught by the content path wildcard', function () {
+    $this->getJson(route('api.ogp'))->assertUnprocessable();
+});
+
+test('reserved prefixes with nested segments are not caught by the content path wildcard', function (string $path) {
+    $this->get("/{$path}")->assertNotFound();
+})->with(fn (): array => collect(ReservedContentPath::ROOT_SEGMENTS)
+    ->mapWithKeys(fn (string $segment): array => [$segment => "{$segment}/foo"])
+    ->all());
+
+test('lookalike slugs still resolve through the content path wildcard', function (string $slug) {
+    $namespace = PostNamespace::factory()->create([
+        'slug' => $slug,
+        'name' => ucfirst($slug),
+        'is_published' => true,
+    ]);
+
+    $this->get("/{$slug}")
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/namespace')
+            ->where('namespace.full_path', $namespace->full_path)
+        );
+})->with([
+    'apiary' => 'apiary',
+    'administrator' => 'administrator',
+]);

--- a/tests/Feature/PostSeederTest.php
+++ b/tests/Feature/PostSeederTest.php
@@ -93,3 +93,30 @@ test('post seeder creates the mintlify syntax page', function () {
     expect($post->content)->toContain('```php PHP icon="php"');
     expect($post->published_at)->not->toBeNull();
 });
+
+test('post seeder creates wildcard routing lookalike namespaces', function () {
+    $this->seed(PostSeeder::class);
+
+    $apiaryNamespace = PostNamespace::query()->where('slug', 'apiary')->first();
+    $administratorNamespace = PostNamespace::query()->where('slug', 'administrator')->first();
+
+    expect($apiaryNamespace)->not->toBeNull();
+    expect($administratorNamespace)->not->toBeNull();
+
+    $apiaryPost = Post::query()
+        ->where('namespace_id', $apiaryNamespace->id)
+        ->where('slug', 'routing-check')
+        ->first();
+    $administratorPost = Post::query()
+        ->where('namespace_id', $administratorNamespace->id)
+        ->where('slug', 'routing-check')
+        ->first();
+
+    expect($apiaryPost)->not->toBeNull();
+    expect($apiaryPost->content)->toContain('/apiary');
+    expect($apiaryPost->content)->toContain('/api/*');
+
+    expect($administratorPost)->not->toBeNull();
+    expect($administratorPost->content)->toContain('/administrator');
+    expect($administratorPost->content)->toContain('/admin/*');
+});


### PR DESCRIPTION
## Summary
- extract the nested path/domain core from the larger `feat/nested-namespaces` effort into a focused branch
- add `parent_id` / `full_path` support, path sync services/observers, reserved content path handling, and public wildcard path resolution
- cover ancestor publication, reserved route prefixes, seeded lookalike paths, and namespace parent validation with focused tests

## Why this branch
`feat/nested-namespaces` turned into a migration branch that mixes path/domain changes with importer and navigation UX work. This PR lands only the backend/public-path core that main needs first.

## Included here
- namespace/post `full_path` support via forward migration
- `ContentPathService` plus observers for namespace/post path computation and subtree sync
- public `posts.path` wildcard resolver with reserved-root protection
- ancestor-aware publication checks for direct URLs
- public page updates to navigate by `full_path`
- reserved content root segments centralized in `App\\Support\\ReservedContentPath`
- seeded lookalike examples (`apiary`, `administrator`) for manual verification
- feature/browser coverage for routing, publication visibility, seeding, and parent validation

## Explicitly not included
- importer changes from issue #32
- nav tree / broader docs-CMS UX from `feat/nested-namespaces`
- broader README / product-axis cleanup

## Branch strategy decision
- **Merge this PR into `main` first** as the safe nested-path foundation.
- **Keep `feat/nested-namespaces` for now** as a reference branch until the remaining importer and nav follow-up work is split out.
- **Do not delete `origin/feat/nested-namespaces` yet**: it still contains implementation context for the pending follow-ups and is not safe to prune yet.
