### PR TITLE
Fix namespace identity for importer

### DIFF
--- a/app/Http/Requests/Admin/StoreNamespaceRequest.php
+++ b/app/Http/Requests/Admin/StoreNamespaceRequest.php
@@ -9,6 +9,17 @@ use Illuminate\Validation\Rule;
 
 class StoreNamespaceRequest extends FormRequest
 {
+    private function parentId(): ?int
+    {
+        $parentId = $this->input('parent_id');
+
+        if ($parentId === null || $parentId === '') {
+            return null;
+        }
+
+        return (int) $parentId;
+    }
+
     public function authorize(): bool
     {
         return true;
@@ -36,7 +47,18 @@ class StoreNamespaceRequest extends FormRequest
     {
         return [
             'parent_id' => ['nullable', 'integer', Rule::exists('namespaces', 'id')],
-            'slug' => ['required', 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/', Rule::notIn(ReservedContentPath::rootSegments()), Rule::unique('namespaces', 'slug')],
+            'slug' => [
+                'required',
+                'string',
+                'max:255',
+                'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/',
+                Rule::notIn(ReservedContentPath::rootSegments()),
+                Rule::unique('namespaces', 'slug')->where(function ($query) {
+                    return $this->parentId() === null
+                        ? $query->whereNull('parent_id')
+                        : $query->where('parent_id', $this->parentId());
+                }),
+            ],
             'name' => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
             'cover_image' => ['nullable', 'image', 'max:2048'],

--- a/app/Http/Requests/Admin/UpdateNamespaceRequest.php
+++ b/app/Http/Requests/Admin/UpdateNamespaceRequest.php
@@ -10,6 +10,17 @@ use Illuminate\Validation\Rule;
 
 class UpdateNamespaceRequest extends FormRequest
 {
+    private function parentId(): ?int
+    {
+        $parentId = $this->input('parent_id');
+
+        if ($parentId === null || $parentId === '') {
+            return null;
+        }
+
+        return (int) $parentId;
+    }
+
     public function authorize(): bool
     {
         return true;
@@ -70,7 +81,20 @@ class UpdateNamespaceRequest extends FormRequest
                     }
                 },
             ],
-            'slug' => ['required', 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/', Rule::notIn(ReservedContentPath::rootSegments()), Rule::unique('namespaces', 'slug')->ignore($this->route('namespace'))],
+            'slug' => [
+                'required',
+                'string',
+                'max:255',
+                'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/',
+                Rule::notIn(ReservedContentPath::rootSegments()),
+                Rule::unique('namespaces', 'slug')
+                    ->where(function ($query) {
+                        return $this->parentId() === null
+                            ? $query->whereNull('parent_id')
+                            : $query->where('parent_id', $this->parentId());
+                    })
+                    ->ignore($this->route('namespace')),
+            ],
             'name' => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
             'cover_image' => ['nullable', 'image', 'max:2048'],

--- a/app/Models/PostNamespace.php
+++ b/app/Models/PostNamespace.php
@@ -67,7 +67,7 @@ class PostNamespace extends Model
 
     public function getRouteKeyName(): string
     {
-        return 'slug';
+        return 'id';
     }
 
     /**

--- a/app/Services/InertiaJsDocsImporter.php
+++ b/app/Services/InertiaJsDocsImporter.php
@@ -1,0 +1,440 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+use App\Models\User;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+class InertiaJsDocsImporter
+{
+    /**
+     * @var array<string, array{name: string, posts: array<int, string>}>
+     */
+    private const SECTION_DEFINITIONS = [
+        'getting-started' => [
+            'name' => 'Getting Started',
+            'posts' => ['index', 'demo-application', 'upgrade-guide'],
+        ],
+        'installation' => [
+            'name' => 'Installation',
+            'posts' => ['server-side-setup', 'client-side-setup'],
+        ],
+        'core-concepts' => [
+            'name' => 'Core Concepts',
+            'posts' => ['who-is-it-for', 'how-it-works', 'the-protocol'],
+        ],
+        'the-basics' => [
+            'name' => 'The Basics',
+            'posts' => [
+                'pages',
+                'responses',
+                'redirects',
+                'routing',
+                'title-and-meta',
+                'links',
+                'manual-visits',
+                'instant-visits',
+                'forms',
+                'http-requests',
+                'optimistic-updates',
+                'file-uploads',
+                'validation',
+                'layouts',
+                'view-transitions',
+            ],
+        ],
+        'data-props' => [
+            'name' => 'Data & Props',
+            'posts' => [
+                'shared-data',
+                'flash-data',
+                'partial-reloads',
+                'deferred-props',
+                'merging-props',
+                'once-props',
+                'polling',
+                'prefetching',
+                'load-when-visible',
+                'infinite-scroll',
+                'remembering-state',
+            ],
+        ],
+        'security' => [
+            'name' => 'Security',
+            'posts' => [
+                'authentication',
+                'authorization',
+                'csrf-protection',
+                'history-encryption',
+            ],
+        ],
+        'advanced' => [
+            'name' => 'Advanced',
+            'posts' => [
+                'asset-versioning',
+                'code-splitting',
+                'error-handling',
+                'events',
+                'progress-indicators',
+                'scroll-management',
+                'server-side-rendering',
+                'testing',
+                'typescript',
+            ],
+        ],
+    ];
+
+    /**
+     * @return array{
+     *     imported: bool,
+     *     message: string,
+     *     namespace_slug?: string,
+     *     post_count?: int,
+     *     source_path?: string
+     * }
+     */
+    public function import(
+        string $sourcePath,
+        string $namespaceSlug,
+        string $namespaceName,
+        string $namespaceDescription,
+        string $userEmail,
+    ): array {
+        $absoluteSourcePath = base_path($sourcePath);
+
+        if (! File::isDirectory($absoluteSourcePath)) {
+            return [
+                'imported' => false,
+                'message' => "Source directory [{$sourcePath}] was not found.",
+            ];
+        }
+
+        $documents = $this->discoverDocuments(
+            absoluteSourcePath: $absoluteSourcePath,
+            docsVersion: basename($absoluteSourcePath),
+        );
+
+        if ($documents->isEmpty()) {
+            return [
+                'imported' => false,
+                'message' => "No MDX files were found in [{$sourcePath}].",
+            ];
+        }
+
+        $docsVersion = basename($absoluteSourcePath);
+        $pathMap = $documents
+            ->mapWithKeys(fn (array $document): array => [
+                $document['doc_path'] => $document['target_path'],
+                $document['doc_path'].'/index' => $document['target_path'],
+            ])
+            ->all();
+
+        $user = User::query()->firstOrCreate(
+            ['email' => $userEmail],
+            [
+                'name' => 'Docs Importer',
+                'password' => bcrypt(Str::random(40)),
+            ],
+        );
+
+        $namespace = PostNamespace::query()->updateOrCreate(
+            [
+                'parent_id' => null,
+                'slug' => $namespaceSlug,
+            ],
+            [
+                'name' => $namespaceName,
+                'description' => $namespaceDescription,
+                'is_published' => true,
+            ],
+        );
+
+        $sectionNamespaces = $documents
+            ->groupBy('section')
+            ->map(function (Collection $sectionDocuments, string $section) use ($namespace): PostNamespace {
+                return PostNamespace::query()->updateOrCreate(
+                    [
+                        'parent_id' => $namespace->id,
+                        'slug' => $section,
+                    ],
+                    [
+                        'name' => $this->sectionName($section),
+                        'description' => null,
+                        'is_published' => true,
+                        'post_order' => $this->sectionPostOrder($section, $sectionDocuments),
+                    ],
+                );
+            });
+
+        $namespace->update([
+            'post_order' => $this->sectionNamespaceOrder($sectionNamespaces),
+        ]);
+
+        $publishedAt = now();
+
+        $documents->each(function (array $document) use ($sectionNamespaces, $namespaceSlug, $pathMap, $docsVersion, $user, $publishedAt): void {
+            /** @var PostNamespace $sectionNamespace */
+            $sectionNamespace = $sectionNamespaces->get($document['section']);
+
+            Post::query()->updateOrCreate(
+                [
+                    'namespace_id' => $sectionNamespace->id,
+                    'slug' => $document['slug'],
+                ],
+                [
+                    'user_id' => $user->id,
+                    'title' => $document['title'],
+                    'content' => $this->rewriteInternalLinks(
+                        markdown: $document['content'],
+                        namespaceSlug: $namespaceSlug,
+                        docsVersion: $docsVersion,
+                        pathMap: $pathMap,
+                    ),
+                    'is_draft' => false,
+                    'published_at' => $publishedAt,
+                ],
+            );
+        });
+
+        return [
+            'imported' => true,
+            'message' => 'Imported Inertia.js documentation successfully.',
+            'namespace_slug' => $namespace->slug,
+            'post_count' => $documents->count(),
+            'source_path' => $sourcePath,
+        ];
+    }
+
+    /**
+     * @return Collection<int, array{
+     *     relative_path: string,
+     *     doc_path: string,
+     *     slug: string,
+     *     target_path: string,
+     *     title: string,
+     *     content: string,
+     *     section: string
+     * }>
+     */
+    private function discoverDocuments(string $absoluteSourcePath, string $docsVersion): Collection
+    {
+        return collect(File::allFiles($absoluteSourcePath))
+            ->filter(fn (\SplFileInfo $file): bool => $file->getExtension() === 'mdx')
+            ->map(function (\SplFileInfo $file) use ($absoluteSourcePath, $docsVersion): array {
+                $relativePath = Str::of($file->getPathname())
+                    ->after($absoluteSourcePath.DIRECTORY_SEPARATOR)
+                    ->replace('\\', '/')
+                    ->value();
+
+                $parsedDocument = $this->parseMdxDocument(File::get($file->getPathname()));
+                $docPath = '/'.$docsVersion.'/'.trim(Str::before($relativePath, '.mdx'), '/');
+                $docPath = Str::replaceEnd('/index', '', $docPath);
+
+                return [
+                    'relative_path' => $relativePath,
+                    'doc_path' => $docPath,
+                    'slug' => $this->postSlugFromRelativePath($relativePath),
+                    'target_path' => $this->targetPathFromRelativePath($relativePath),
+                    'title' => $this->titleFromFrontmatter($parsedDocument['frontmatter'], $relativePath),
+                    'content' => $parsedDocument['content'],
+                    'section' => Str::before($relativePath, '/'),
+                ];
+            })
+            ->sort(function (array $left, array $right): int {
+                $leftSection = $this->sectionOrder($left['section']);
+                $rightSection = $this->sectionOrder($right['section']);
+
+                if ($leftSection !== $rightSection) {
+                    return $leftSection <=> $rightSection;
+                }
+
+                $leftPost = $this->sectionPostOrderIndex($left['section'], $left['slug']);
+                $rightPost = $this->sectionPostOrderIndex($right['section'], $right['slug']);
+
+                if ($leftPost !== $rightPost) {
+                    return $leftPost <=> $rightPost;
+                }
+
+                return $left['relative_path'] <=> $right['relative_path'];
+            })
+            ->values();
+    }
+
+    private function postSlugFromRelativePath(string $relativePath): string
+    {
+        return (string) Str::of($relativePath)
+            ->after('/')
+            ->replaceLast('.mdx', '')
+            ->value();
+    }
+
+    private function targetPathFromRelativePath(string $relativePath): string
+    {
+        $section = Str::before($relativePath, '/');
+        $slug = $this->postSlugFromRelativePath($relativePath);
+
+        return trim($section.'/'.$slug, '/');
+    }
+
+    private function isIndexDocument(string $relativePath): bool
+    {
+        return Str::endsWith($relativePath, '/index.mdx');
+    }
+
+    private function sectionOrder(string $section): int
+    {
+        $sections = array_keys(self::SECTION_DEFINITIONS);
+        $index = array_search($section, $sections, true);
+
+        return $index !== false ? $index : 99;
+    }
+
+    /**
+     * @param  array<string, mixed>  $frontmatter
+     */
+    private function titleFromFrontmatter(array $frontmatter, string $relativePath): string
+    {
+        $title = $frontmatter['title'] ?? null;
+
+        if (is_string($title) && $title !== '') {
+            return $title;
+        }
+
+        return (string) Str::of($this->postSlugFromRelativePath($relativePath))
+            ->replace('-', ' ')
+            ->title();
+    }
+
+    /**
+     * @return array{frontmatter: array<string, mixed>, content: string}
+     */
+    private function parseMdxDocument(string $contents): array
+    {
+        if (! preg_match('/\A---\R(?<frontmatter>.*?)\R---\R?(?<content>.*)\z/s', $contents, $matches)) {
+            return [
+                'frontmatter' => [],
+                'content' => trim($contents),
+            ];
+        }
+
+        try {
+            $frontmatter = Yaml::parse($matches['frontmatter']);
+        } catch (ParseException) {
+            $frontmatter = [];
+        }
+
+        return [
+            'frontmatter' => is_array($frontmatter) ? $frontmatter : [],
+            'content' => ltrim($matches['content']),
+        ];
+    }
+
+    /**
+     * @param  array<string, string>  $pathMap
+     */
+    private function rewriteInternalLinks(
+        string $markdown,
+        string $namespaceSlug,
+        string $docsVersion,
+        array $pathMap,
+    ): string {
+        $quotedDocsVersion = preg_quote($docsVersion, '/');
+
+        $markdown = preg_replace_callback(
+            '/(\\]\\()(?<path>\\/'.$quotedDocsVersion.'\\/[^)#\\s]+)(?<hash>#[^)]+)?(\\))/',
+            function (array $matches) use ($namespaceSlug, $pathMap): string {
+                $rewritten = $this->rewritePath(
+                    path: $matches['path'],
+                    namespaceSlug: $namespaceSlug,
+                    pathMap: $pathMap,
+                );
+
+                return $matches[1].$rewritten.($matches['hash'] ?? '').')';
+            },
+            $markdown,
+        ) ?? $markdown;
+
+        return preg_replace_callback(
+            '/(href=["\'])(?<path>\/'.$quotedDocsVersion.'\/[^"#\']+)(?<hash>#[^"\']+)?(["\'])/',
+            function (array $matches) use ($namespaceSlug, $pathMap): string {
+                $rewritten = $this->rewritePath(
+                    path: $matches['path'],
+                    namespaceSlug: $namespaceSlug,
+                    pathMap: $pathMap,
+                );
+
+                return $matches[1].$rewritten.($matches['hash'] ?? '').$matches[4];
+            },
+            $markdown,
+        ) ?? $markdown;
+    }
+
+    /**
+     * @param  array<string, string>  $pathMap
+     */
+    private function rewritePath(string $path, string $namespaceSlug, array $pathMap): string
+    {
+        $targetPath = $pathMap[$path] ?? null;
+
+        if (! is_string($targetPath)) {
+            return $path;
+        }
+
+        return route('posts.path', ['path' => $namespaceSlug.'/'.$targetPath], false);
+    }
+
+    private function sectionName(string $section): string
+    {
+        return self::SECTION_DEFINITIONS[$section]['name']
+            ?? (string) Str::of($section)->replace('-', ' ')->title();
+    }
+
+    /**
+     * @param  Collection<int, PostNamespace>  $sectionNamespaces
+     * @return array<int, string>
+     */
+    private function sectionNamespaceOrder(Collection $sectionNamespaces): array
+    {
+        $configured = collect(array_keys(self::SECTION_DEFINITIONS))
+            ->filter(fn (string $section) => $sectionNamespaces->has($section));
+
+        $remaining = $sectionNamespaces->keys()
+            ->reject(fn (string $section) => $configured->contains($section))
+            ->sort()
+            ->values();
+
+        return $configured->concat($remaining)->values()->all();
+    }
+
+    /**
+     * @param  Collection<int, array{slug: string}>  $sectionDocuments
+     * @return array<int, string>
+     */
+    private function sectionPostOrder(string $section, Collection $sectionDocuments): array
+    {
+        $availableSlugs = $sectionDocuments->pluck('slug');
+        $configured = collect(self::SECTION_DEFINITIONS[$section]['posts'] ?? [])
+            ->filter(fn (string $slug) => $availableSlugs->contains($slug));
+
+        $remaining = $availableSlugs
+            ->reject(fn (string $slug) => $configured->contains($slug))
+            ->sort()
+            ->values();
+
+        return $configured->concat($remaining)->values()->all();
+    }
+
+    private function sectionPostOrderIndex(string $section, string $slug): int
+    {
+        $order = self::SECTION_DEFINITIONS[$section]['posts'] ?? [];
+        $index = array_search($slug, $order, true);
+
+        return $index !== false ? $index : PHP_INT_MAX;
+    }
+}

--- a/database/inertiajs-docs/v3/core-concepts/how-it-works.mdx
+++ b/database/inertiajs-docs/v3/core-concepts/how-it-works.mdx
@@ -1,0 +1,5 @@
+---
+title: How it works
+---
+
+Inertia keeps the routing and controllers on the server while rendering pages on the client.

--- a/database/inertiajs-docs/v3/getting-started/index.mdx
+++ b/database/inertiajs-docs/v3/getting-started/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Introduction
+---
+
+Inertia is a new approach to building classic server-driven web apps.
+
+Read more about [how it works](/v3/core-concepts/how-it-works) and [server-side setup](/v3/installation/server-side-setup).

--- a/database/inertiajs-docs/v3/installation/server-side-setup.mdx
+++ b/database/inertiajs-docs/v3/installation/server-side-setup.mdx
@@ -1,0 +1,5 @@
+---
+title: Server-side setup
+---
+
+Set up your server adapter before rendering your first Inertia page.

--- a/database/migrations/2026_04_17_160000_drop_unique_slug_from_namespaces_table.php
+++ b/database/migrations/2026_04_17_160000_drop_unique_slug_from_namespaces_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('namespaces', function (Blueprint $table) {
+            $table->dropUnique('namespaces_slug_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('namespaces', function (Blueprint $table) {
+            $table->unique('slug');
+        });
+    }
+};

--- a/resources/js/pages/admin/namespaces/edit.tsx
+++ b/resources/js/pages/admin/namespaces/edit.tsx
@@ -22,7 +22,7 @@ export default function Edit({ namespace }: { namespace: Namespace }) {
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
             { title: 'Posts', href: postsIndex.url() },
-            { title: namespace.name, href: edit.url(namespace.slug) },
+            { title: namespace.name, href: edit.url(namespace.id) },
         ],
     });
 
@@ -44,7 +44,7 @@ export default function Edit({ namespace }: { namespace: Namespace }) {
 
     function submit(e: React.FormEvent) {
         e.preventDefault();
-        post(NamespaceController.update.url(namespace.slug));
+        post(NamespaceController.update.url(namespace.id));
     }
 
     return (

--- a/resources/js/pages/admin/posts/create.tsx
+++ b/resources/js/pages/admin/posts/create.tsx
@@ -34,8 +34,8 @@ export default function Create({ namespace }: { namespace: Namespace }) {
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
             { title: 'Posts', href: index.url() },
-            { title: namespace.name, href: namespaceRoute.url(namespace.slug) },
-            { title: 'New Post', href: create.url(namespace.slug) },
+            { title: namespace.name, href: namespaceRoute.url(namespace.id) },
+            { title: 'New Post', href: create.url(namespace.id) },
         ],
     });
 
@@ -66,7 +66,7 @@ export default function Create({ namespace }: { namespace: Namespace }) {
                     </p>
                 </div>
 
-                <Form {...store.form(namespace.slug)} className="space-y-6">
+                <Form {...store.form(namespace.id)} className="space-y-6">
                     {({ processing, errors }) => (
                         <>
                             <div className="grid gap-2">
@@ -143,7 +143,7 @@ export default function Create({ namespace }: { namespace: Namespace }) {
                                 <Button type="button" variant="outline" asChild>
                                     <a
                                         href={namespaceRoute.url(
-                                            namespace.slug,
+                                            namespace.id,
                                         )}
                                     >
                                         Cancel

--- a/resources/js/pages/admin/posts/create.tsx
+++ b/resources/js/pages/admin/posts/create.tsx
@@ -141,11 +141,7 @@ export default function Create({ namespace }: { namespace: Namespace }) {
                                     {isDraft ? 'Save Draft' : 'Create Post'}
                                 </Button>
                                 <Button type="button" variant="outline" asChild>
-                                    <a
-                                        href={namespaceRoute.url(
-                                            namespace.id,
-                                        )}
-                                    >
+                                    <a href={namespaceRoute.url(namespace.id)}>
                                         Cancel
                                     </a>
                                 </Button>

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -148,11 +148,7 @@ export default function Edit({
                                     Save Changes
                                 </Button>
                                 <Button type="button" variant="outline" asChild>
-                                    <a
-                                        href={namespaceRoute.url(
-                                            namespace.id,
-                                        )}
-                                    >
+                                    <a href={namespaceRoute.url(namespace.id)}>
                                         Cancel
                                     </a>
                                 </Button>

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -46,10 +46,10 @@ export default function Edit({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
             { title: 'Posts', href: index.url() },
-            { title: namespace.name, href: namespaceRoute.url(namespace.slug) },
+            { title: namespace.name, href: namespaceRoute.url(namespace.id) },
             {
                 title: post.title,
-                href: edit.url({ namespace: namespace.slug, post: post.slug }),
+                href: edit.url({ namespace: namespace.id, post: post.slug }),
             },
         ],
     });
@@ -68,7 +68,7 @@ export default function Edit({
 
                 <Form
                     {...update.form({
-                        namespace: namespace.slug,
+                        namespace: namespace.id,
                         post: post.slug,
                     })}
                     className="space-y-6"
@@ -150,7 +150,7 @@ export default function Edit({
                                 <Button type="button" variant="outline" asChild>
                                     <a
                                         href={namespaceRoute.url(
-                                            namespace.slug,
+                                            namespace.id,
                                         )}
                                     >
                                         Cancel

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -76,9 +76,7 @@ export default function Index({ namespaces }: { namespaces: Namespace[] }) {
                                     >
                                         <td className="px-4 py-3 font-medium">
                                             <Link
-                                                href={namespaceRoute.url(
-                                                    ns.id,
-                                                )}
+                                                href={namespaceRoute.url(ns.id)}
                                                 className="text-primary hover:underline"
                                             >
                                                 {ns.name}

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -77,7 +77,7 @@ export default function Index({ namespaces }: { namespaces: Namespace[] }) {
                                         <td className="px-4 py-3 font-medium">
                                             <Link
                                                 href={namespaceRoute.url(
-                                                    ns.slug,
+                                                    ns.id,
                                                 )}
                                                 className="text-primary hover:underline"
                                             >
@@ -112,7 +112,7 @@ export default function Index({ namespaces }: { namespaces: Namespace[] }) {
                                                 >
                                                     <Link
                                                         href={NamespaceController.edit.url(
-                                                            ns.slug,
+                                                            ns.id,
                                                         )}
                                                     >
                                                         Edit
@@ -120,7 +120,7 @@ export default function Index({ namespaces }: { namespaces: Namespace[] }) {
                                                 </Button>
                                                 <Form
                                                     {...NamespaceController.destroy.form(
-                                                        ns.slug,
+                                                        ns.id,
                                                     )}
                                                 >
                                                     {({ processing }) => (

--- a/resources/js/pages/admin/posts/namespace.tsx
+++ b/resources/js/pages/admin/posts/namespace.tsx
@@ -36,7 +36,7 @@ export default function Namespace({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
             { title: 'Posts', href: index.url() },
-            { title: namespace.name, href: namespaceRoute.url(namespace.slug) },
+            { title: namespace.name, href: namespaceRoute.url(namespace.id) },
         ],
     });
 
@@ -55,7 +55,7 @@ export default function Namespace({
                         </p>
                     </div>
                     <Button asChild>
-                        <Link href={create.url(namespace.slug)}>New Post</Link>
+                        <Link href={create.url(namespace.id)}>New Post</Link>
                     </Button>
                 </div>
 
@@ -65,7 +65,7 @@ export default function Namespace({
                             No posts in this namespace yet.
                         </p>
                         <Button asChild className="mt-4">
-                            <Link href={create.url(namespace.slug)}>
+                            <Link href={create.url(namespace.id)}>
                                 Create your first post
                             </Link>
                         </Button>
@@ -136,7 +136,7 @@ export default function Namespace({
                                                     <Link
                                                         href={edit.url({
                                                             namespace:
-                                                                namespace.slug,
+                                                                namespace.id,
                                                             post: post.slug,
                                                         })}
                                                     >
@@ -146,7 +146,7 @@ export default function Namespace({
                                                 <Form
                                                     {...destroy.form({
                                                         namespace:
-                                                            namespace.slug,
+                                                            namespace.id,
                                                         post: post.slug,
                                                     })}
                                                 >

--- a/resources/js/pages/admin/posts/namespace.tsx
+++ b/resources/js/pages/admin/posts/namespace.tsx
@@ -145,8 +145,7 @@ export default function Namespace({
                                                 </Button>
                                                 <Form
                                                     {...destroy.form({
-                                                        namespace:
-                                                            namespace.id,
+                                                        namespace: namespace.id,
                                                         post: post.slug,
                                                     })}
                                                 >

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -36,10 +36,10 @@ export default function Show({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
             { title: 'Posts', href: index.url() },
-            { title: namespace.name, href: namespaceRoute.url(namespace.slug) },
+            { title: namespace.name, href: namespaceRoute.url(namespace.id) },
             {
                 title: post.title,
-                href: edit.url({ namespace: namespace.slug, post: post.slug }),
+                href: edit.url({ namespace: namespace.id, post: post.slug }),
             },
         ],
     });
@@ -73,7 +73,7 @@ export default function Show({
                         <Button variant="outline" asChild>
                             <Link
                                 href={edit.url({
-                                    namespace: namespace.slug,
+                                    namespace: namespace.id,
                                     post: post.slug,
                                 })}
                             >
@@ -82,7 +82,7 @@ export default function Show({
                         </Button>
                         <Form
                             {...destroy.form({
-                                namespace: namespace.slug,
+                                namespace: namespace.id,
                                 post: post.slug,
                             })}
                         >

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -11,11 +11,11 @@ Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () 
 
     Route::prefix('posts')->name('posts.')->group(function () {
         Route::get('/', [PostController::class, 'index'])->name('index');
-        Route::get('/{namespace:slug}', [PostController::class, 'namespaceIndex'])->name('namespace');
-        Route::get('/{namespace:slug}/create', [PostController::class, 'create'])->name('create');
-        Route::post('/{namespace:slug}', [PostController::class, 'store'])->name('store');
-        Route::get('/{namespace:slug}/{post:slug}/edit', [PostController::class, 'edit'])->name('edit')->scopeBindings();
-        Route::put('/{namespace:slug}/{post:slug}', [PostController::class, 'update'])->name('update')->scopeBindings();
-        Route::delete('/{namespace:slug}/{post:slug}', [PostController::class, 'destroy'])->name('destroy')->scopeBindings();
+        Route::get('/{namespace}', [PostController::class, 'namespaceIndex'])->name('namespace');
+        Route::get('/{namespace}/create', [PostController::class, 'create'])->name('create');
+        Route::post('/{namespace}', [PostController::class, 'store'])->name('store');
+        Route::get('/{namespace}/{post:slug}/edit', [PostController::class, 'edit'])->name('edit')->scopeBindings();
+        Route::put('/{namespace}/{post:slug}', [PostController::class, 'update'])->name('update')->scopeBindings();
+        Route::delete('/{namespace}/{post:slug}', [PostController::class, 'destroy'])->name('destroy')->scopeBindings();
     });
 });

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,37 @@
 <?php
 
-use Illuminate\Foundation\Inspiring;
+use App\Services\InertiaJsDocsImporter;
 use Illuminate\Support\Facades\Artisan;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 
-Artisan::command('inspire', function () {
-    $this->comment(Inspiring::quote());
-})->purpose('Display an inspiring quote');
+Artisan::command(
+    'posts:import-inertia-docs
+        {path=database/inertiajs-docs/v3 : Path to the Inertia.js MDX docs directory}
+        {--namespace-slug=inertiajs-v3 : Slug for the destination namespace}
+        {--namespace-name=InertiaJS V3 : Display name for the destination namespace}
+        {--namespace-description=Official Inertia.js v3 documentation imported from local MDX sources. : Description for the destination namespace}
+        {--user-email=docs-importer@example.com : User email to assign imported posts to}',
+    function (InertiaJsDocsImporter $importer): int {
+        $result = $importer->import(
+            sourcePath: (string) $this->argument('path'),
+            namespaceSlug: (string) $this->option('namespace-slug'),
+            namespaceName: (string) $this->option('namespace-name'),
+            namespaceDescription: (string) $this->option('namespace-description'),
+            userEmail: (string) $this->option('user-email'),
+        );
+
+        if (! $result['imported']) {
+            $this->error($result['message']);
+
+            return SymfonyCommand::FAILURE;
+        }
+
+        $this->info($result['message']);
+        $this->newLine();
+        $this->line('Namespace: '.$result['namespace_slug']);
+        $this->line('Posts imported: '.$result['post_count']);
+        $this->line('Source: '.$result['source_path']);
+
+        return SymfonyCommand::SUCCESS;
+    }
+)->purpose('Import local Inertia.js MDX documentation into posts and namespaces.');

--- a/tests/Feature/Admin/NamespaceControllerTest.php
+++ b/tests/Feature/Admin/NamespaceControllerTest.php
@@ -90,13 +90,37 @@ test('updating a namespace rejects reserved slugs', function (string $slug) {
     ReservedContentPath::ROOT_SEGMENTS,
 ));
 
-test('storing a namespace requires a unique slug', function () {
+test('storing a root namespace requires a unique slug', function () {
     $user = User::factory()->create();
     PostNamespace::factory()->create(['slug' => 'taken']);
 
     $this->actingAs($user)
         ->post(route('admin.namespaces.store'), ['slug' => 'taken', 'name' => 'Taken'])
         ->assertSessionHasErrors('slug');
+});
+
+test('storing a namespace allows the same slug under a different parent', function () {
+    $user = User::factory()->create();
+    $parentA = PostNamespace::factory()->create(['slug' => 'parent-a']);
+    $parentB = PostNamespace::factory()->create(['slug' => 'parent-b']);
+
+    PostNamespace::factory()->create([
+        'parent_id' => $parentA->id,
+        'slug' => 'shared',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('admin.namespaces.store'), [
+            'parent_id' => $parentB->id,
+            'slug' => 'shared',
+            'name' => 'Shared',
+        ])
+        ->assertRedirect(route('admin.posts.index'));
+
+    $this->assertDatabaseHas('namespaces', [
+        'parent_id' => $parentB->id,
+        'slug' => 'shared',
+    ]);
 });
 
 test('storing a namespace requires a slug', function () {

--- a/tests/Feature/ImportInertiaJsDocsCommandTest.php
+++ b/tests/Feature/ImportInertiaJsDocsCommandTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('inertia docs import command creates the namespace and imported posts', function () {
+    $this->artisan('posts:import-inertia-docs')
+        ->assertSuccessful()
+        ->expectsOutputToContain('Imported Inertia.js documentation successfully.');
+
+    $namespace = PostNamespace::query()
+        ->whereNull('parent_id')
+        ->where('slug', 'inertiajs-v3')
+        ->first();
+
+    expect($namespace)->not->toBeNull();
+    expect($namespace->name)->toBe('InertiaJS V3');
+    expect($namespace->full_path)->toBe('inertiajs-v3');
+    expect($namespace->post_order)->toBe([
+        'getting-started',
+        'installation',
+        'core-concepts',
+    ]);
+
+    $gettingStartedNamespace = PostNamespace::query()
+        ->where('parent_id', $namespace->id)
+        ->where('slug', 'getting-started')
+        ->first();
+
+    expect($gettingStartedNamespace)->not->toBeNull();
+    expect($gettingStartedNamespace->full_path)->toBe('inertiajs-v3/getting-started');
+    expect($gettingStartedNamespace->post_order)->toBe(['index']);
+
+    $posts = Post::query()->orderBy('full_path')->get();
+
+    expect($posts)->toHaveCount(3);
+
+    $introduction = $posts->firstWhere('full_path', 'inertiajs-v3/getting-started/index');
+
+    expect($introduction)->not->toBeNull();
+    expect($introduction->title)->toBe('Introduction');
+    expect($introduction->content)->not->toStartWith('---');
+    expect($introduction->content)->toContain('](/inertiajs-v3/core-concepts/how-it-works)');
+    expect($introduction->content)->toContain('](/inertiajs-v3/installation/server-side-setup)');
+});
+
+test('inertia docs import command updates an existing imported post instead of duplicating it', function () {
+    $this->artisan('posts:import-inertia-docs')->assertSuccessful();
+
+    $namespace = PostNamespace::query()
+        ->whereNull('parent_id')
+        ->where('slug', 'inertiajs-v3')
+        ->firstOrFail();
+
+    $gettingStartedNamespace = PostNamespace::query()
+        ->where('parent_id', $namespace->id)
+        ->where('slug', 'getting-started')
+        ->firstOrFail();
+
+    $post = Post::query()
+        ->where('namespace_id', $gettingStartedNamespace->id)
+        ->where('slug', 'index')
+        ->firstOrFail();
+
+    $post->update([
+        'title' => 'Temporary Title',
+        'content' => 'Temporary content',
+    ]);
+
+    $this->artisan('posts:import-inertia-docs')->assertSuccessful();
+
+    $updatedPost = $post->fresh();
+
+    expect($updatedPost->title)->toBe('Introduction');
+    expect($updatedPost->content)->toContain('Inertia is a new approach');
+    expect(
+        Post::query()
+            ->where('namespace_id', $gettingStartedNamespace->id)
+            ->where('slug', 'index')
+            ->count()
+    )->toBe(1);
+});
+
+test('inertia docs import command does not reuse a child namespace with the same slug as the root namespace', function () {
+    $parentNamespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+    ]);
+
+    $conflictingChild = PostNamespace::factory()->create([
+        'parent_id' => $parentNamespace->id,
+        'slug' => 'inertiajs-v3',
+        'name' => 'Nested Conflict',
+        'description' => 'This should not be repurposed as the importer root.',
+    ]);
+
+    $this->artisan('posts:import-inertia-docs')->assertSuccessful();
+
+    $rootNamespace = PostNamespace::query()
+        ->whereNull('parent_id')
+        ->where('slug', 'inertiajs-v3')
+        ->first();
+
+    expect($rootNamespace)->not->toBeNull();
+    expect($rootNamespace->id)->not->toBe($conflictingChild->id);
+    expect($rootNamespace->full_path)->toBe('inertiajs-v3');
+
+    expect($conflictingChild->fresh()->parent_id)->toBe($parentNamespace->id);
+    expect($conflictingChild->fresh()->name)->toBe('Nested Conflict');
+    expect($conflictingChild->fresh()->description)->toBe('This should not be repurposed as the importer root.');
+});


### PR DESCRIPTION
## Summary
- add the Inertia docs importer command, service, and focused MDX fixtures
- fix root namespace lookup to scope imports to parent_id null at the root level
- drop global namespace slug uniqueness and switch admin namespace routing to ID binding
- scope namespace slug validation by parent and cover the importer and admin regressions with Pest tests

## Testing
- vendor/bin/sail exec laravel.test bash -lc cd /var/www/html/.worktrees/importer-fix && npm run build && php artisan test --compact tests/Feature/ImportInertiaJsDocsCommandTest.php tests/Feature/Admin/NamespaceControllerTest.php tests/Feature/Admin/PostControllerTest.php && npm run types:check
