### PR TITLE
Freeze markdown syntax manifest

### DIFF
--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -26,6 +26,10 @@ import { MarkdownTooltip } from '@/components/markdown-tooltip';
 import { MarkdownTree } from '@/components/markdown-tree';
 import { MarkdownUpdate } from '@/components/markdown-update';
 import {
+    MARKDOWN_CALLOUT_VARIANTS,
+    MARKDOWN_CUSTOM_COMPONENT_NAMES,
+} from '@/lib/markdown-syntax-manifest';
+import {
     preprocessMarkdownContent,
     preprocessMarkdownSyntax,
 } from '@/lib/markdown-syntax';
@@ -106,7 +110,9 @@ const CALLOUT_CONFIG = {
     },
 } as const;
 
-type CalloutType = keyof typeof CALLOUT_CONFIG;
+type CalloutType = (typeof MARKDOWN_CALLOUT_VARIANTS)[number];
+type CustomMarkdownComponentName =
+    (typeof MARKDOWN_CUSTOM_COMPONENT_NAMES)[number];
 
 function MessageBox({
     children,
@@ -152,25 +158,10 @@ export default function MarkdownContent({
     content,
     components,
 }: MarkdownContentProps) {
-    const markdownComponents: Components & {
-        tabs?: (props: Record<string, unknown>) => React.ReactElement;
-        tab?: (props: Record<string, unknown>) => React.ReactElement;
-        card?: (props: Record<string, unknown>) => React.ReactElement;
-        cardgroup?: (props: Record<string, unknown>) => React.ReactElement;
-        steps?: (props: Record<string, unknown>) => React.ReactElement;
-        step?: (props: Record<string, unknown>) => React.ReactElement;
-        responsefield?: (props: Record<string, unknown>) => React.ReactElement;
-        paramfield?: (props: Record<string, unknown>) => React.ReactElement;
-        codegroup?: (props: Record<string, unknown>) => React.ReactElement;
-        badge?: (props: Record<string, unknown>) => React.ReactElement;
-        tooltip?: (props: Record<string, unknown>) => React.ReactElement;
-        update?: (props: Record<string, unknown>) => React.ReactElement;
-        tree?: (props: Record<string, unknown>) => React.ReactElement;
-    } = {
-        pre: ({ children }) => <>{children}</>,
-        aside: MessageBox,
-        details: DetailsBox,
-        summary: SummaryEl,
+    const customMarkdownComponents: Record<
+        CustomMarkdownComponentName,
+        (props: Record<string, unknown>) => React.ReactElement
+    > = {
         tabs: (props: Record<string, unknown>) => <MarkdownTabs {...props} />,
         tab: (props: Record<string, unknown>) => <MarkdownTab {...props} />,
         card: (props: Record<string, unknown>) => (
@@ -222,6 +213,14 @@ export default function MarkdownContent({
         tree: (props: Record<string, unknown>) => (
             <MarkdownTree {...(props as Parameters<typeof MarkdownTree>[0])} />
         ),
+    };
+
+    const markdownComponents: Components &
+        Partial<typeof customMarkdownComponents> = {
+        pre: ({ children }) => <>{children}</>,
+        aside: MessageBox,
+        details: DetailsBox,
+        summary: SummaryEl,
         dl: ({ node, ...props }) => {
             void node;
 
@@ -251,6 +250,7 @@ export default function MarkdownContent({
 
             return <div {...props} />;
         },
+        ...customMarkdownComponents,
         ...components,
     };
 

--- a/resources/js/lib/markdown-syntax-manifest.ts
+++ b/resources/js/lib/markdown-syntax-manifest.ts
@@ -1,0 +1,123 @@
+export const MARKDOWN_DIRECTIVE_ATTRIBUTE_NAMES = [
+    'title',
+    'icon',
+    'sync',
+    'borderBottom',
+    'href',
+    'cols',
+    'name',
+    'type',
+    'required',
+    'default',
+    'deprecated',
+    'path',
+    'query',
+    'body',
+    'color',
+    'size',
+    'shape',
+    'stroke',
+    'disabled',
+    'tip',
+    'headline',
+    'cta',
+    'label',
+    'description',
+    'tags',
+] as const;
+
+export const MINTLIFY_CALLOUT_TAGS = {
+    Note: ':::message{.note}',
+    Tip: ':::message{.tip}',
+    Info: ':::message',
+    Warning: ':::message{.alert}',
+    Check: ':::message{.check}',
+} as const;
+
+export const MINTLIFY_CALLOUT_TAG_NAMES = [
+    'Note',
+    'Tip',
+    'Info',
+    'Warning',
+    'Check',
+] as const;
+
+export const MINTLIFY_BLOCK_TAG_NAMES = [
+    'Card',
+    'CardGroup',
+    'Columns',
+    'Tabs',
+    'Tab',
+    'Accordion',
+    'Steps',
+    'Step',
+    'ResponseField',
+    'ParamField',
+    'CodeGroup',
+    'Update',
+    ...MINTLIFY_CALLOUT_TAG_NAMES,
+] as const;
+
+export const MINTLIFY_INLINE_TAG_NAMES = ['Badge', 'Tooltip'] as const;
+
+export const MINTLIFY_TREE_TAG_NAMES = [
+    'Tree',
+    'Tree.Folder',
+    'Tree.File',
+] as const;
+
+export const MINTLIFY_MULTILINE_JOINABLE_TAG_NAMES = [
+    ...MINTLIFY_BLOCK_TAG_NAMES,
+    ...MINTLIFY_INLINE_TAG_NAMES,
+] as const;
+
+export const ZENN_MESSAGE_VARIANTS = [
+    'alert',
+    'note',
+    'tip',
+    'info',
+    'check',
+] as const;
+
+export const ZENN_EMBED_DIRECTIVES = ['card', 'github'] as const;
+
+export const MARKDOWN_CALLOUT_VARIANTS = [
+    'note',
+    'tip',
+    'info',
+    'alert',
+    'check',
+] as const;
+
+export const MARKDOWN_CUSTOM_COMPONENT_NAMES = [
+    'tabs',
+    'tab',
+    'card',
+    'cardgroup',
+    'steps',
+    'step',
+    'responsefield',
+    'paramfield',
+    'codegroup',
+    'badge',
+    'tooltip',
+    'update',
+    'tree',
+] as const;
+
+export const MARKDOWN_SYNTAX_MANIFEST = {
+    directiveAttributes: [...MARKDOWN_DIRECTIVE_ATTRIBUTE_NAMES],
+    mintlify: {
+        blockTags: [...MINTLIFY_BLOCK_TAG_NAMES],
+        inlineTags: [...MINTLIFY_INLINE_TAG_NAMES],
+        treeTags: [...MINTLIFY_TREE_TAG_NAMES],
+        multilineJoinableTags: [...MINTLIFY_MULTILINE_JOINABLE_TAG_NAMES],
+        calloutTags: { ...MINTLIFY_CALLOUT_TAGS },
+    },
+    zenn: {
+        messageVariants: [...ZENN_MESSAGE_VARIANTS],
+        embedDirectives: [...ZENN_EMBED_DIRECTIVES],
+    },
+    rendererComponents: [...MARKDOWN_CUSTOM_COMPONENT_NAMES],
+    calloutVariants: [...MARKDOWN_CALLOUT_VARIANTS],
+} as const;

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -1,3 +1,12 @@
+import {
+    MARKDOWN_DIRECTIVE_ATTRIBUTE_NAMES,
+    MINTLIFY_CALLOUT_TAG_NAMES,
+    MINTLIFY_CALLOUT_TAGS,
+    MINTLIFY_MULTILINE_JOINABLE_TAG_NAMES,
+    ZENN_EMBED_DIRECTIVES,
+    ZENN_MESSAGE_VARIANTS,
+} from './markdown-syntax-manifest.js';
+
 const IMAGE_WIDTH_PARAM = '__markdown_width';
 const IMAGE_HEIGHT_PARAM = '__markdown_height';
 const IMAGE_CAPTION_PARAM = '__markdown_caption';
@@ -143,33 +152,9 @@ function buildDirectiveAttributes(
     attributes: Record<string, string | boolean>,
 ): string {
     const supportedEntries = Object.entries(attributes).filter(([key]) =>
-        [
-            'title',
-            'icon',
-            'sync',
-            'borderBottom',
-            'href',
-            'cols',
-            'name',
-            'type',
-            'required',
-            'default',
-            'deprecated',
-            'path',
-            'query',
-            'body',
-            'color',
-            'size',
-            'shape',
-            'stroke',
-            'disabled',
-            'tip',
-            'headline',
-            'cta',
-            'label',
-            'description',
-            'tags',
-        ].includes(key),
+        MARKDOWN_DIRECTIVE_ATTRIBUTE_NAMES.includes(
+            key as (typeof MARKDOWN_DIRECTIVE_ATTRIBUTE_NAMES)[number],
+        ),
     );
 
     if (supportedEntries.length === 0) {
@@ -189,41 +174,15 @@ function buildDirectiveAttributes(
     return `{${serialized}}`;
 }
 
-const MINTLIFY_CALLOUT_TAGS = {
-    Note: ':::message{.note}',
-    Tip: ':::message{.tip}',
-    Info: ':::message',
-    Warning: ':::message{.alert}',
-    Check: ':::message{.check}',
-} as const;
-
 type MintlifyCalloutTag = keyof typeof MINTLIFY_CALLOUT_TAGS;
 
-const MULTILINE_JOINABLE_TAGS = [
-    'Card',
-    'CardGroup',
-    'Columns',
-    'Tabs',
-    'Tab',
-    'Accordion',
-    'Steps',
-    'Step',
-    'ResponseField',
-    'ParamField',
-    'CodeGroup',
-    'Update',
-    'Badge',
-    'Tooltip',
-    'Note',
-    'Tip',
-    'Info',
-    'Warning',
-    'Check',
-];
-
 const MULTILINE_TAG_OPEN_RE = new RegExp(
-    `^<(${MULTILINE_JOINABLE_TAGS.join('|')})(?:\\s|$)`,
+    `^<(${MINTLIFY_MULTILINE_JOINABLE_TAG_NAMES.join('|')})(?:\\s|$)`,
 );
+
+const MINTLIFY_CALLOUT_TAG_PATTERN = MINTLIFY_CALLOUT_TAG_NAMES.join('|');
+const ZENN_MESSAGE_VARIANT_PATTERN = ZENN_MESSAGE_VARIANTS.join('|');
+const ZENN_EMBED_DIRECTIVE_PATTERN = ZENN_EMBED_DIRECTIVES.join('|');
 
 function joinMultilineJsxTags(markdown: string): string {
     const lines = markdown.split('\n');
@@ -408,9 +367,9 @@ export function preprocessMintlifySyntax(markdown: string): string {
         }
 
         // Mintlify callout open tag: <Note>, <Tip>, <Info>, <Warning>, <Check>
-        const calloutOpenMatch = /^<(?<tag>Note|Tip|Info|Warning|Check)>$/.exec(
-            trimmedLine,
-        );
+        const calloutOpenMatch = new RegExp(
+            `^<(?<tag>${MINTLIFY_CALLOUT_TAG_PATTERN})>$`,
+        ).exec(trimmedLine);
 
         if (calloutOpenMatch) {
             const tag = calloutOpenMatch.groups!.tag as MintlifyCalloutTag;
@@ -424,8 +383,9 @@ export function preprocessMintlifySyntax(markdown: string): string {
             continue;
         }
 
-        const calloutCloseMatch =
-            /^<\/(?<tag>Note|Tip|Info|Warning|Check)>$/.exec(trimmedLine);
+        const calloutCloseMatch = new RegExp(
+            `^<\\/(?<tag>${MINTLIFY_CALLOUT_TAG_PATTERN})>$`,
+        ).exec(trimmedLine);
 
         if (calloutCloseMatch) {
             const tag = calloutCloseMatch.groups!.tag as MintlifyCalloutTag;
@@ -1034,15 +994,20 @@ export function preprocessMarkdownSyntax(markdown: string): string {
                 line
                     // Normalize :::message <type> to the attribute form remark-directive expects.
                     .replace(
-                        /:::message\s+(alert|note|tip|info|check)\b/,
+                        new RegExp(
+                            `:::message\\s+(${ZENN_MESSAGE_VARIANT_PATTERN})\\b`,
+                        ),
                         ':::message{.$1}',
                     )
                     // Convert :::details title to the label form remark-directive expects.
                     .replace(/:::details\s+(.+?)$/, ':::details[$1]')
-                    // Convert @[card](URL) to a bare URL line so remark-linkify-to-card picks it up.
-                    .replace(/^@\[card\]\((https?:\/\/[^\s)]+)\)$/, '$1')
-                    // Convert @[github](URL) to a bare URL line so remark-linkify-to-card picks it up.
-                    .replace(/^@\[github\]\((https?:\/\/[^\s)]+)\)$/, '$1'),
+                    // Convert Zenn embeds to bare URL lines so remark-linkify-to-card picks them up.
+                    .replace(
+                        new RegExp(
+                            `^@\\[(?:${ZENN_EMBED_DIRECTIVE_PATTERN})\\]\\((https?:\\/\\/[^\\s)]+)\\)$`,
+                        ),
+                        '$1',
+                    ),
             ),
         ),
     );

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -5,6 +5,7 @@ import {
     preprocessMarkdownContent,
     preprocessMarkdownSyntax,
 } from '../../resources/js/lib/markdown-syntax.ts';
+import { MARKDOWN_SYNTAX_MANIFEST } from '../../resources/js/lib/markdown-syntax-manifest.ts';
 
 test('preprocessMarkdownSyntax normalizes Zenn shorthand and Mintlify tabs', () => {
     const output = preprocessMarkdownSyntax(`:::message alert
@@ -136,6 +137,109 @@ test('preprocessMarkdownSyntax converts Mintlify callout tags to message directi
     assert.match(output, /:::message\n/);
     assert.match(output, /:::message\{\.alert\}/);
     assert.match(output, /:::message\{\.check\}/);
+});
+
+test('markdown syntax manifest freezes the supported extension surface', () => {
+    assert.deepEqual(MARKDOWN_SYNTAX_MANIFEST, {
+        directiveAttributes: [
+            'title',
+            'icon',
+            'sync',
+            'borderBottom',
+            'href',
+            'cols',
+            'name',
+            'type',
+            'required',
+            'default',
+            'deprecated',
+            'path',
+            'query',
+            'body',
+            'color',
+            'size',
+            'shape',
+            'stroke',
+            'disabled',
+            'tip',
+            'headline',
+            'cta',
+            'label',
+            'description',
+            'tags',
+        ],
+        mintlify: {
+            blockTags: [
+                'Card',
+                'CardGroup',
+                'Columns',
+                'Tabs',
+                'Tab',
+                'Accordion',
+                'Steps',
+                'Step',
+                'ResponseField',
+                'ParamField',
+                'CodeGroup',
+                'Update',
+                'Note',
+                'Tip',
+                'Info',
+                'Warning',
+                'Check',
+            ],
+            inlineTags: ['Badge', 'Tooltip'],
+            treeTags: ['Tree', 'Tree.Folder', 'Tree.File'],
+            multilineJoinableTags: [
+                'Card',
+                'CardGroup',
+                'Columns',
+                'Tabs',
+                'Tab',
+                'Accordion',
+                'Steps',
+                'Step',
+                'ResponseField',
+                'ParamField',
+                'CodeGroup',
+                'Update',
+                'Note',
+                'Tip',
+                'Info',
+                'Warning',
+                'Check',
+                'Badge',
+                'Tooltip',
+            ],
+            calloutTags: {
+                Note: ':::message{.note}',
+                Tip: ':::message{.tip}',
+                Info: ':::message',
+                Warning: ':::message{.alert}',
+                Check: ':::message{.check}',
+            },
+        },
+        zenn: {
+            messageVariants: ['alert', 'note', 'tip', 'info', 'check'],
+            embedDirectives: ['card', 'github'],
+        },
+        rendererComponents: [
+            'tabs',
+            'tab',
+            'card',
+            'cardgroup',
+            'steps',
+            'step',
+            'responsefield',
+            'paramfield',
+            'codegroup',
+            'badge',
+            'tooltip',
+            'update',
+            'tree',
+        ],
+        calloutVariants: ['note', 'tip', 'info', 'alert', 'check'],
+    });
 });
 
 test('preprocessMarkdownSyntax leaves Mintlify callout tags untouched inside fenced code blocks', () => {

--- a/tsconfig.markdown-tests.json
+++ b/tsconfig.markdown-tests.json
@@ -12,6 +12,7 @@
     },
     "include": [
         "resources/js/lib/markdown-card-href.ts",
+        "resources/js/lib/markdown-syntax-manifest.ts",
         "resources/js/lib/markdown-syntax.ts",
         "resources/js/lib/remark-tabs-directive.ts",
         "resources/js/lib/remark-card-directive.ts",


### PR DESCRIPTION
## Summary
- add a markdown syntax manifest as the single source of truth for the currently supported extension surface
- refactor the markdown preprocessor and renderer to consume the manifest instead of ad hoc allowlists
- freeze the current syntax set with a node-side regression test

## Testing
- npm run format:check
- npm run markdown:test
- npm run types:check
- npm run build