### PR TITLE
Add public content nav tree

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -59,6 +59,7 @@ class PostController extends Controller
      */
     private function renderNamespace(PostNamespace $namespace, Collection $ancestors): Response
     {
+        $rootNamespace = $this->rootNamespace($namespace, $ancestors);
         $children = $namespace->children()
             ->where('is_published', true)
             ->withCount(['posts' => fn ($query) => $query->where('is_draft', false)])
@@ -73,6 +74,7 @@ class PostController extends Controller
         return Inertia::render('posts/namespace', [
             'breadcrumbs' => $this->breadcrumbs($ancestors),
             'children' => $namespace->sortNamespaces($children),
+            'navRoot' => $this->buildNavigationNode($rootNamespace),
             'namespace' => $namespace->only(['id', 'slug', 'full_path', 'name', 'description', 'cover_image_url']),
             'posts' => $namespace->sortPosts($posts),
         ]);
@@ -84,6 +86,7 @@ class PostController extends Controller
     private function renderPost(Post $post, Collection $ancestors): Response
     {
         $namespace = $post->namespace;
+        $rootNamespace = $this->rootNamespace($namespace, $ancestors);
         $posts = $namespace->posts()
             ->where('is_draft', false)
             ->orderBy('published_at')
@@ -92,10 +95,58 @@ class PostController extends Controller
 
         return Inertia::render('posts/show', [
             'breadcrumbs' => $this->breadcrumbs($ancestors),
+            'navRoot' => $this->buildNavigationNode($rootNamespace),
             'namespace' => $namespace->only(['id', 'slug', 'full_path', 'name', 'cover_image_url']),
             'post' => $post->only(['id', 'slug', 'full_path', 'title', 'content', 'published_at']),
             'posts' => $namespace->sortPosts($posts),
         ]);
+    }
+
+    /**
+     * @param  Collection<int, PostNamespace>  $ancestors
+     */
+    private function rootNamespace(PostNamespace $namespace, Collection $ancestors): PostNamespace
+    {
+        return $ancestors->first() ?? $namespace;
+    }
+
+    /**
+     * @return array{
+     *     name: string,
+     *     full_path: string,
+     *     children: array<int, array{name: string, full_path: string, children: array, posts: array<int, array{title: string, full_path: string}>}>,
+     *     posts: array<int, array{title: string, full_path: string}>
+     * }
+     */
+    private function buildNavigationNode(PostNamespace $namespace): array
+    {
+        $children = $namespace->children()
+            ->where('is_published', true)
+            ->get(['id', 'slug', 'full_path', 'name', 'post_order']);
+
+        $posts = $namespace->sortPosts(
+            $namespace->posts()
+                ->where('is_draft', false)
+                ->orderBy('published_at')
+                ->orderBy('id')
+                ->get(['title', 'full_path', 'slug'])
+        );
+
+        return [
+            'name' => $namespace->name,
+            'full_path' => $namespace->full_path,
+            'children' => $namespace->sortNamespaces($children)
+                ->map(fn (PostNamespace $child) => $this->buildNavigationNode($child))
+                ->values()
+                ->all(),
+            'posts' => $posts
+                ->map(fn (Post $post) => [
+                    'title' => $post->title,
+                    'full_path' => $post->full_path,
+                ])
+                ->values()
+                ->all(),
+        ];
     }
 
     /**

--- a/resources/js/components/content-nav-tree.tsx
+++ b/resources/js/components/content-nav-tree.tsx
@@ -1,0 +1,100 @@
+import { Link } from '@inertiajs/react';
+import { ChevronDown, ChevronRight, FileText } from 'lucide-react';
+import { path as contentPath } from '@/routes/posts';
+
+export type ContentNavNode = {
+    name: string;
+    full_path: string;
+    children: ContentNavNode[];
+    posts: Array<{
+        title: string;
+        full_path: string;
+    }>;
+};
+
+function isCurrentBranch(currentPath: string, fullPath: string): boolean {
+    return currentPath === fullPath || currentPath.startsWith(`${fullPath}/`);
+}
+
+function TreeNode({
+    currentPath,
+    node,
+    depth = 0,
+}: {
+    currentPath: string;
+    node: ContentNavNode;
+    depth?: number;
+}) {
+    const inCurrentBranch = isCurrentBranch(currentPath, node.full_path);
+    const hasChildren = node.children.length > 0 || node.posts.length > 0;
+
+    return (
+        <div className="space-y-1">
+            <Link
+                href={contentPath.url(node.full_path)}
+                className={`flex items-center gap-2 rounded px-2 py-1.5 text-sm transition-colors ${
+                    currentPath === node.full_path
+                        ? 'bg-accent font-medium text-accent-foreground'
+                        : inCurrentBranch
+                          ? 'text-foreground'
+                          : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+                }`}
+                style={{ paddingLeft: `${depth * 12 + 8}px` }}
+            >
+                {hasChildren ? (
+                    inCurrentBranch ? (
+                        <ChevronDown className="size-4 shrink-0" />
+                    ) : (
+                        <ChevronRight className="size-4 shrink-0" />
+                    )
+                ) : (
+                    <span className="size-4 shrink-0" />
+                )}
+                <span className="truncate">{node.name}</span>
+            </Link>
+
+            {hasChildren && (
+                <div className="space-y-1">
+                    {node.children.map((child) => (
+                        <TreeNode
+                            key={child.full_path}
+                            currentPath={currentPath}
+                            node={child}
+                            depth={depth + 1}
+                        />
+                    ))}
+
+                    {node.posts.map((post) => (
+                        <Link
+                            key={post.full_path}
+                            href={contentPath.url(post.full_path)}
+                            className={`flex items-center gap-2 rounded px-2 py-1.5 text-sm transition-colors ${
+                                currentPath === post.full_path
+                                    ? 'bg-accent font-medium text-accent-foreground'
+                                    : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+                            }`}
+                            style={{ paddingLeft: `${(depth + 1) * 12 + 8}px` }}
+                        >
+                            <FileText className="size-4 shrink-0" />
+                            <span className="truncate">{post.title}</span>
+                        </Link>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default function ContentNavTree({
+    currentPath,
+    root,
+}: {
+    currentPath: string;
+    root: ContentNavNode;
+}) {
+    return (
+        <nav className="space-y-1 text-sm">
+            <TreeNode currentPath={currentPath} node={root} />
+        </nav>
+    );
+}

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -1,6 +1,11 @@
 import { Head, Link, usePage } from '@inertiajs/react';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+import { useState } from 'react';
+import ContentNavTree, {
+    type ContentNavNode,
+} from '@/components/content-nav-tree';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { login } from '@/routes';
 import { index as adminPosts } from '@/routes/admin/posts';
 import { path as contentPath } from '@/routes/posts';
@@ -29,17 +34,22 @@ type Post = {
 export default function Namespace({
     breadcrumbs,
     children,
+    navRoot,
     namespace,
     posts,
 }: {
     breadcrumbs: Array<{ name: string; full_path: string }>;
     children: ChildNamespace[];
+    navRoot: ContentNavNode;
     namespace: PostNamespace;
     posts: Post[];
 }) {
     const { auth } = usePage<{
         auth: { user: { id: number; name: string } | null };
     }>().props;
+    const isMobile = useIsMobile();
+    const [navOverride, setNavOverride] = useState<boolean | null>(null);
+    const navVisible = navOverride ?? !isMobile;
 
     return (
         <>
@@ -90,6 +100,21 @@ export default function Namespace({
                             </div>
                         </div>
                         <div className="flex items-center gap-4">
+                            <button
+                                onClick={() =>
+                                    setNavOverride(
+                                        (prev) => !(prev ?? !isMobile),
+                                    )
+                                }
+                                className="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                            >
+                                {navVisible ? (
+                                    <PanelLeftClose size={16} />
+                                ) : (
+                                    <PanelLeftOpen size={16} />
+                                )}
+                                Toggle Nav
+                            </button>
                             {auth.user ? (
                                 <Link
                                     href={adminPosts.url()}
@@ -109,7 +134,23 @@ export default function Namespace({
                     </div>
                 </header>
 
-                <div className="mx-auto max-w-7xl px-4 py-10">
+                <div className="mx-auto max-w-7xl px-4 py-10 lg:grid lg:grid-cols-[240px_1fr] lg:gap-12">
+                    {navVisible && (
+                        <aside className="mb-8 lg:mb-0 lg:block">
+                            <div className="lg:sticky lg:top-24">
+                                <p className="mb-3 text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                                    {navRoot.name}
+                                </p>
+                                <div className="max-h-[calc(100vh-7rem)] overflow-y-auto pr-1">
+                                    <ContentNavTree
+                                        currentPath={namespace.full_path}
+                                        root={navRoot}
+                                    />
+                                </div>
+                            </div>
+                        </aside>
+                    )}
+
                     <main className="space-y-12">
                         <section className="space-y-3">
                             <p className="text-sm text-muted-foreground">

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -7,6 +7,9 @@ import {
     PanelRightOpen,
 } from 'lucide-react';
 import { useState } from 'react';
+import ContentNavTree, {
+    type ContentNavNode,
+} from '@/components/content-nav-tree';
 import MarkdownContent from '@/components/markdown-content';
 import TableOfContents from '@/components/table-of-contents';
 import { useMarkdownToc } from '@/hooks/use-markdown-toc';
@@ -32,24 +35,16 @@ type Post = {
     published_at: string;
 };
 
-type NavPost = {
-    id: number;
-    slug: string;
-    full_path: string;
-    title: string;
-    published_at: string;
-};
-
 export default function Show({
     breadcrumbs,
+    navRoot,
     namespace,
     post,
-    posts,
 }: {
     breadcrumbs: Array<{ name: string; full_path: string }>;
+    navRoot: ContentNavNode;
     namespace: PostNamespace;
     post: Post;
-    posts: NavPost[];
 }) {
     const { auth } = usePage<{
         auth: { user: { id: number; name: string } | null };
@@ -60,9 +55,9 @@ export default function Show({
     const [tocOverride, setTocOverride] = useState<boolean | null>(null);
     const [navOverride, setNavOverride] = useState<boolean | null>(null);
     const tocVisible = tocOverride ?? !isMobile;
-    const hasNav = posts.length > 1;
+    const hasNav = navRoot.children.length > 0 || navRoot.posts.length > 0;
     const hasHeadings = (entry?.headings.length ?? 0) > 0;
-    const navVisible = navOverride ?? true;
+    const navVisible = navOverride ?? !isMobile;
 
     let gridCols = '';
 
@@ -145,6 +140,24 @@ export default function Show({
                                     Toggle TOC
                                 </button>
                             )}
+                            {hasNav && (
+                                <button
+                                    type="button"
+                                    onClick={() =>
+                                        setNavOverride(
+                                            (prev) => !(prev ?? !isMobile),
+                                        )
+                                    }
+                                    className="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                                >
+                                    {navVisible ? (
+                                        <PanelLeftClose size={16} />
+                                    ) : (
+                                        <PanelLeftOpen size={16} />
+                                    )}
+                                    Toggle Nav
+                                </button>
+                            )}
                             {auth.user ? (
                                 <Link
                                     href={adminPosts.url()}
@@ -168,30 +181,19 @@ export default function Show({
                     className={`mx-auto max-w-7xl px-4 py-10 ${gridCols ? `lg:grid lg:gap-12 ${gridCols}` : ''}`}
                 >
                     {hasNav && (
-                        <aside className="hidden self-start lg:sticky lg:top-24 lg:block">
+                        <aside className="self-start lg:sticky lg:top-24">
                             {navVisible ? (
-                                <nav className="flex max-h-[calc(100vh-7rem)] flex-col text-sm">
+                                <div className="flex max-h-[calc(100vh-7rem)] flex-col text-sm">
                                     <div className="mb-3 shrink-0">
                                         <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
-                                            {namespace.name}
+                                            {navRoot.name}
                                         </p>
                                     </div>
-                                    <div className="min-h-0 flex-1 space-y-1 overflow-y-auto pr-1">
-                                        {posts.map((p) => (
-                                            <Link
-                                                key={p.id}
-                                                href={contentPath.url(
-                                                    p.full_path,
-                                                )}
-                                                className={`block rounded px-2 py-1.5 leading-snug transition-colors ${
-                                                    p.slug === post.slug
-                                                        ? 'bg-accent font-medium text-accent-foreground'
-                                                        : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
-                                                }`}
-                                            >
-                                                {p.title}
-                                            </Link>
-                                        ))}
+                                    <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+                                        <ContentNavTree
+                                            currentPath={post.full_path}
+                                            root={navRoot}
+                                        />
                                     </div>
                                     <div className="mt-4 shrink-0 border-t pt-3">
                                         <button
@@ -206,7 +208,7 @@ export default function Show({
                                             Close
                                         </button>
                                     </div>
-                                </nav>
+                                </div>
                             ) : (
                                 <div>
                                     <button

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -75,9 +75,12 @@ test('published namespace shows child namespaces and direct posts', function () 
         ->assertInertia(fn ($page) => $page
             ->component('posts/namespace')
             ->where('namespace.full_path', $namespace->full_path)
+            ->where('navRoot.full_path', $namespace->full_path)
             ->has('children', 1)
+            ->where('navRoot.children.0.full_path', $child->full_path)
             ->where('children.0.full_path', $child->full_path)
             ->where('posts.0.full_path', $post->full_path)
+            ->where('navRoot.posts.0.full_path', $post->full_path)
         );
 });
 
@@ -143,6 +146,9 @@ test('published namespace shows post with breadcrumbs', function () {
         ->assertSuccessful()
         ->assertInertia(fn ($page) => $page
             ->component('posts/show')
+            ->where('navRoot.full_path', $root->full_path)
+            ->where('navRoot.children.0.full_path', $child->full_path)
+            ->where('navRoot.children.0.posts.0.full_path', $post->full_path)
             ->where('namespace.full_path', $child->full_path)
             ->where('post.full_path', $post->full_path)
             ->where('breadcrumbs.0.full_path', $root->full_path)


### PR DESCRIPTION
## Summary
- add a reusable public content nav tree component
- expose navRoot from the public post controller using the root namespace tree
- show the tree on namespace and post pages with toggle controls
- add feature coverage for navRoot on namespace and post responses
