### PR TITLE
Fix hardcoded app branding label

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-APP_NAME=Laravel
+APP_NAME=ThinkStream
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true

--- a/resources/js/components/app-logo.tsx
+++ b/resources/js/components/app-logo.tsx
@@ -1,6 +1,9 @@
 import AppLogoIcon from '@/components/app-logo-icon';
+import { usePage } from '@inertiajs/react';
 
 export default function AppLogo() {
+    const { name } = usePage().props;
+
     return (
         <>
             <div className="flex aspect-square size-8 items-center justify-center rounded-md bg-sidebar-primary text-sidebar-primary-foreground">
@@ -8,7 +11,7 @@ export default function AppLogo() {
             </div>
             <div className="ml-1 grid flex-1 text-left text-sm">
                 <span className="mb-0.5 truncate leading-tight font-semibold">
-                    Laravel Starter Kit
+                    {name}
                 </span>
             </div>
         </>

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -3,14 +3,22 @@
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\RateLimiter;
+use Inertia\Testing\AssertableInertia as Assert;
 use Laravel\Fortify\Features;
 
 uses(RefreshDatabase::class);
 
 test('login screen can be rendered', function () {
+    config()->set('app.name', 'ThinkStream Test');
+
     $response = $this->get(route('login'));
 
     $response->assertOk();
+
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('auth/login')
+        ->where('name', 'ThinkStream Test'),
+    );
 });
 
 test('users can authenticate using the login screen', function () {


### PR DESCRIPTION
## Summary
- replace the hardcoded app label in `AppLogo` with the shared Inertia app name
- set the repository default `APP_NAME` in `.env.example` to `ThinkStream`
- add a regression test covering the shared app name on the login page

## Testing
- vendor/bin/sail npm run types:check
- vendor/bin/sail artisan test --compact tests/Feature/Auth/AuthenticationTest.php

Closes #1