### PR TITLE
Add admin namespace sorting and reordering

### DIFF
--- a/app/Http/Controllers/Admin/NamespaceController.php
+++ b/app/Http/Controllers/Admin/NamespaceController.php
@@ -7,13 +7,44 @@ use App\Http\Requests\Admin\StoreNamespaceRequest;
 use App\Http\Requests\Admin\UpdateNamespaceRequest;
 use App\Models\PostNamespace;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rule;
 use Inertia\Inertia;
-use Inertia\Response;
+use Inertia\Response as InertiaResponse;
 
 class NamespaceController extends Controller
 {
-    public function create(): Response
+    public function reorder(Request $request): RedirectResponse
+    {
+        $ids = $request->validate([
+            'ids' => ['required', 'array'],
+            'ids.*' => ['integer', 'distinct', Rule::exists('namespaces', 'id')],
+        ])['ids'];
+
+        $caseStatement = collect($ids)
+            ->values()
+            ->map(fn (int $id, int $index): string => 'WHEN ? THEN ?')
+            ->implode(' ');
+
+        $bindings = [
+            ...collect($ids)
+                ->values()
+                ->flatMap(fn (int $id, int $index): array => [$id, $index])
+                ->all(),
+            ...$ids,
+        ];
+
+        DB::update(
+            "UPDATE namespaces SET sort_order = CASE id {$caseStatement} END WHERE id IN (".implode(', ', array_fill(0, count($ids), '?')).')',
+            $bindings,
+        );
+
+        return back();
+    }
+
+    public function create(): InertiaResponse
     {
         return Inertia::render('admin/namespaces/create');
     }
@@ -31,7 +62,7 @@ class NamespaceController extends Controller
         return to_route('admin.posts.index');
     }
 
-    public function edit(PostNamespace $namespace): Response
+    public function edit(PostNamespace $namespace): InertiaResponse
     {
         return Inertia::render('admin/namespaces/edit', [
             'namespace' => $namespace,

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -8,15 +8,36 @@ use App\Http\Requests\Admin\UpdatePostRequest;
 use App\Models\Post;
 use App\Models\PostNamespace;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class PostController extends Controller
 {
-    public function index(): Response
+    public function index(Request $request): Response
     {
+        $allowedColumns = ['name', 'posts_count', 'is_published'];
+        $allowedDirections = ['asc', 'desc'];
+
+        if ($request->hasAny(['sort', 'dir'])) {
+            $column = in_array($request->input('sort'), $allowedColumns) ? $request->input('sort') : 'name';
+            $direction = in_array($request->input('dir'), $allowedDirections) ? $request->input('dir') : 'asc';
+
+            $namespaces = PostNamespace::withCount('posts')
+                ->orderBy($column, $direction)
+                ->get();
+        } else {
+            $column = 'sort_order';
+            $direction = 'asc';
+
+            $namespaces = PostNamespace::withCount('posts')
+                ->orderByRaw('sort_order IS NULL, sort_order ASC, name ASC')
+                ->get();
+        }
+
         return Inertia::render('admin/posts/index', [
-            'namespaces' => PostNamespace::withCount('posts')->orderBy('name')->get(),
+            'namespaces' => $namespaces,
+            'sort' => ['column' => $column, 'direction' => $direction],
         ]);
     }
 
@@ -24,7 +45,7 @@ class PostController extends Controller
     {
         return Inertia::render('admin/posts/namespace', [
             'namespace' => $namespace,
-            'posts' => $namespace->posts()->latest()->get(['id', 'title', 'slug', 'is_draft', 'published_at', 'created_at']),
+            'posts' => $namespace->sortPosts($namespace->posts()->latest()->get(['id', 'title', 'slug', 'is_draft', 'published_at', 'created_at'])),
         ]);
     }
 

--- a/database/migrations/2026_04_18_070700_add_sort_order_to_namespaces_table.php
+++ b/database/migrations/2026_04_18_070700_add_sort_order_to_namespaces_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('namespaces', function (Blueprint $table) {
+            $table->unsignedInteger('sort_order')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('namespaces', function (Blueprint $table) {
+            $table->dropColumn('sort_order');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,9 @@
     "packages": {
         "": {
             "dependencies": {
+                "@dnd-kit/core": "^6.3.1",
+                "@dnd-kit/sortable": "^10.0.0",
+                "@dnd-kit/utilities": "^3.2.2",
                 "@headlessui/react": "^2.2.0",
                 "@inertiajs/react": "^3.0.0",
                 "@inertiajs/vite": "^3.0.0",
@@ -380,6 +383,59 @@
             "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
             "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
             "license": "Apache-2.0"
+        },
+        "node_modules/@dnd-kit/accessibility": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+            "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/core": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+            "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@dnd-kit/accessibility": "^3.1.1",
+                "@dnd-kit/utilities": "^3.2.2",
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/sortable": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+            "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+            "license": "MIT",
+            "dependencies": {
+                "@dnd-kit/utilities": "^3.2.2",
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "@dnd-kit/core": "^6.3.0",
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/utilities": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+            "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
         },
         "node_modules/@emnapi/core": {
             "version": "1.9.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
         "typescript-eslint": "^8.23.0"
     },
     "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@headlessui/react": "^2.2.0",
         "@inertiajs/react": "^3.0.0",
         "@inertiajs/vite": "^3.0.0",

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -1,6 +1,32 @@
-import { Head, Link } from '@inertiajs/react';
+import type { DragEndEvent } from '@dnd-kit/core';
+import {
+    DndContext,
+    KeyboardSensor,
+    PointerSensor,
+    closestCenter,
+    useSensor,
+    useSensors,
+} from '@dnd-kit/core';
+import {
+    SortableContext,
+    sortableKeyboardCoordinates,
+    useSortable,
+    verticalListSortingStrategy,
+    arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { Form } from '@inertiajs/react';
-import { CheckCircle2, ExternalLink, FilePen } from 'lucide-react';
+import { Head, Link, router } from '@inertiajs/react';
+import {
+    CheckCircle2,
+    ChevronDown,
+    ChevronUp,
+    ChevronsUpDown,
+    ExternalLink,
+    FilePen,
+    GripVertical,
+} from 'lucide-react';
+import { useEffect, useState } from 'react';
 import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import { Button } from '@/components/ui/button';
 import { dashboard } from '@/routes';
@@ -16,7 +42,212 @@ type Namespace = {
     posts_count: number;
 };
 
-export default function Index({ namespaces }: { namespaces: Namespace[] }) {
+type Sort = {
+    column: string;
+    direction: 'asc' | 'desc';
+};
+
+function SortIcon({ column, sort }: { column: string; sort: Sort }) {
+    if (sort.column !== column) {
+        return <ChevronsUpDown className="ml-1 inline size-3 opacity-40" />;
+    }
+
+    return sort.direction === 'asc' ? (
+        <ChevronUp className="ml-1 inline size-3" />
+    ) : (
+        <ChevronDown className="ml-1 inline size-3" />
+    );
+}
+
+function SortableHeader({
+    column,
+    label,
+    sort,
+}: {
+    column: string;
+    label: string;
+    sort: Sort;
+}) {
+    function handleSort() {
+        const direction =
+            sort.column === column && sort.direction === 'asc' ? 'desc' : 'asc';
+        router.get(
+            index.url(),
+            { sort: column, dir: direction },
+            { preserveScroll: true },
+        );
+    }
+
+    return (
+        <button
+            onClick={handleSort}
+            className="flex cursor-pointer items-center font-medium hover:text-foreground"
+        >
+            {label}
+            <SortIcon column={column} sort={sort} />
+        </button>
+    );
+}
+
+function SortableRow({
+    namespace,
+    isDndActive,
+}: {
+    namespace: Namespace;
+    isDndActive: boolean;
+}) {
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id: namespace.id });
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+    };
+
+    return (
+        <tr ref={setNodeRef} style={style} className="border-b last:border-0">
+            <td className="w-8 px-2 py-3">
+                {isDndActive && (
+                    <button
+                        {...attributes}
+                        {...listeners}
+                        className="cursor-grab touch-none text-muted-foreground hover:text-foreground active:cursor-grabbing"
+                    >
+                        <GripVertical className="size-4" />
+                    </button>
+                )}
+            </td>
+            <td className="px-4 py-3 font-medium">
+                <Link
+                    href={namespaceRoute.url(namespace.id)}
+                    className="text-primary hover:underline"
+                >
+                    {namespace.name}
+                </Link>
+            </td>
+            <td className="px-4 py-3 text-muted-foreground">
+                /{namespace.slug}
+            </td>
+            <td className="px-4 py-3">
+                {namespace.is_published ? (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
+                        <CheckCircle2 className="size-3" />
+                        Published
+                    </span>
+                ) : (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                        <FilePen className="size-3" />
+                        Draft
+                    </span>
+                )}
+            </td>
+            <td className="px-4 py-3 text-muted-foreground">
+                {namespace.posts_count}
+            </td>
+            <td className="px-4 py-3 text-right">
+                <div className="flex items-center justify-end gap-2">
+                    {namespace.is_published && (
+                        <Button variant="outline" size="sm" asChild>
+                            <a
+                                href={`/${namespace.full_path}`}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                <ExternalLink className="size-4" />
+                                View
+                            </a>
+                        </Button>
+                    )}
+                    <Button variant="outline" size="sm" asChild>
+                        <Link href={NamespaceController.edit.url(namespace.id)}>
+                            Edit
+                        </Link>
+                    </Button>
+                    <Form {...NamespaceController.destroy.form(namespace.id)}>
+                        {({ processing }) => (
+                            <Button
+                                type="submit"
+                                variant="destructive"
+                                size="sm"
+                                disabled={processing}
+                            >
+                                Delete
+                            </Button>
+                        )}
+                    </Form>
+                </div>
+            </td>
+        </tr>
+    );
+}
+
+export default function Index({
+    namespaces: initialNamespaces,
+    sort,
+}: {
+    namespaces: Namespace[];
+    sort: Sort;
+}) {
+    const [namespaces, setNamespaces] = useState(initialNamespaces);
+    const [reorderMode, setReorderMode] = useState(false);
+
+    useEffect(() => {
+        setNamespaces(initialNamespaces);
+    }, [initialNamespaces]);
+
+    const sensors = useSensors(
+        useSensor(PointerSensor),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates,
+        }),
+    );
+
+    function handleDragEnd(event: DragEndEvent) {
+        const { active, over } = event;
+
+        if (!over || active.id === over.id) {
+            return;
+        }
+
+        const oldIndex = namespaces.findIndex((ns) => ns.id === active.id);
+        const newIndex = namespaces.findIndex((ns) => ns.id === over.id);
+        const reordered = arrayMove(namespaces, oldIndex, newIndex);
+
+        setNamespaces(reordered);
+        router.patch(
+            NamespaceController.reorder.url(),
+            { ids: reordered.map((ns) => ns.id) },
+            { preserveScroll: true },
+        );
+    }
+
+    function handleReorderToggle() {
+        if (reorderMode) {
+            setReorderMode(false);
+
+            return;
+        }
+
+        if (sort.column !== 'sort_order' || sort.direction !== 'asc') {
+            router.get(index.url(), undefined, {
+                preserveScroll: true,
+                replace: true,
+                onSuccess: () => setReorderMode(true),
+            });
+
+            return;
+        }
+
+        setReorderMode(true);
+    }
+
     return (
         <>
             <Head title="Posts" />
@@ -29,9 +260,19 @@ export default function Index({ namespaces }: { namespaces: Namespace[] }) {
                             Manage namespaces and their posts
                         </p>
                     </div>
-                    <Button asChild>
-                        <Link href={namespaceCreate.url()}>New Namespace</Link>
-                    </Button>
+                    <div className="flex items-center gap-2">
+                        <Button
+                            variant={reorderMode ? 'secondary' : 'outline'}
+                            onClick={handleReorderToggle}
+                        >
+                            {reorderMode ? 'Done' : 'Reorder'}
+                        </Button>
+                        <Button asChild>
+                            <Link href={namespaceCreate.url()}>
+                                New Namespace
+                            </Link>
+                        </Button>
+                    </div>
                 </div>
 
                 {namespaces.length === 0 ? (
@@ -49,116 +290,80 @@ export default function Index({ namespaces }: { namespaces: Namespace[] }) {
                         </Button>
                     </div>
                 ) : (
-                    <div className="rounded-xl border">
-                        <table className="w-full text-sm">
-                            <thead>
-                                <tr className="border-b bg-muted/50">
-                                    <th className="px-4 py-3 text-left font-medium">
-                                        Namespace
-                                    </th>
-                                    <th className="px-4 py-3 text-left font-medium">
-                                        Slug
-                                    </th>
-                                    <th className="px-4 py-3 text-left font-medium">
-                                        Status
-                                    </th>
-                                    <th className="px-4 py-3 text-left font-medium">
-                                        Posts
-                                    </th>
-                                    <th className="px-4 py-3 text-right font-medium">
-                                        Actions
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {namespaces.map((ns) => (
-                                    <tr
-                                        key={ns.id}
-                                        className="border-b last:border-0"
-                                    >
-                                        <td className="px-4 py-3 font-medium">
-                                            <Link
-                                                href={namespaceRoute.url(ns.id)}
-                                                className="text-primary hover:underline"
-                                            >
-                                                {ns.name}
-                                            </Link>
-                                        </td>
-                                        <td className="px-4 py-3 text-muted-foreground">
-                                            {ns.slug}
-                                        </td>
-                                        <td className="px-4 py-3">
-                                            {ns.is_published ? (
-                                                <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
-                                                    <CheckCircle2 className="size-3" />
-                                                    Published
+                    <DndContext
+                        sensors={sensors}
+                        collisionDetection={closestCenter}
+                        onDragEnd={handleDragEnd}
+                    >
+                        <div className="rounded-xl border">
+                            <table className="w-full text-sm">
+                                <thead>
+                                    <tr className="border-b bg-muted/50">
+                                        <th className="w-8 px-2 py-3" />
+                                        <th className="px-4 py-3 text-left">
+                                            {reorderMode ? (
+                                                <span className="font-medium">
+                                                    Namespace
                                                 </span>
                                             ) : (
-                                                <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                                                    <FilePen className="size-3" />
-                                                    Draft
-                                                </span>
+                                                <SortableHeader
+                                                    column="name"
+                                                    label="Namespace"
+                                                    sort={sort}
+                                                />
                                             )}
-                                        </td>
-                                        <td className="px-4 py-3 text-muted-foreground">
-                                            {ns.posts_count}
-                                        </td>
-                                        <td className="px-4 py-3 text-right">
-                                            <div className="flex items-center justify-end gap-2">
-                                                {ns.is_published && (
-                                                    <Button
-                                                        variant="outline"
-                                                        size="sm"
-                                                        asChild
-                                                    >
-                                                        <a
-                                                            href={`/${ns.full_path}`}
-                                                            target="_blank"
-                                                            rel="noreferrer"
-                                                        >
-                                                            <ExternalLink className="size-4" />
-                                                            View
-                                                        </a>
-                                                    </Button>
-                                                )}
-                                                <Button
-                                                    variant="outline"
-                                                    size="sm"
-                                                    asChild
-                                                >
-                                                    <Link
-                                                        href={NamespaceController.edit.url(
-                                                            ns.id,
-                                                        )}
-                                                    >
-                                                        Edit
-                                                    </Link>
-                                                </Button>
-                                                <Form
-                                                    {...NamespaceController.destroy.form(
-                                                        ns.id,
-                                                    )}
-                                                >
-                                                    {({ processing }) => (
-                                                        <Button
-                                                            type="submit"
-                                                            variant="destructive"
-                                                            size="sm"
-                                                            disabled={
-                                                                processing
-                                                            }
-                                                        >
-                                                            Delete
-                                                        </Button>
-                                                    )}
-                                                </Form>
-                                            </div>
-                                        </td>
+                                        </th>
+                                        <th className="px-4 py-3 text-left font-medium">
+                                            Slug
+                                        </th>
+                                        <th className="px-4 py-3 text-left">
+                                            {reorderMode ? (
+                                                <span className="font-medium">
+                                                    Status
+                                                </span>
+                                            ) : (
+                                                <SortableHeader
+                                                    column="is_published"
+                                                    label="Status"
+                                                    sort={sort}
+                                                />
+                                            )}
+                                        </th>
+                                        <th className="px-4 py-3 text-left">
+                                            {reorderMode ? (
+                                                <span className="font-medium">
+                                                    Posts
+                                                </span>
+                                            ) : (
+                                                <SortableHeader
+                                                    column="posts_count"
+                                                    label="Posts"
+                                                    sort={sort}
+                                                />
+                                            )}
+                                        </th>
+                                        <th className="px-4 py-3 text-right font-medium">
+                                            Actions
+                                        </th>
                                     </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    </div>
+                                </thead>
+                                <tbody>
+                                    <SortableContext
+                                        items={namespaces.map((ns) => ns.id)}
+                                        strategy={verticalListSortingStrategy}
+                                    >
+                                        {namespaces.map((ns) => (
+                                            <SortableRow
+                                                key={ns.id}
+                                                namespace={ns}
+                                                isDndActive={reorderMode}
+                                            />
+                                        ))}
+                                    </SortableContext>
+                                </tbody>
+                            </table>
+                        </div>
+                    </DndContext>
                 )}
             </div>
         </>

--- a/resources/js/pages/admin/posts/namespace.tsx
+++ b/resources/js/pages/admin/posts/namespace.tsx
@@ -113,7 +113,7 @@ export default function Namespace({
                                             </Link>
                                         </td>
                                         <td className="px-4 py-3 text-muted-foreground">
-                                            {post.slug}
+                                            /{namespace.full_path}/{post.slug}
                                         </td>
                                         <td className="px-4 py-3">
                                             {post.is_draft ? (

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Route;
 Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () {
     Route::redirect('/', '/admin/posts')->name('index');
 
+    Route::patch('namespaces/reorder', [NamespaceController::class, 'reorder'])->name('namespaces.reorder');
     Route::resource('namespaces', NamespaceController::class)->except(['index', 'show']);
 
     Route::prefix('posts')->name('posts.')->group(function () {

--- a/tests/Feature/Admin/NamespaceControllerTest.php
+++ b/tests/Feature/Admin/NamespaceControllerTest.php
@@ -352,3 +352,41 @@ test('deleting a namespace removes the cover image file', function () {
 
     Storage::disk('public')->assertMissing($path);
 });
+
+test('guests cannot reorder namespaces', function () {
+    $this->patch(route('admin.namespaces.reorder'), ['ids' => [1, 2]])
+        ->assertRedirect(route('login'));
+});
+
+test('reorder updates sort_order on namespaces', function () {
+    $user = User::factory()->create();
+    $a = PostNamespace::factory()->create();
+    $b = PostNamespace::factory()->create();
+    $c = PostNamespace::factory()->create();
+
+    $this->actingAs($user)
+        ->patch(route('admin.namespaces.reorder'), ['ids' => [$c->id, $a->id, $b->id]])
+        ->assertRedirect();
+
+    expect($c->fresh()->sort_order)->toBe(0);
+    expect($a->fresh()->sort_order)->toBe(1);
+    expect($b->fresh()->sort_order)->toBe(2);
+});
+
+test('reorder validates ids are required', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->patchJson(route('admin.namespaces.reorder'), [])
+        ->assertUnprocessable();
+});
+
+test('reorder validates namespace ids are distinct and existing', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+
+    $this->actingAs($user)
+        ->patchJson(route('admin.namespaces.reorder'), ['ids' => [$namespace->id, $namespace->id, 999999]])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['ids.1', 'ids.2']);
+});

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -17,11 +17,71 @@ test('authenticated users can view the posts index (namespace list)', function (
     $this->actingAs($user)->get(route('admin.posts.index'))->assertOk();
 });
 
+test('posts index defaults to namespace sort order', function () {
+    $user = User::factory()->create();
+    $first = PostNamespace::factory()->create(['name' => 'Beta', 'sort_order' => 1]);
+    $second = PostNamespace::factory()->create(['name' => 'Alpha', 'sort_order' => 0]);
+    $last = PostNamespace::factory()->create(['name' => 'Gamma', 'sort_order' => null]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.index'))
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/index')
+            ->has('sort', fn ($sort) => $sort
+                ->where('column', 'sort_order')
+                ->where('direction', 'asc')
+            )
+            ->where('namespaces.0.id', $second->id)
+            ->where('namespaces.1.id', $first->id)
+            ->where('namespaces.2.id', $last->id)
+        );
+});
+
+test('posts index uses url sort params when provided', function () {
+    $user = User::factory()->create();
+    $topNamespace = PostNamespace::factory()->create();
+    $bottomNamespace = PostNamespace::factory()->create();
+    Post::factory()->for($user)->create(['namespace_id' => $topNamespace->id]);
+    Post::factory()->for($user)->create(['namespace_id' => $topNamespace->id]);
+    Post::factory()->for($user)->create(['namespace_id' => $bottomNamespace->id]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.index', ['sort' => 'posts_count', 'dir' => 'desc']))
+        ->assertInertia(fn ($page) => $page
+            ->has('sort', fn ($sort) => $sort
+                ->where('column', 'posts_count')
+                ->where('direction', 'desc')
+            )
+            ->where('namespaces.0.id', $topNamespace->id)
+            ->where('namespaces.1.id', $bottomNamespace->id)
+        );
+});
+
 test('authenticated users can view the namespace post list', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create();
 
     $this->actingAs($user)->get(route('admin.posts.namespace', $namespace))->assertOk();
+});
+
+test('namespace post list defaults to latest posts when no custom order exists', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $olderPost = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'created_at' => now()->subDay(),
+    ]);
+    $newerPost = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'created_at' => now(),
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.namespace', $namespace))
+        ->assertInertia(fn ($page) => $page
+            ->where('posts.0.id', $newerPost->id)
+            ->where('posts.1.id', $olderPost->id)
+        );
 });
 
 test('authenticated users can view the create form', function () {


### PR DESCRIPTION
- add drag-and-drop namespace ordering in the admin posts index
- keep namespace post listings stable when no custom order exists
- add a forward migration and regression coverage for sorting behavior