### PR TITLE
Add fresh environment build workflow

### DIFF
--- a/.github/workflows/fresh-build.yml
+++ b/.github/workflows/fresh-build.yml
@@ -1,0 +1,51 @@
+name: fresh-build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/fresh-build.yml'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'resources/js/**'
+      - 'tsconfig.json'
+      - 'vite.config.ts'
+  schedule:
+    - cron: '0 3 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          tools: composer:v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build frontend assets
+        run: npm run build


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow for fresh-environment build verification
- run only composer install, npm ci, and npm run build on manual dispatch, weekly schedule, and pushes to main
- keep the existing test workflows unchanged because page-rendering tests still require built assets

## Notes
- current clean-worktree reproduction succeeds, so this addresses issue #8 by continuously checking the failure path instead of changing Prism code that is currently green

Closes #8