### PR TITLE
Add scheduled publishing controls for posts

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -6,7 +6,6 @@ use App\Models\Post;
 use App\Models\PostNamespace;
 use App\Support\ReservedContentPath;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -67,8 +66,8 @@ class PostController extends Controller
             ->withCount(['posts' => fn (Builder $query) => $this->applyPublishedPostScope($query)])
             ->get(['id', 'name', 'slug', 'full_path', 'description', 'cover_image']);
 
-        $posts = $this->applyPublishedPostScope($namespace->posts())
-            ->orderByRaw('published_at is null')
+        $posts = $namespace->posts()
+            ->tap(fn (Builder $query) => $this->applyPublishedPostScope($query))
             ->orderBy('published_at')
             ->orderBy('id')
             ->get(['id', 'slug', 'full_path', 'title', 'published_at']);
@@ -89,8 +88,8 @@ class PostController extends Controller
     {
         $namespace = $post->namespace;
         $rootNamespace = $this->rootNamespace($namespace, $ancestors);
-        $posts = $this->applyPublishedPostScope($namespace->posts())
-            ->orderByRaw('published_at is null')
+        $posts = $namespace->posts()
+            ->tap(fn (Builder $query) => $this->applyPublishedPostScope($query))
             ->orderBy('published_at')
             ->orderBy('id')
             ->get(['id', 'slug', 'full_path', 'title', 'published_at']);
@@ -112,14 +111,11 @@ class PostController extends Controller
         return $ancestors->first() ?? $namespace;
     }
 
-    private function applyPublishedPostScope(Builder|HasMany $query): Builder|HasMany
+    private function applyPublishedPostScope(Builder $query): Builder
     {
         return $query
             ->where('is_draft', false)
-            ->where(function (Builder $query): void {
-                $query->whereNull('published_at')
-                    ->orWhere('published_at', '<=', now());
-            });
+            ->where('published_at', '<=', now());
     }
 
     /**
@@ -136,8 +132,8 @@ class PostController extends Controller
             ->where('is_published', true)
             ->get(['id', 'slug', 'full_path', 'name', 'post_order']);
 
-        $posts = $namespace->sortPosts($this->applyPublishedPostScope($namespace->posts())
-            ->orderByRaw('published_at is null')
+        $posts = $namespace->sortPosts($namespace->posts()
+            ->tap(fn (Builder $query) => $this->applyPublishedPostScope($query))
             ->orderBy('published_at')
             ->orderBy('id')
             ->get(['title', 'full_path', 'slug']));

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use App\Models\Post;
 use App\Models\PostNamespace;
 use App\Support\ReservedContentPath;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -16,7 +18,7 @@ class PostController extends Controller
         return Inertia::render('posts/index', [
             'namespaces' => PostNamespace::published()
                 ->whereNull('parent_id')
-                ->withCount(['posts' => fn ($q) => $q->where('is_draft', false)])
+                ->withCount(['posts' => fn (Builder $query) => $this->applyPublishedPostScope($query)])
                 ->orderBy('name')
                 ->get(['id', 'slug', 'full_path', 'name', 'description', 'cover_image']),
         ]);
@@ -31,7 +33,7 @@ class PostController extends Controller
         $post = Post::query()
             ->with('namespace:id,parent_id,slug,full_path,name,cover_image,is_published')
             ->where('full_path', $normalizedPath)
-            ->where('is_draft', false)
+            ->tap(fn (Builder $query) => $this->applyPublishedPostScope($query))
             ->first();
 
         if ($post) {
@@ -62,11 +64,11 @@ class PostController extends Controller
         $rootNamespace = $this->rootNamespace($namespace, $ancestors);
         $children = $namespace->children()
             ->where('is_published', true)
-            ->withCount(['posts' => fn ($query) => $query->where('is_draft', false)])
+            ->withCount(['posts' => fn (Builder $query) => $this->applyPublishedPostScope($query)])
             ->get(['id', 'name', 'slug', 'full_path', 'description', 'cover_image']);
 
-        $posts = $namespace->posts()
-            ->where('is_draft', false)
+        $posts = $this->applyPublishedPostScope($namespace->posts())
+            ->orderByRaw('published_at is null')
             ->orderBy('published_at')
             ->orderBy('id')
             ->get(['id', 'slug', 'full_path', 'title', 'published_at']);
@@ -87,8 +89,8 @@ class PostController extends Controller
     {
         $namespace = $post->namespace;
         $rootNamespace = $this->rootNamespace($namespace, $ancestors);
-        $posts = $namespace->posts()
-            ->where('is_draft', false)
+        $posts = $this->applyPublishedPostScope($namespace->posts())
+            ->orderByRaw('published_at is null')
             ->orderBy('published_at')
             ->orderBy('id')
             ->get(['id', 'slug', 'full_path', 'title', 'published_at']);
@@ -110,6 +112,16 @@ class PostController extends Controller
         return $ancestors->first() ?? $namespace;
     }
 
+    private function applyPublishedPostScope(Builder|HasMany $query): Builder|HasMany
+    {
+        return $query
+            ->where('is_draft', false)
+            ->where(function (Builder $query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            });
+    }
+
     /**
      * @return array{
      *     name: string,
@@ -124,13 +136,11 @@ class PostController extends Controller
             ->where('is_published', true)
             ->get(['id', 'slug', 'full_path', 'name', 'post_order']);
 
-        $posts = $namespace->sortPosts(
-            $namespace->posts()
-                ->where('is_draft', false)
-                ->orderBy('published_at')
-                ->orderBy('id')
-                ->get(['title', 'full_path', 'slug'])
-        );
+        $posts = $namespace->sortPosts($this->applyPublishedPostScope($namespace->posts())
+            ->orderByRaw('published_at is null')
+            ->orderBy('published_at')
+            ->orderBy('id')
+            ->get(['title', 'full_path', 'slug']));
 
         return [
             'name' => $namespace->name,

--- a/app/Http/Requests/Admin/StorePostRequest.php
+++ b/app/Http/Requests/Admin/StorePostRequest.php
@@ -13,6 +13,27 @@ class StorePostRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('is_draft')) {
+            $this->merge([
+                'is_draft' => $this->boolean('is_draft'),
+            ]);
+        }
+
+        if ($this->input('published_at') === '') {
+            $this->merge([
+                'published_at' => null,
+            ]);
+        }
+
+        if (! $this->boolean('is_draft') && $this->input('published_at') === null) {
+            $this->merge([
+                'published_at' => now()->toDateTimeString(),
+            ]);
+        }
+    }
+
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
      */

--- a/app/Http/Requests/Admin/UpdatePostRequest.php
+++ b/app/Http/Requests/Admin/UpdatePostRequest.php
@@ -13,6 +13,27 @@ class UpdatePostRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('is_draft')) {
+            $this->merge([
+                'is_draft' => $this->boolean('is_draft'),
+            ]);
+        }
+
+        if ($this->input('published_at') === '') {
+            $this->merge([
+                'published_at' => null,
+            ]);
+        }
+
+        if (! $this->boolean('is_draft') && $this->input('published_at') === null) {
+            $this->merge([
+                'published_at' => now()->toDateTimeString(),
+            ]);
+        }
+    }
+
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
      */

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -43,4 +43,12 @@ class PostFactory extends Factory
             'published_at' => now(),
         ]);
     }
+
+    public function scheduled(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_draft' => false,
+            'published_at' => now()->addDay(),
+        ]);
+    }
 }

--- a/resources/js/components/ui/switch.tsx
+++ b/resources/js/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as SwitchPrimitive from "@radix-ui/react-switch"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-5 w-9 shrink-0 items-center rounded-full border-2 border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="bg-background pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/resources/js/pages/admin/posts/create.tsx
+++ b/resources/js/pages/admin/posts/create.tsx
@@ -45,18 +45,35 @@ export default function Create({ namespace }: { namespace: Namespace }) {
     const [isDraft, setIsDraft] = useState(false);
     const [scheduleEnabled, setScheduleEnabled] = useState(false);
     const [publishedAt, setPublishedAt] = useState('');
+    const [relativeTimeHint, setRelativeTimeHint] = useState<string | null>(
+        null,
+    );
 
-    function getRelativeTimeHint(value: string): string | null {
-        if (!value) return null;
-        const diff = new Date(value).getTime() - Date.now();
-        if (diff <= 0) return 'This date is in the past.';
+    function getRelativeTimeHint(value: string, now: number): string | null {
+        if (!value) {
+            return null;
+        }
+
+        const diff = new Date(value).getTime() - now;
+
+        if (diff <= 0) {
+            return 'This date is in the past.';
+        }
+
         const minutes = Math.round(diff / 60000);
-        if (minutes < 60)
+
+        if (minutes < 60) {
             return `Publishes in ${minutes} minute${minutes !== 1 ? 's' : ''}.`;
+        }
+
         const hours = Math.round(diff / 3600000);
-        if (hours < 24)
+
+        if (hours < 24) {
             return `Publishes in ${hours} hour${hours !== 1 ? 's' : ''}.`;
+        }
+
         const days = Math.round(diff / 86400000);
+
         return `Publishes in ${days} day${days !== 1 ? 's' : ''}.`;
     }
 
@@ -129,9 +146,15 @@ export default function Create({ namespace }: { namespace: Namespace }) {
                                 <Checkbox
                                     id="is_draft"
                                     checked={isDraft}
-                                    onCheckedChange={(checked) =>
-                                        setIsDraft(checked === true)
-                                    }
+                                    onCheckedChange={(checked) => {
+                                        const nextIsDraft = checked === true;
+
+                                        setIsDraft(nextIsDraft);
+
+                                        if (nextIsDraft) {
+                                            setRelativeTimeHint(null);
+                                        }
+                                    }}
                                 />
                                 <Label htmlFor="is_draft">Save as draft</Label>
                             </div>
@@ -143,7 +166,11 @@ export default function Create({ namespace }: { namespace: Namespace }) {
                                         checked={scheduleEnabled && !isDraft}
                                         onCheckedChange={(checked) => {
                                             setScheduleEnabled(checked);
-                                            if (!checked) setPublishedAt('');
+
+                                            if (!checked) {
+                                                setPublishedAt('');
+                                                setRelativeTimeHint(null);
+                                            }
                                         }}
                                         disabled={isDraft}
                                     />
@@ -167,15 +194,22 @@ export default function Create({ namespace }: { namespace: Namespace }) {
                                             type="datetime-local"
                                             className="w-fit"
                                             value={publishedAt}
-                                            onChange={(e) =>
-                                                setPublishedAt(e.target.value)
-                                            }
+                                            onChange={(e) => {
+                                                const nextValue =
+                                                    e.target.value;
+
+                                                setPublishedAt(nextValue);
+                                                setRelativeTimeHint(
+                                                    getRelativeTimeHint(
+                                                        nextValue,
+                                                        Date.now(),
+                                                    ),
+                                                );
+                                            }}
                                         />
-                                        {getRelativeTimeHint(publishedAt) && (
+                                        {relativeTimeHint && (
                                             <p className="text-sm text-muted-foreground">
-                                                {getRelativeTimeHint(
-                                                    publishedAt,
-                                                )}
+                                                {relativeTimeHint}
                                             </p>
                                         )}
                                     </div>

--- a/resources/js/pages/admin/posts/create.tsx
+++ b/resources/js/pages/admin/posts/create.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { dashboard } from '@/routes';
 import {
     index,
@@ -42,6 +43,22 @@ export default function Create({ namespace }: { namespace: Namespace }) {
     const [slug, setSlug] = useState('');
     const [slugTouched, setSlugTouched] = useState(false);
     const [isDraft, setIsDraft] = useState(false);
+    const [scheduleEnabled, setScheduleEnabled] = useState(false);
+    const [publishedAt, setPublishedAt] = useState('');
+
+    function getRelativeTimeHint(value: string): string | null {
+        if (!value) return null;
+        const diff = new Date(value).getTime() - Date.now();
+        if (diff <= 0) return 'This date is in the past.';
+        const minutes = Math.round(diff / 60000);
+        if (minutes < 60)
+            return `Publishes in ${minutes} minute${minutes !== 1 ? 's' : ''}.`;
+        const hours = Math.round(diff / 3600000);
+        if (hours < 24)
+            return `Publishes in ${hours} hour${hours !== 1 ? 's' : ''}.`;
+        const days = Math.round(diff / 86400000);
+        return `Publishes in ${days} day${days !== 1 ? 's' : ''}.`;
+    }
 
     function handleTitleChange(e: React.ChangeEvent<HTMLInputElement>) {
         if (!slugTouched) {
@@ -119,20 +136,50 @@ export default function Create({ namespace }: { namespace: Namespace }) {
                                 <Label htmlFor="is_draft">Save as draft</Label>
                             </div>
 
-                            <div className="grid gap-2">
-                                <Label htmlFor="published_at">
-                                    Publish date (optional)
-                                </Label>
-                                <Input
-                                    id="published_at"
+                            <div className="grid gap-3">
+                                <div className="flex items-center gap-3">
+                                    <Switch
+                                        id="schedule_toggle"
+                                        checked={scheduleEnabled && !isDraft}
+                                        onCheckedChange={(checked) => {
+                                            setScheduleEnabled(checked);
+                                            if (!checked) setPublishedAt('');
+                                        }}
+                                        disabled={isDraft}
+                                    />
+                                    <Label htmlFor="schedule_toggle">
+                                        Enable scheduled publishing
+                                    </Label>
+                                </div>
+                                <input
+                                    type="hidden"
                                     name="published_at"
-                                    type="datetime-local"
-                                    className="w-fit"
-                                    disabled={isDraft}
+                                    value={
+                                        scheduleEnabled && !isDraft
+                                            ? publishedAt
+                                            : ''
+                                    }
                                 />
-                                <p className="text-xs text-muted-foreground">
-                                    Leave blank to publish immediately.
-                                </p>
+                                {scheduleEnabled && !isDraft && (
+                                    <div className="flex flex-wrap items-center gap-3">
+                                        <Input
+                                            id="published_at"
+                                            type="datetime-local"
+                                            className="w-fit"
+                                            value={publishedAt}
+                                            onChange={(e) =>
+                                                setPublishedAt(e.target.value)
+                                            }
+                                        />
+                                        {getRelativeTimeHint(publishedAt) && (
+                                            <p className="text-sm text-muted-foreground">
+                                                {getRelativeTimeHint(
+                                                    publishedAt,
+                                                )}
+                                            </p>
+                                        )}
+                                    </div>
+                                )}
                                 <InputError message={errors.published_at} />
                             </div>
 

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -50,18 +50,35 @@ export default function Edit({
     const [publishedAt, setPublishedAt] = useState(
         isFutureDate ? initialPublishedAt : '',
     );
+    const [relativeTimeHint, setRelativeTimeHint] = useState<string | null>(
+        null,
+    );
 
-    function getRelativeTimeHint(value: string): string | null {
-        if (!value) return null;
-        const diff = new Date(value).getTime() - Date.now();
-        if (diff <= 0) return 'This date is in the past.';
+    function getRelativeTimeHint(value: string, now: number): string | null {
+        if (!value) {
+            return null;
+        }
+
+        const diff = new Date(value).getTime() - now;
+
+        if (diff <= 0) {
+            return 'This date is in the past.';
+        }
+
         const minutes = Math.round(diff / 60000);
-        if (minutes < 60)
+
+        if (minutes < 60) {
             return `Publishes in ${minutes} minute${minutes !== 1 ? 's' : ''}.`;
+        }
+
         const hours = Math.round(diff / 3600000);
-        if (hours < 24)
+
+        if (hours < 24) {
             return `Publishes in ${hours} hour${hours !== 1 ? 's' : ''}.`;
+        }
+
         const days = Math.round(diff / 86400000);
+
         return `Publishes in ${days} day${days !== 1 ? 's' : ''}.`;
     }
 
@@ -141,9 +158,15 @@ export default function Edit({
                                 <Checkbox
                                     id="is_draft"
                                     checked={isDraft}
-                                    onCheckedChange={(checked) =>
-                                        setIsDraft(checked === true)
-                                    }
+                                    onCheckedChange={(checked) => {
+                                        const nextIsDraft = checked === true;
+
+                                        setIsDraft(nextIsDraft);
+
+                                        if (nextIsDraft) {
+                                            setRelativeTimeHint(null);
+                                        }
+                                    }}
                                 />
                                 <Label htmlFor="is_draft">Save as draft</Label>
                             </div>
@@ -155,7 +178,11 @@ export default function Edit({
                                         checked={scheduleEnabled && !isDraft}
                                         onCheckedChange={(checked) => {
                                             setScheduleEnabled(checked);
-                                            if (!checked) setPublishedAt('');
+
+                                            if (!checked) {
+                                                setPublishedAt('');
+                                                setRelativeTimeHint(null);
+                                            }
                                         }}
                                         disabled={isDraft}
                                     />
@@ -179,15 +206,22 @@ export default function Edit({
                                             type="datetime-local"
                                             className="w-fit"
                                             value={publishedAt}
-                                            onChange={(e) =>
-                                                setPublishedAt(e.target.value)
-                                            }
+                                            onChange={(e) => {
+                                                const nextValue =
+                                                    e.target.value;
+
+                                                setPublishedAt(nextValue);
+                                                setRelativeTimeHint(
+                                                    getRelativeTimeHint(
+                                                        nextValue,
+                                                        Date.now(),
+                                                    ),
+                                                );
+                                            }}
                                         />
-                                        {getRelativeTimeHint(publishedAt) && (
+                                        {relativeTimeHint && (
                                             <p className="text-sm text-muted-foreground">
-                                                {getRelativeTimeHint(
-                                                    publishedAt,
-                                                )}
+                                                {relativeTimeHint}
                                             </p>
                                         )}
                                     </div>

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { dashboard } from '@/routes';
 import {
     index,
@@ -36,11 +37,33 @@ export default function Edit({
     namespace: Namespace;
     post: Post;
 }) {
-    const publishedAt = post.published_at
+    const initialPublishedAt = post.published_at
         ? new Date(post.published_at).toISOString().slice(0, 16)
         : '';
 
+    const isFutureDate = post.published_at
+        ? new Date(post.published_at) > new Date()
+        : false;
+
     const [isDraft, setIsDraft] = useState(post.is_draft);
+    const [scheduleEnabled, setScheduleEnabled] = useState(isFutureDate);
+    const [publishedAt, setPublishedAt] = useState(
+        isFutureDate ? initialPublishedAt : '',
+    );
+
+    function getRelativeTimeHint(value: string): string | null {
+        if (!value) return null;
+        const diff = new Date(value).getTime() - Date.now();
+        if (diff <= 0) return 'This date is in the past.';
+        const minutes = Math.round(diff / 60000);
+        if (minutes < 60)
+            return `Publishes in ${minutes} minute${minutes !== 1 ? 's' : ''}.`;
+        const hours = Math.round(diff / 3600000);
+        if (hours < 24)
+            return `Publishes in ${hours} hour${hours !== 1 ? 's' : ''}.`;
+        const days = Math.round(diff / 86400000);
+        return `Publishes in ${days} day${days !== 1 ? 's' : ''}.`;
+    }
 
     setLayoutProps({
         breadcrumbs: [
@@ -125,21 +148,50 @@ export default function Edit({
                                 <Label htmlFor="is_draft">Save as draft</Label>
                             </div>
 
-                            <div className="grid gap-2">
-                                <Label htmlFor="published_at">
-                                    Publish date (optional)
-                                </Label>
-                                <Input
-                                    id="published_at"
+                            <div className="grid gap-3">
+                                <div className="flex items-center gap-3">
+                                    <Switch
+                                        id="schedule_toggle"
+                                        checked={scheduleEnabled && !isDraft}
+                                        onCheckedChange={(checked) => {
+                                            setScheduleEnabled(checked);
+                                            if (!checked) setPublishedAt('');
+                                        }}
+                                        disabled={isDraft}
+                                    />
+                                    <Label htmlFor="schedule_toggle">
+                                        Enable scheduled publishing
+                                    </Label>
+                                </div>
+                                <input
+                                    type="hidden"
                                     name="published_at"
-                                    type="datetime-local"
-                                    defaultValue={publishedAt}
-                                    className="w-fit"
-                                    disabled={isDraft}
+                                    value={
+                                        scheduleEnabled && !isDraft
+                                            ? publishedAt
+                                            : ''
+                                    }
                                 />
-                                <p className="text-xs text-muted-foreground">
-                                    Leave blank to publish immediately.
-                                </p>
+                                {scheduleEnabled && !isDraft && (
+                                    <div className="flex flex-wrap items-center gap-3">
+                                        <Input
+                                            id="published_at"
+                                            type="datetime-local"
+                                            className="w-fit"
+                                            value={publishedAt}
+                                            onChange={(e) =>
+                                                setPublishedAt(e.target.value)
+                                            }
+                                        />
+                                        {getRelativeTimeHint(publishedAt) && (
+                                            <p className="text-sm text-muted-foreground">
+                                                {getRelativeTimeHint(
+                                                    publishedAt,
+                                                )}
+                                            </p>
+                                        )}
+                                    </div>
+                                )}
                                 <InputError message={errors.published_at} />
                             </div>
 

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -1,5 +1,6 @@
 import { Head, Link } from '@inertiajs/react';
 import { Form } from '@inertiajs/react';
+import { CheckCircle2, FilePen } from 'lucide-react';
 import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import { Button } from '@/components/ui/button';
 import { dashboard } from '@/routes';
@@ -86,17 +87,17 @@ export default function Index({ namespaces }: { namespaces: Namespace[] }) {
                                             {ns.slug}
                                         </td>
                                         <td className="px-4 py-3">
-                                            <span
-                                                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-                                                    ns.is_published
-                                                        ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
-                                                        : 'bg-muted text-muted-foreground'
-                                                }`}
-                                            >
-                                                {ns.is_published
-                                                    ? 'Published'
-                                                    : 'Draft'}
-                                            </span>
+                                            {ns.is_published ? (
+                                                <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
+                                                    <CheckCircle2 className="size-3" />
+                                                    Published
+                                                </span>
+                                            ) : (
+                                                <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                                                    <FilePen className="size-3" />
+                                                    Draft
+                                                </span>
+                                            )}
                                         </td>
                                         <td className="px-4 py-3 text-muted-foreground">
                                             {ns.posts_count}

--- a/resources/js/pages/admin/posts/namespace.tsx
+++ b/resources/js/pages/admin/posts/namespace.tsx
@@ -111,7 +111,7 @@ export default function Namespace({
                                                     <FilePen className="size-3" />
                                                     Draft
                                                 </span>
-                                            ) : post.published_at &&
+                                            ) : !post.published_at ||
                                               new Date(post.published_at) >
                                                   new Date() ? (
                                                 <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">

--- a/resources/js/pages/admin/posts/namespace.tsx
+++ b/resources/js/pages/admin/posts/namespace.tsx
@@ -1,5 +1,6 @@
 import { Head, Link, setLayoutProps } from '@inertiajs/react';
 import { Form } from '@inertiajs/react';
+import { CheckCircle2, Clock, FilePen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { dashboard } from '@/routes';
 import {
@@ -106,17 +107,20 @@ export default function Namespace({
                                         </td>
                                         <td className="px-4 py-3">
                                             {post.is_draft ? (
-                                                <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                                                <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                                                    <FilePen className="size-3" />
                                                     Draft
                                                 </span>
                                             ) : post.published_at &&
                                               new Date(post.published_at) >
                                                   new Date() ? (
-                                                <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                                                <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                                                    <Clock className="size-3" />
                                                     Scheduled
                                                 </span>
                                             ) : (
-                                                <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                                                <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                                                    <CheckCircle2 className="size-3" />
                                                     Published
                                                 </span>
                                             )}

--- a/resources/js/pages/posts/index.tsx
+++ b/resources/js/pages/posts/index.tsx
@@ -1,4 +1,5 @@
 import { Head, Link, usePage } from '@inertiajs/react';
+import { ImageOff } from 'lucide-react';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import { login } from '@/routes';
 import { index as adminPosts } from '@/routes/admin/posts';
@@ -66,7 +67,15 @@ export default function Index({ namespaces }: { namespaces: PostNamespace[] }) {
                                                 className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
                                             />
                                         ) : (
-                                            <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
+                                            <>
+                                                <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
+                                                <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 text-muted-foreground/50">
+                                                    <ImageOff className="size-6" />
+                                                    <span className="text-xs font-medium tracking-wide uppercase">
+                                                        No image
+                                                    </span>
+                                                </div>
+                                            </>
                                         )}
                                     </div>
                                     <div className="flex flex-col gap-1 p-5">

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -1,5 +1,10 @@
 import { Head, Link, usePage } from '@inertiajs/react';
-import { ChevronRight, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+import {
+    ChevronRight,
+    ImageOff,
+    PanelLeftClose,
+    PanelLeftOpen,
+} from 'lucide-react';
 import { useState } from 'react';
 import ContentNavTree, {
     type ContentNavNode,
@@ -192,7 +197,15 @@ export default function Namespace({
                                                         className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
                                                     />
                                                 ) : (
-                                                    <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
+                                                    <>
+                                                        <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
+                                                        <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 text-muted-foreground/50">
+                                                            <ImageOff className="size-6" />
+                                                            <span className="text-xs font-medium tracking-wide uppercase">
+                                                                No image
+                                                            </span>
+                                                        </div>
+                                                    </>
                                                 )}
                                             </div>
                                             <div className="space-y-2 p-5">

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -50,6 +50,8 @@ test('authenticated users can store a post', function () {
         'slug' => 'hello-world',
         'user_id' => $user->id,
     ]);
+
+    expect(Post::query()->where('slug', 'hello-world')->value('published_at'))->not->toBeNull();
 });
 
 test('storing a post requires a title', function () {
@@ -127,6 +129,7 @@ test('authenticated users can update a post', function () {
     $post->refresh();
     expect($post->title)->toBe('New Title');
     expect($post->slug)->toBe('new-slug');
+    expect($post->published_at)->not->toBeNull();
 });
 
 test('updating a post allows keeping the same slug', function () {

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -168,7 +168,7 @@ test('scheduled post is not counted on homepage', function () {
         );
 });
 
-test('post without publish date is counted on homepage', function () {
+test('post without publish date is not counted on homepage', function () {
     $namespace = PostNamespace::factory()->create(['is_published' => true, 'parent_id' => null]);
 
     Post::factory()->for($namespace, 'namespace')->create([
@@ -178,7 +178,7 @@ test('post without publish date is counted on homepage', function () {
 
     $this->get(route('home'))
         ->assertSuccessful()
-        ->assertInertia(fn ($page) => $page->where('namespaces.0.posts_count', 1));
+        ->assertInertia(fn ($page) => $page->where('namespaces.0.posts_count', 0));
 });
 
 test('scheduled post is not shown in namespace listing', function () {
@@ -190,19 +190,14 @@ test('scheduled post is not shown in namespace listing', function () {
         ->assertInertia(fn ($page) => $page->has('posts', 0));
 });
 
-test('post without publish date remains directly accessible', function () {
+test('post without publish date is not directly accessible', function () {
     $namespace = PostNamespace::factory()->create(['is_published' => true]);
     $post = Post::factory()->for($namespace, 'namespace')->create([
         'is_draft' => false,
         'published_at' => null,
     ]);
 
-    $this->get(route('posts.path', ['path' => $post->full_path]))
-        ->assertSuccessful()
-        ->assertInertia(fn ($page) => $page
-            ->component('posts/show')
-            ->where('post.full_path', $post->full_path)
-        );
+    $this->get(route('posts.path', ['path' => $post->full_path]))->assertNotFound();
 });
 
 test('scheduled post is not directly accessible', function () {

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -156,6 +156,72 @@ test('published namespace shows post with breadcrumbs', function () {
         );
 });
 
+test('scheduled post is not counted on homepage', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true, 'parent_id' => null]);
+    Post::factory()->for($namespace, 'namespace')->published()->create();
+    Post::factory()->for($namespace, 'namespace')->scheduled()->create();
+
+    $this->get(route('home'))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->where('namespaces.0.posts_count', 1)
+        );
+});
+
+test('post without publish date is counted on homepage', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true, 'parent_id' => null]);
+
+    Post::factory()->for($namespace, 'namespace')->create([
+        'is_draft' => false,
+        'published_at' => null,
+    ]);
+
+    $this->get(route('home'))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page->where('namespaces.0.posts_count', 1));
+});
+
+test('scheduled post is not shown in namespace listing', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    Post::factory()->for($namespace, 'namespace')->scheduled()->create();
+
+    $this->get(route('posts.path', ['path' => $namespace->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page->has('posts', 0));
+});
+
+test('post without publish date remains directly accessible', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->create([
+        'is_draft' => false,
+        'published_at' => null,
+    ]);
+
+    $this->get(route('posts.path', ['path' => $post->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/show')
+            ->where('post.full_path', $post->full_path)
+        );
+});
+
+test('scheduled post is not directly accessible', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->scheduled()->create();
+
+    $this->get(route('posts.path', ['path' => $post->full_path]))->assertNotFound();
+});
+
+test('scheduled post does not appear in sidebar when viewing another post', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $published = Post::factory()->for($namespace, 'namespace')->published()->create();
+    Post::factory()->for($namespace, 'namespace')->scheduled()->create();
+
+    $this->get(route('posts.path', ['path' => $published->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page->has('posts', 1));
+});
+
 test('admin routes are not caught by the content path wildcard', function () {
     $this->get('/admin/namespaces/create')->assertRedirect(route('login'));
 });


### PR DESCRIPTION
## Summary
- add scheduled publishing controls to the admin post create/edit flows
- show clearer publish status and fallback imagery across admin and public post listings
- keep immediate-publish posts with a null `published_at` visible while excluding future scheduled posts from public pages

## Testing
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail artisan test --compact tests/Feature/PostControllerTest.php tests/Feature/Admin/PostControllerTest.php
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build