### PR TITLE
Add admin post detail flow

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -37,13 +37,23 @@ class PostController extends Controller
 
     public function store(StorePostRequest $request, PostNamespace $namespace): RedirectResponse
     {
-        Post::create([
+        $post = Post::create([
             ...$request->validated(),
             'namespace_id' => $namespace->id,
             'user_id' => $request->user()->id,
         ]);
 
-        return to_route('admin.posts.namespace', $namespace);
+        Inertia::flash('toast', ['type' => 'success', 'message' => 'Post created.']);
+
+        return to_route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug]);
+    }
+
+    public function show(PostNamespace $namespace, Post $post): Response
+    {
+        return Inertia::render('admin/posts/show', [
+            'namespace' => $namespace,
+            'post' => $post,
+        ]);
     }
 
     public function edit(PostNamespace $namespace, Post $post): Response
@@ -58,12 +68,16 @@ class PostController extends Controller
     {
         $post->update($request->validated());
 
-        return to_route('admin.posts.namespace', $namespace);
+        Inertia::flash('toast', ['type' => 'success', 'message' => 'Post saved.']);
+
+        return to_route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug]);
     }
 
     public function destroy(PostNamespace $namespace, Post $post): RedirectResponse
     {
         $post->delete();
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => 'Post deleted.']);
 
         return to_route('admin.posts.namespace', $namespace);
     }

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -1,12 +1,5 @@
 import { Link, usePage } from '@inertiajs/react';
-import {
-    BookOpen,
-    Folder,
-    LayoutGrid,
-    Menu,
-    NotebookPen,
-    Search,
-} from 'lucide-react';
+import { LayoutGrid, Menu, NotebookPen, Search } from 'lucide-react';
 import AppLogo from '@/components/app-logo';
 import AppLogoIcon from '@/components/app-logo-icon';
 import { Breadcrumbs } from '@/components/breadcrumbs';
@@ -60,18 +53,7 @@ const mainNavItems: NavItem[] = [
     },
 ];
 
-const rightNavItems: NavItem[] = [
-    {
-        title: 'Repository',
-        href: 'https://github.com/laravel/react-starter-kit',
-        icon: Folder,
-    },
-    {
-        title: 'Documentation',
-        href: 'https://laravel.com/docs/starter-kits#react',
-        icon: BookOpen,
-    },
-];
+const rightNavItems: NavItem[] = [];
 
 const activeItemStyles =
     'text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100';

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@inertiajs/react';
-import { BookOpen, FolderGit2, LayoutGrid, NotebookPen } from 'lucide-react';
+import { LayoutGrid, NotebookPen } from 'lucide-react';
 import AppLogo from '@/components/app-logo';
 import { NavFooter } from '@/components/nav-footer';
 import { NavMain } from '@/components/nav-main';
@@ -30,18 +30,7 @@ const mainNavItems: NavItem[] = [
     },
 ];
 
-const footerNavItems: NavItem[] = [
-    {
-        title: 'Repository',
-        href: 'https://github.com/laravel/react-starter-kit',
-        icon: FolderGit2,
-    },
-    {
-        title: 'Documentation',
-        href: 'https://laravel.com/docs/starter-kits#react',
-        icon: BookOpen,
-    },
-];
+const footerNavItems: NavItem[] = [];
 
 export function AppSidebar() {
     return (

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -1,4 +1,5 @@
-import { Form, Head, setLayoutProps } from '@inertiajs/react';
+import { Form, Head, Link, setLayoutProps } from '@inertiajs/react';
+import { ExternalLink } from 'lucide-react';
 import { useState } from 'react';
 import InputError from '@/components/input-error';
 import MarkdownEditor from '@/components/markdown-editor';
@@ -12,6 +13,7 @@ import {
     index,
     namespace as namespaceRoute,
     edit,
+    show,
     update,
 } from '@/routes/admin/posts';
 
@@ -24,6 +26,7 @@ type Namespace = {
 type Post = {
     id: number;
     slug: string;
+    full_path: string;
     title: string;
     content: string;
     is_draft: boolean;
@@ -99,11 +102,27 @@ export default function Edit({
             <Head title={`Edit: ${post.title}`} />
 
             <div className="space-y-6 p-4">
-                <div>
-                    <h1 className="text-2xl font-semibold">Edit Post</h1>
-                    <p className="text-sm text-muted-foreground">
-                        {namespace.slug}/{post.slug}
-                    </p>
+                <div className="flex items-start justify-between">
+                    <div>
+                        <h1 className="text-2xl font-semibold">Edit Post</h1>
+                        <p className="text-sm text-muted-foreground">
+                            {namespace.slug}/{post.slug}
+                        </p>
+                    </div>
+                    {!post.is_draft &&
+                        post.published_at &&
+                        new Date(post.published_at) <= new Date() && (
+                            <Button variant="outline" size="sm" asChild>
+                                <a
+                                    href={`/${post.full_path}`}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
+                                    <ExternalLink className="size-4" />
+                                    View Live
+                                </a>
+                            </Button>
+                        )}
                 </div>
 
                 <Form
@@ -234,9 +253,14 @@ export default function Edit({
                                     Save Changes
                                 </Button>
                                 <Button type="button" variant="outline" asChild>
-                                    <a href={namespaceRoute.url(namespace.id)}>
+                                    <Link
+                                        href={show.url({
+                                            namespace: namespace.id,
+                                            post: post.slug,
+                                        })}
+                                    >
                                         Cancel
-                                    </a>
+                                    </Link>
                                 </Button>
                             </div>
                         </>

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -1,6 +1,6 @@
 import { Head, Link } from '@inertiajs/react';
 import { Form } from '@inertiajs/react';
-import { CheckCircle2, FilePen } from 'lucide-react';
+import { CheckCircle2, ExternalLink, FilePen } from 'lucide-react';
 import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import { Button } from '@/components/ui/button';
 import { dashboard } from '@/routes';
@@ -10,6 +10,7 @@ import { index, namespace as namespaceRoute } from '@/routes/admin/posts';
 type Namespace = {
     id: number;
     slug: string;
+    full_path: string;
     name: string;
     is_published: boolean;
     posts_count: number;
@@ -104,6 +105,22 @@ export default function Index({ namespaces }: { namespaces: Namespace[] }) {
                                         </td>
                                         <td className="px-4 py-3 text-right">
                                             <div className="flex items-center justify-end gap-2">
+                                                {ns.is_published && (
+                                                    <Button
+                                                        variant="outline"
+                                                        size="sm"
+                                                        asChild
+                                                    >
+                                                        <a
+                                                            href={`/${ns.full_path}`}
+                                                            target="_blank"
+                                                            rel="noreferrer"
+                                                        >
+                                                            <ExternalLink className="size-4" />
+                                                            View
+                                                        </a>
+                                                    </Button>
+                                                )}
                                                 <Button
                                                     variant="outline"
                                                     size="sm"

--- a/resources/js/pages/admin/posts/namespace.tsx
+++ b/resources/js/pages/admin/posts/namespace.tsx
@@ -1,6 +1,6 @@
 import { Head, Link, setLayoutProps } from '@inertiajs/react';
 import { Form } from '@inertiajs/react';
-import { CheckCircle2, Clock, FilePen } from 'lucide-react';
+import { CheckCircle2, Clock, ExternalLink, FilePen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { dashboard } from '@/routes';
 import {
@@ -9,11 +9,13 @@ import {
     create,
     edit,
     destroy,
+    show,
 } from '@/routes/admin/posts';
 
 type Namespace = {
     id: number;
     slug: string;
+    full_path: string;
     name: string;
 };
 
@@ -100,7 +102,15 @@ export default function Namespace({
                                         className="border-b last:border-0"
                                     >
                                         <td className="px-4 py-3 font-medium">
-                                            {post.title}
+                                            <Link
+                                                href={show.url({
+                                                    namespace: namespace.id,
+                                                    post: post.slug,
+                                                })}
+                                                className="hover:underline"
+                                            >
+                                                {post.title}
+                                            </Link>
                                         </td>
                                         <td className="px-4 py-3 text-muted-foreground">
                                             {post.slug}
@@ -132,6 +142,26 @@ export default function Namespace({
                                         </td>
                                         <td className="px-4 py-3 text-right">
                                             <div className="flex items-center justify-end gap-2">
+                                                {!post.is_draft &&
+                                                    post.published_at &&
+                                                    new Date(
+                                                        post.published_at,
+                                                    ) <= new Date() && (
+                                                        <Button
+                                                            variant="outline"
+                                                            size="sm"
+                                                            asChild
+                                                        >
+                                                            <a
+                                                                href={`/${namespace.full_path}/${post.slug}`}
+                                                                target="_blank"
+                                                                rel="noreferrer"
+                                                            >
+                                                                <ExternalLink className="size-4" />
+                                                                View
+                                                            </a>
+                                                        </Button>
+                                                    )}
                                                 <Button
                                                     variant="outline"
                                                     size="sm"

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -1,4 +1,5 @@
 import { Form, Head, Link, setLayoutProps } from '@inertiajs/react';
+import { CheckCircle2, Clock, FilePen } from 'lucide-react';
 import MarkdownContent from '@/components/markdown-content';
 import { Button } from '@/components/ui/button';
 import { createMarkdownComponents } from '@/lib/markdown-components';
@@ -8,6 +9,7 @@ import {
     edit,
     index,
     namespace as namespaceRoute,
+    show,
 } from '@/routes/admin/posts';
 
 type Namespace = {
@@ -21,6 +23,7 @@ type Post = {
     title: string;
     slug: string;
     content: string;
+    is_draft: boolean;
     published_at: string | null;
     created_at: string;
 };
@@ -39,7 +42,7 @@ export default function Show({
             { title: namespace.name, href: namespaceRoute.url(namespace.id) },
             {
                 title: post.title,
-                href: edit.url({ namespace: namespace.id, post: post.slug }),
+                href: show.url({ namespace: namespace.id, post: post.slug }),
             },
         ],
     });
@@ -57,13 +60,21 @@ export default function Show({
                                 {namespace.slug}/{post.slug}
                             </span>
                             <span>·</span>
-                            {post.published_at ? (
-                                <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
-                                    Published
+                            {post.is_draft ? (
+                                <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                                    <FilePen className="size-3" />
+                                    Draft
+                                </span>
+                            ) : !post.published_at ||
+                              new Date(post.published_at) > new Date() ? (
+                                <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                                    <Clock className="size-3" />
+                                    Scheduled
                                 </span>
                             ) : (
-                                <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                                    Draft
+                                <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                                    <CheckCircle2 className="size-3" />
+                                    Published
                                 </span>
                             )}
                         </div>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -14,6 +14,7 @@ Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () 
         Route::get('/{namespace}', [PostController::class, 'namespaceIndex'])->name('namespace');
         Route::get('/{namespace}/create', [PostController::class, 'create'])->name('create');
         Route::post('/{namespace}', [PostController::class, 'store'])->name('store');
+        Route::get('/{namespace}/{post:slug}', [PostController::class, 'show'])->name('show')->scopeBindings();
         Route::get('/{namespace}/{post:slug}/edit', [PostController::class, 'edit'])->name('edit')->scopeBindings();
         Route::put('/{namespace}/{post:slug}', [PostController::class, 'update'])->name('update')->scopeBindings();
         Route::delete('/{namespace}/{post:slug}', [PostController::class, 'destroy'])->name('destroy')->scopeBindings();

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -42,7 +42,12 @@ test('authenticated users can store a post', function () {
             'content' => '# Hello\n\nThis is a test post.',
             'published_at' => null,
         ])
-        ->assertRedirect(route('admin.posts.namespace', $namespace));
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('inertia.flash_data.toast', [
+            'type' => 'success',
+            'message' => 'Post created.',
+        ])
+        ->assertRedirect(route('admin.posts.show', [$namespace, 'hello-world']));
 
     $this->assertDatabaseHas('posts', [
         'namespace_id' => $namespace->id,
@@ -90,7 +95,7 @@ test('the same slug is allowed in different namespaces', function () {
 
     $this->actingAs($user)
         ->post(route('admin.posts.store', $namespaceB), ['title' => 'My Post', 'slug' => 'shared-slug', 'content' => 'Some content'])
-        ->assertRedirect(route('admin.posts.namespace', $namespaceB));
+        ->assertRedirect(route('admin.posts.show', [$namespaceB, 'shared-slug']));
 });
 
 test('storing a post requires content', function () {
@@ -112,6 +117,41 @@ test('authenticated users can view the edit form', function () {
         ->assertOk();
 });
 
+test('authenticated users can view a post details page', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'title' => 'Release Notes',
+        'slug' => 'release-notes',
+        'is_draft' => false,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.show', [$namespace, $post]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/show')
+            ->where('namespace.id', $namespace->id)
+            ->where('post.id', $post->id)
+            ->where('post.slug', 'release-notes')
+            ->where('post.title', 'Release Notes')
+        );
+});
+
+test('post details are scoped to their namespace', function () {
+    $user = User::factory()->create();
+    $correctNamespace = PostNamespace::factory()->create();
+    $wrongNamespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $correctNamespace->id,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.show', [$wrongNamespace, $post]))
+        ->assertNotFound();
+});
+
 test('authenticated users can update a post', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create();
@@ -124,7 +164,12 @@ test('authenticated users can update a post', function () {
             'content' => 'Updated content.',
             'published_at' => null,
         ])
-        ->assertRedirect(route('admin.posts.namespace', $namespace));
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('inertia.flash_data.toast', [
+            'type' => 'success',
+            'message' => 'Post saved.',
+        ])
+        ->assertRedirect(route('admin.posts.show', [$namespace, 'new-slug']));
 
     $post->refresh();
     expect($post->title)->toBe('New Title');
@@ -143,7 +188,7 @@ test('updating a post allows keeping the same slug', function () {
             'slug' => 'my-slug',
             'content' => 'Updated content.',
         ])
-        ->assertRedirect(route('admin.posts.namespace', $namespace));
+        ->assertRedirect(route('admin.posts.show', [$namespace, 'my-slug']));
 
     expect($post->fresh()->slug)->toBe('my-slug');
 });
@@ -155,6 +200,11 @@ test('authenticated users can delete a post', function () {
 
     $this->actingAs($user)
         ->delete(route('admin.posts.destroy', [$namespace, $post]))
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('inertia.flash_data.toast', [
+            'type' => 'success',
+            'message' => 'Post deleted.',
+        ])
         ->assertRedirect(route('admin.posts.namespace', $namespace));
 
     expect($post->fresh())->toBeNull();


### PR DESCRIPTION
## Summary
- add an admin post detail page and redirect create/update flows to it
- add live-view actions in the admin post screens and remove starter-kit external chrome links
- cover the new detail route and admin post toasts in feature tests

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/Admin/PostControllerTest.php
- vendor/bin/sail npm run types:check