### PR TITLE
Add nested content path conflict detection and admin UI enhancements

### DIFF
--- a/app/Http/Controllers/Admin/NamespaceController.php
+++ b/app/Http/Controllers/Admin/NamespaceController.php
@@ -44,9 +44,19 @@ class NamespaceController extends Controller
         return back();
     }
 
-    public function create(): InertiaResponse
+    public function create(Request $request): InertiaResponse
     {
-        return Inertia::render('admin/namespaces/create');
+        $data = $request->validate([
+            'parent' => ['nullable', 'integer', Rule::exists('namespaces', 'id')],
+        ]);
+
+        $parentNamespace = isset($data['parent'])
+            ? PostNamespace::query()->find($data['parent'], ['id', 'name', 'full_path'])
+            : null;
+
+        return Inertia::render('admin/namespaces/create', [
+            'parentNamespace' => $parentNamespace,
+        ]);
     }
 
     public function store(StoreNamespaceRequest $request): RedirectResponse

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -24,6 +24,8 @@ class PostController extends Controller
             $direction = in_array($request->input('dir'), $allowedDirections) ? $request->input('dir') : 'asc';
 
             $namespaces = PostNamespace::withCount('posts')
+                ->with($this->childrenRelation())
+                ->whereNull('parent_id')
                 ->orderBy($column, $direction)
                 ->get();
         } else {
@@ -31,6 +33,8 @@ class PostController extends Controller
             $direction = 'asc';
 
             $namespaces = PostNamespace::withCount('posts')
+                ->with($this->childrenRelation())
+                ->whereNull('parent_id')
                 ->orderByRaw('sort_order IS NULL, sort_order ASC, name ASC')
                 ->get();
         }
@@ -41,10 +45,23 @@ class PostController extends Controller
         ]);
     }
 
+    /** @return array<string, \Closure> */
+    private function childrenRelation(): array
+    {
+        $order = 'sort_order IS NULL, sort_order ASC, name ASC';
+
+        return [
+            'children' => fn ($q) => $q->withCount('posts')->orderByRaw($order)
+                ->with(['children' => fn ($q2) => $q2->withCount('posts')->orderByRaw($order)]),
+        ];
+    }
+
     public function namespaceIndex(PostNamespace $namespace): Response
     {
         return Inertia::render('admin/posts/namespace', [
             'namespace' => $namespace,
+            'ancestors' => $namespace->ancestors()->map(fn (PostNamespace $ns) => ['id' => $ns->id, 'name' => $ns->name]),
+            'children' => $namespace->sortNamespaces($namespace->children()->withCount('posts')->get()),
             'posts' => $namespace->sortPosts($namespace->posts()->latest()->get(['id', 'title', 'slug', 'is_draft', 'published_at', 'created_at'])),
         ]);
     }
@@ -53,6 +70,9 @@ class PostController extends Controller
     {
         return Inertia::render('admin/posts/create', [
             'namespace' => $namespace,
+            'slugPrefix' => $namespace->full_path !== $namespace->slug
+                ? trim($namespace->full_path, '/').'/'
+                : null,
         ]);
     }
 

--- a/app/Http/Requests/Admin/StoreNamespaceRequest.php
+++ b/app/Http/Requests/Admin/StoreNamespaceRequest.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Requests\Admin;
 
+use App\Support\ContentPathConflict;
 use App\Support\ReservedContentPath;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class StoreNamespaceRequest extends FormRequest
 {
@@ -63,6 +65,32 @@ class StoreNamespaceRequest extends FormRequest
             'description' => ['nullable', 'string'],
             'cover_image' => ['nullable', 'image', 'max:2048'],
             'is_published' => ['boolean'],
+        ];
+    }
+
+    /**
+     * @return array<int, callable(Validator): void>
+     */
+    public function after(): array
+    {
+        return [
+            function (Validator $validator): void {
+                if ($validator->errors()->hasAny(['parent_id', 'slug'])) {
+                    return;
+                }
+
+                $conflictPath = ContentPathConflict::findNamespaceConflict(
+                    $this->parentId(),
+                    (string) $this->input('slug'),
+                );
+
+                if ($conflictPath !== null) {
+                    $validator->errors()->add(
+                        'slug',
+                        "This slug is already used by another page or child namespace at /{$conflictPath}.",
+                    );
+                }
+            },
         ];
     }
 }

--- a/app/Http/Requests/Admin/StorePostRequest.php
+++ b/app/Http/Requests/Admin/StorePostRequest.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Requests\Admin;
 
+use App\Support\ContentPathConflict;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class StorePostRequest extends FormRequest
 {
@@ -53,6 +55,38 @@ class StorePostRequest extends FormRequest
             'content' => ['required', 'string'],
             'is_draft' => ['boolean'],
             'published_at' => ['nullable', 'date'],
+        ];
+    }
+
+    /**
+     * @return array<int, callable(Validator): void>
+     */
+    public function after(): array
+    {
+        return [
+            function (Validator $validator): void {
+                if ($validator->errors()->has('slug')) {
+                    return;
+                }
+
+                $namespace = $this->route('namespace');
+
+                if ($namespace === null) {
+                    return;
+                }
+
+                $conflictPath = ContentPathConflict::findPostConflict(
+                    $namespace->id,
+                    (string) $this->input('slug'),
+                );
+
+                if ($conflictPath !== null) {
+                    $validator->errors()->add(
+                        'slug',
+                        "This slug is already used by another page or child namespace at /{$conflictPath}.",
+                    );
+                }
+            },
         ];
     }
 }

--- a/app/Http/Requests/Admin/UpdateNamespaceRequest.php
+++ b/app/Http/Requests/Admin/UpdateNamespaceRequest.php
@@ -3,10 +3,12 @@
 namespace App\Http\Requests\Admin;
 
 use App\Models\PostNamespace;
+use App\Support\ContentPathConflict;
 use App\Support\ReservedContentPath;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class UpdateNamespaceRequest extends FormRequest
 {
@@ -99,6 +101,33 @@ class UpdateNamespaceRequest extends FormRequest
             'description' => ['nullable', 'string'],
             'cover_image' => ['nullable', 'image', 'max:2048'],
             'is_published' => ['boolean'],
+        ];
+    }
+
+    /**
+     * @return array<int, callable(Validator): void>
+     */
+    public function after(): array
+    {
+        return [
+            function (Validator $validator): void {
+                if ($validator->errors()->hasAny(['parent_id', 'slug'])) {
+                    return;
+                }
+
+                $conflictPath = ContentPathConflict::findNamespaceConflict(
+                    $this->parentId(),
+                    (string) $this->input('slug'),
+                    $this->route('namespace'),
+                );
+
+                if ($conflictPath !== null) {
+                    $validator->errors()->add(
+                        'slug',
+                        "This slug is already used by another page or child namespace at /{$conflictPath}.",
+                    );
+                }
+            },
         ];
     }
 }

--- a/app/Http/Requests/Admin/UpdatePostRequest.php
+++ b/app/Http/Requests/Admin/UpdatePostRequest.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Requests\Admin;
 
+use App\Support\ContentPathConflict;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class UpdatePostRequest extends FormRequest
 {
@@ -55,6 +57,39 @@ class UpdatePostRequest extends FormRequest
             'content' => ['required', 'string'],
             'is_draft' => ['boolean'],
             'published_at' => ['nullable', 'date'],
+        ];
+    }
+
+    /**
+     * @return array<int, callable(Validator): void>
+     */
+    public function after(): array
+    {
+        return [
+            function (Validator $validator): void {
+                if ($validator->errors()->has('slug')) {
+                    return;
+                }
+
+                $namespace = $this->route('namespace');
+
+                if ($namespace === null) {
+                    return;
+                }
+
+                $conflictPath = ContentPathConflict::findPostConflict(
+                    $namespace->id,
+                    (string) $this->input('slug'),
+                    $this->route('post'),
+                );
+
+                if ($conflictPath !== null) {
+                    $validator->errors()->add(
+                        'slug',
+                        "This slug is already used by another page or child namespace at /{$conflictPath}.",
+                    );
+                }
+            },
         ];
     }
 }

--- a/app/Support/ContentPathConflict.php
+++ b/app/Support/ContentPathConflict.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+
+class ContentPathConflict
+{
+    public static function findNamespaceConflict(
+        ?int $parentId,
+        string $slug,
+        ?PostNamespace $namespace = null,
+    ): ?string {
+        $futureRootPath = self::buildNamespacePath($parentId, $slug);
+
+        if ($namespace === null) {
+            return self::findConflict([$futureRootPath]);
+        }
+
+        $affectedNamespaces = PostNamespace::query()
+            ->whereKey($namespace->id)
+            ->orWhere('full_path', 'like', $namespace->full_path.'/%')
+            ->get(['id', 'full_path']);
+
+        $affectedPosts = Post::query()
+            ->where('full_path', 'like', $namespace->full_path.'/%')
+            ->get(['id', 'full_path']);
+
+        $futurePaths = $affectedNamespaces
+            ->pluck('full_path')
+            ->map(fn (string $path): string => self::replacePathPrefix($path, $namespace->full_path, $futureRootPath))
+            ->merge(
+                $affectedPosts
+                    ->pluck('full_path')
+                    ->map(fn (string $path): string => self::replacePathPrefix($path, $namespace->full_path, $futureRootPath)),
+            )
+            ->values()
+            ->all();
+
+        return self::findConflict(
+            $futurePaths,
+            $affectedNamespaces->pluck('id')->all(),
+            $affectedPosts->pluck('id')->all(),
+        );
+    }
+
+    public static function findPostConflict(
+        int $namespaceId,
+        string $slug,
+        ?Post $post = null,
+    ): ?string {
+        $futurePath = self::buildPostPath($namespaceId, $slug);
+
+        return self::findConflict(
+            [$futurePath],
+            [],
+            $post ? [$post->id] : [],
+        );
+    }
+
+    private static function buildNamespacePath(?int $parentId, string $slug): string
+    {
+        $parentPath = $parentId === null
+            ? null
+            : PostNamespace::query()->whereKey($parentId)->value('full_path');
+
+        return self::joinPath($parentPath, $slug);
+    }
+
+    private static function buildPostPath(int $namespaceId, string $slug): string
+    {
+        $namespacePath = PostNamespace::query()->whereKey($namespaceId)->value('full_path');
+
+        return self::joinPath($namespacePath, $slug);
+    }
+
+    /**
+     * @param  array<int, string>  $paths
+     * @param  array<int, int>  $ignoredNamespaceIds
+     * @param  array<int, int>  $ignoredPostIds
+     */
+    private static function findConflict(
+        array $paths,
+        array $ignoredNamespaceIds = [],
+        array $ignoredPostIds = [],
+    ): ?string {
+        $namespaceConflict = PostNamespace::query()
+            ->whereIn('full_path', $paths)
+            ->when(
+                $ignoredNamespaceIds !== [],
+                fn ($query) => $query->whereNotIn('id', $ignoredNamespaceIds),
+            )
+            ->value('full_path');
+
+        if ($namespaceConflict !== null) {
+            return $namespaceConflict;
+        }
+
+        return Post::query()
+            ->whereIn('full_path', $paths)
+            ->when(
+                $ignoredPostIds !== [],
+                fn ($query) => $query->whereNotIn('id', $ignoredPostIds),
+            )
+            ->value('full_path');
+    }
+
+    private static function joinPath(?string $prefix, string $slug): string
+    {
+        return trim(implode('/', array_filter([$prefix, $slug])), '/');
+    }
+
+    private static function replacePathPrefix(
+        string $path,
+        string $currentPrefix,
+        string $futurePrefix,
+    ): string {
+        if ($path === $currentPrefix) {
+            return $futurePrefix;
+        }
+
+        return self::joinPath(
+            $futurePrefix,
+            ltrim(substr($path, strlen($currentPrefix)), '/'),
+        );
+    }
+}

--- a/resources/js/pages/admin/namespaces/create.tsx
+++ b/resources/js/pages/admin/namespaces/create.tsx
@@ -1,5 +1,4 @@
-import { Head } from '@inertiajs/react';
-import { Form } from '@inertiajs/react';
+import { Form, Head, Link, setLayoutProps } from '@inertiajs/react';
 import { useRef, useState } from 'react';
 import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import InputError from '@/components/input-error';
@@ -8,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { dashboard } from '@/routes';
 import { create } from '@/routes/admin/namespaces';
+import { namespace as namespaceRoute } from '@/routes/admin/posts';
 import { index as postsIndex } from '@/routes/admin/posts';
 
 function toSlug(value: string): string {
@@ -19,10 +19,51 @@ function toSlug(value: string): string {
         .replace(/-+/g, '-');
 }
 
-export default function Create() {
+type ParentNamespace = {
+    id: number;
+    name: string;
+    full_path: string;
+};
+
+export default function Create({
+    parentNamespace,
+}: {
+    parentNamespace?: ParentNamespace | null;
+}) {
     const [slug, setSlug] = useState('');
     const [slugTouched, setSlugTouched] = useState(false);
     const composing = useRef(false);
+    const createQuery = parentNamespace
+        ? `?${new URLSearchParams({ parent: String(parentNamespace.id) }).toString()}`
+        : '';
+    const createHref = `${create.url()}${createQuery}`;
+    const previewPath = parentNamespace
+        ? `${parentNamespace.full_path}/${slug || 'your-slug'}`
+        : slug || 'your-slug';
+    const cancelHref = parentNamespace
+        ? namespaceRoute.url(parentNamespace.id)
+        : postsIndex.url();
+
+    setLayoutProps({
+        breadcrumbs: [
+            { title: 'Dashboard', href: dashboard() },
+            { title: 'Posts', href: postsIndex.url() },
+            ...(parentNamespace
+                ? [
+                      {
+                          title: parentNamespace.name,
+                          href: namespaceRoute.url(parentNamespace.id),
+                      },
+                  ]
+                : []),
+            {
+                title: parentNamespace
+                    ? 'New Child Namespace'
+                    : 'New Namespace',
+                href: createHref,
+            },
+        ],
+    });
 
     function handleNameChange(e: React.ChangeEvent<HTMLInputElement>) {
         if (!slugTouched && !composing.current) {
@@ -47,13 +88,23 @@ export default function Create() {
 
     return (
         <>
-            <Head title="New Namespace" />
+            <Head
+                title={
+                    parentNamespace ? 'New Child Namespace' : 'New Namespace'
+                }
+            />
 
             <div className="space-y-6 p-4">
                 <div>
-                    <h1 className="text-2xl font-semibold">New Namespace</h1>
+                    <h1 className="text-2xl font-semibold">
+                        {parentNamespace
+                            ? 'New Child Namespace'
+                            : 'New Namespace'}
+                    </h1>
                     <p className="text-sm text-muted-foreground">
-                        Create a namespace to group your posts
+                        {parentNamespace
+                            ? `Create a child namespace inside ${parentNamespace.name}.`
+                            : 'Create a namespace to group your posts'}
                     </p>
                 </div>
 
@@ -63,6 +114,25 @@ export default function Create() {
                 >
                     {({ processing, errors }) => (
                         <>
+                            {parentNamespace && (
+                                <>
+                                    <input
+                                        type="hidden"
+                                        name="parent_id"
+                                        value={String(parentNamespace.id)}
+                                    />
+                                    <div className="grid gap-2">
+                                        <Label>Parent</Label>
+                                        <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
+                                            /{parentNamespace.full_path}
+                                        </div>
+                                        <InputError
+                                            message={errors.parent_id}
+                                        />
+                                    </div>
+                                </>
+                            )}
+
                             <div className="grid gap-2">
                                 <Label htmlFor="name">Name</Label>
                                 <Input
@@ -92,6 +162,16 @@ export default function Create() {
                                 <p className="text-xs text-muted-foreground">
                                     Lowercase letters, numbers, and hyphens
                                     only. Used in URLs.
+                                </p>
+                                <p className="text-xs text-muted-foreground">
+                                    Must be unique among pages and child
+                                    namespaces under{' '}
+                                    {parentNamespace
+                                        ? `/${parentNamespace.full_path}.`
+                                        : '/ (the root).'}
+                                </p>
+                                <p className="text-xs text-muted-foreground">
+                                    Path preview: /{previewPath}
                                 </p>
                                 <InputError message={errors.slug} />
                             </div>
@@ -141,10 +221,12 @@ export default function Create() {
 
                             <div className="flex gap-3">
                                 <Button type="submit" disabled={processing}>
-                                    Create Namespace
+                                    {parentNamespace
+                                        ? 'Create Child Namespace'
+                                        : 'Create Namespace'}
                                 </Button>
                                 <Button type="button" variant="outline" asChild>
-                                    <a href={postsIndex.url()}>Cancel</a>
+                                    <Link href={cancelHref}>Cancel</Link>
                                 </Button>
                             </div>
                         </>
@@ -154,11 +236,3 @@ export default function Create() {
         </>
     );
 }
-
-Create.layout = {
-    breadcrumbs: [
-        { title: 'Dashboard', href: dashboard() },
-        { title: 'Posts', href: postsIndex.url() },
-        { title: 'New Namespace', href: create.url() },
-    ],
-};

--- a/resources/js/pages/admin/posts/create.tsx
+++ b/resources/js/pages/admin/posts/create.tsx
@@ -7,6 +7,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
+import { cn } from '@/lib/utils';
 import { dashboard } from '@/routes';
 import {
     index,
@@ -18,6 +19,7 @@ import {
 type Namespace = {
     id: number;
     slug: string;
+    full_path: string;
     name: string;
 };
 
@@ -30,7 +32,13 @@ function toSlug(value: string): string {
         .replace(/-+/g, '-');
 }
 
-export default function Create({ namespace }: { namespace: Namespace }) {
+export default function Create({
+    namespace,
+    slugPrefix,
+}: {
+    namespace: Namespace;
+    slugPrefix?: string | null;
+}) {
     setLayoutProps({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
@@ -117,18 +125,39 @@ export default function Create({ namespace }: { namespace: Namespace }) {
 
                             <div className="grid gap-2">
                                 <Label htmlFor="slug">Slug</Label>
-                                <Input
-                                    id="slug"
-                                    name="slug"
-                                    placeholder="my-post-slug"
-                                    value={slug}
-                                    onChange={handleSlugChange}
-                                    required
-                                />
+                                <div className="flex rounded-md border border-input bg-transparent shadow-xs transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50">
+                                    {slugPrefix && (
+                                        <span className="inline-flex items-center border-r border-input bg-muted/30 px-3 text-sm whitespace-nowrap text-muted-foreground">
+                                            {slugPrefix}
+                                        </span>
+                                    )}
+                                    <Input
+                                        id="slug"
+                                        name="slug"
+                                        placeholder="my-post-slug"
+                                        value={slug}
+                                        onChange={handleSlugChange}
+                                        className={cn(
+                                            'border-0 shadow-none focus-visible:border-0 focus-visible:ring-0',
+                                            slugPrefix && 'rounded-l-none',
+                                        )}
+                                        required
+                                    />
+                                </div>
                                 <p className="text-xs text-muted-foreground">
                                     Lowercase letters, numbers, and hyphens
                                     only.
                                 </p>
+                                <p className="text-xs text-muted-foreground">
+                                    Must be unique among pages and child
+                                    namespaces under /{namespace.full_path}.
+                                </p>
+                                {slugPrefix && (
+                                    <p className="text-xs text-muted-foreground">
+                                        Path preview: /{slugPrefix}
+                                        {slug || 'your-slug'}
+                                    </p>
+                                )}
                                 <InputError message={errors.slug} />
                             </div>
 

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -20,6 +20,7 @@ import {
 type Namespace = {
     id: number;
     slug: string;
+    full_path: string;
     name: string;
 };
 
@@ -158,6 +159,10 @@ export default function Edit({
                                 <p className="text-xs text-muted-foreground">
                                     Lowercase letters, numbers, and hyphens
                                     only.
+                                </p>
+                                <p className="text-xs text-muted-foreground">
+                                    Must be unique among pages and child
+                                    namespaces under /{namespace.full_path}.
                                 </p>
                                 <InputError message={errors.slug} />
                             </div>

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -20,10 +20,12 @@ import { Head, Link, router } from '@inertiajs/react';
 import {
     CheckCircle2,
     ChevronDown,
+    ChevronRight,
     ChevronUp,
     ChevronsUpDown,
     ExternalLink,
     FilePen,
+    Folder,
     GripVertical,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -40,6 +42,7 @@ type Namespace = {
     name: string;
     is_published: boolean;
     posts_count: number;
+    children: Namespace[];
 };
 
 type Sort = {
@@ -92,9 +95,13 @@ function SortableHeader({
 function SortableRow({
     namespace,
     isDndActive,
+    isExpanded,
+    onToggle,
 }: {
     namespace: Namespace;
     isDndActive: boolean;
+    isExpanded: boolean;
+    onToggle: () => void;
 }) {
     const {
         attributes,
@@ -114,7 +121,7 @@ function SortableRow({
     return (
         <tr ref={setNodeRef} style={style} className="border-b last:border-0">
             <td className="w-8 px-2 py-3">
-                {isDndActive && (
+                {isDndActive ? (
                     <button
                         {...attributes}
                         {...listeners}
@@ -122,7 +129,19 @@ function SortableRow({
                     >
                         <GripVertical className="size-4" />
                     </button>
-                )}
+                ) : namespace.children.length > 0 ? (
+                    <button
+                        type="button"
+                        onClick={onToggle}
+                        className="text-muted-foreground hover:text-foreground"
+                    >
+                        {isExpanded ? (
+                            <ChevronDown className="size-4" />
+                        ) : (
+                            <ChevronRight className="size-4" />
+                        )}
+                    </button>
+                ) : null}
             </td>
             <td className="px-4 py-3 font-medium">
                 <Link
@@ -188,6 +207,124 @@ function SortableRow({
     );
 }
 
+function ChildRow({
+    namespace,
+    depth,
+    expandedIds,
+    onToggle,
+}: {
+    namespace: Namespace;
+    depth: number;
+    expandedIds: Set<number>;
+    onToggle: (id: number) => void;
+}) {
+    const isExpanded = expandedIds.has(namespace.id);
+
+    return (
+        <>
+            <tr className="border-b bg-muted/30 last:border-0">
+                <td className="w-8 px-2 py-3">
+                    {namespace.children.length > 0 && (
+                        <button
+                            type="button"
+                            onClick={() => onToggle(namespace.id)}
+                            className="text-muted-foreground hover:text-foreground"
+                        >
+                            {isExpanded ? (
+                                <ChevronDown className="size-4" />
+                            ) : (
+                                <ChevronRight className="size-4" />
+                            )}
+                        </button>
+                    )}
+                </td>
+                <td
+                    className="px-4 py-3 font-medium"
+                    style={{ paddingLeft: `${(depth + 1) * 1.5}rem` }}
+                >
+                    <div className="flex items-center gap-1.5">
+                        <Folder className="size-3.5 shrink-0 text-muted-foreground" />
+                        <Link
+                            href={namespaceRoute.url(namespace.id)}
+                            className="text-primary hover:underline"
+                        >
+                            {namespace.name}
+                        </Link>
+                    </div>
+                </td>
+                <td className="px-4 py-3 text-muted-foreground">
+                    /{namespace.full_path}
+                </td>
+                <td className="px-4 py-3">
+                    {namespace.is_published ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
+                            <CheckCircle2 className="size-3" />
+                            Published
+                        </span>
+                    ) : (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                            <FilePen className="size-3" />
+                            Draft
+                        </span>
+                    )}
+                </td>
+                <td className="px-4 py-3 text-muted-foreground">
+                    {namespace.posts_count}
+                </td>
+                <td className="px-4 py-3 text-right">
+                    <div className="flex items-center justify-end gap-2">
+                        {namespace.is_published && (
+                            <Button variant="outline" size="sm" asChild>
+                                <a
+                                    href={`/${namespace.full_path}`}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
+                                    <ExternalLink className="size-4" />
+                                    View
+                                </a>
+                            </Button>
+                        )}
+                        <Button variant="outline" size="sm" asChild>
+                            <Link
+                                href={NamespaceController.edit.url(
+                                    namespace.id,
+                                )}
+                            >
+                                Edit
+                            </Link>
+                        </Button>
+                        <Form
+                            {...NamespaceController.destroy.form(namespace.id)}
+                        >
+                            {({ processing }) => (
+                                <Button
+                                    type="submit"
+                                    variant="destructive"
+                                    size="sm"
+                                    disabled={processing}
+                                >
+                                    Delete
+                                </Button>
+                            )}
+                        </Form>
+                    </div>
+                </td>
+            </tr>
+            {isExpanded &&
+                namespace.children.map((child) => (
+                    <ChildRow
+                        key={child.id}
+                        namespace={child}
+                        depth={depth + 1}
+                        expandedIds={expandedIds}
+                        onToggle={onToggle}
+                    />
+                ))}
+        </>
+    );
+}
+
 export default function Index({
     namespaces: initialNamespaces,
     sort,
@@ -197,6 +334,15 @@ export default function Index({
 }) {
     const [namespaces, setNamespaces] = useState(initialNamespaces);
     const [reorderMode, setReorderMode] = useState(false);
+    const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
+
+    function toggleExpand(id: number) {
+        setExpandedIds((prev) => {
+            const next = new Set(prev);
+            next.has(id) ? next.delete(id) : next.add(id);
+            return next;
+        });
+    }
 
     useEffect(() => {
         setNamespaces(initialNamespaces);
@@ -352,13 +498,35 @@ export default function Index({
                                         items={namespaces.map((ns) => ns.id)}
                                         strategy={verticalListSortingStrategy}
                                     >
-                                        {namespaces.map((ns) => (
+                                        {namespaces.flatMap((ns) => [
                                             <SortableRow
                                                 key={ns.id}
                                                 namespace={ns}
                                                 isDndActive={reorderMode}
-                                            />
-                                        ))}
+                                                isExpanded={expandedIds.has(
+                                                    ns.id,
+                                                )}
+                                                onToggle={() =>
+                                                    toggleExpand(ns.id)
+                                                }
+                                            />,
+                                            ...(!reorderMode &&
+                                            expandedIds.has(ns.id)
+                                                ? ns.children.map((child) => (
+                                                      <ChildRow
+                                                          key={child.id}
+                                                          namespace={child}
+                                                          depth={1}
+                                                          expandedIds={
+                                                              expandedIds
+                                                          }
+                                                          onToggle={
+                                                              toggleExpand
+                                                          }
+                                                      />
+                                                  ))
+                                                : []),
+                                        ])}
                                     </SortableContext>
                                 </tbody>
                             </table>

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -339,7 +339,13 @@ export default function Index({
     function toggleExpand(id: number) {
         setExpandedIds((prev) => {
             const next = new Set(prev);
-            next.has(id) ? next.delete(id) : next.add(id);
+
+            if (next.has(id)) {
+                next.delete(id);
+            } else {
+                next.add(id);
+            }
+
             return next;
         });
     }

--- a/resources/js/pages/admin/posts/namespace.tsx
+++ b/resources/js/pages/admin/posts/namespace.tsx
@@ -1,8 +1,15 @@
 import { Head, Link, setLayoutProps } from '@inertiajs/react';
 import { Form } from '@inertiajs/react';
-import { CheckCircle2, Clock, ExternalLink, FilePen } from 'lucide-react';
+import {
+    CheckCircle2,
+    Clock,
+    ExternalLink,
+    FilePen,
+    FolderOpen,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { dashboard } from '@/routes';
+import { create as namespaceCreate } from '@/routes/admin/namespaces';
 import {
     index,
     namespace as namespaceRoute,
@@ -19,6 +26,15 @@ type Namespace = {
     name: string;
 };
 
+type ChildNamespace = {
+    id: number;
+    slug: string;
+    full_path: string;
+    name: string;
+    is_published: boolean;
+    posts_count: number;
+};
+
 type Post = {
     id: number;
     title: string;
@@ -28,17 +44,32 @@ type Post = {
     created_at: string;
 };
 
+type Ancestor = {
+    id: number;
+    name: string;
+};
+
 export default function Namespace({
     namespace,
+    ancestors,
+    children,
     posts,
 }: {
     namespace: Namespace;
+    ancestors: Ancestor[];
+    children: ChildNamespace[];
     posts: Post[];
 }) {
+    const childNamespaceCreateUrl = `${namespaceCreate.url()}?${new URLSearchParams({ parent: String(namespace.id) }).toString()}`;
+
     setLayoutProps({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
             { title: 'Posts', href: index.url() },
+            ...ancestors.map((ancestor) => ({
+                title: ancestor.name,
+                href: namespaceRoute.url(ancestor.id),
+            })),
             { title: namespace.name, href: namespaceRoute.url(namespace.id) },
         ],
     });
@@ -57,21 +88,93 @@ export default function Namespace({
                             /{namespace.slug}
                         </p>
                     </div>
-                    <Button asChild>
-                        <Link href={create.url(namespace.id)}>New Post</Link>
-                    </Button>
+                    <div className="flex items-center gap-2">
+                        <Button variant="outline" asChild>
+                            <Link href={childNamespaceCreateUrl}>
+                                New Child Namespace
+                            </Link>
+                        </Button>
+                        <Button asChild>
+                            <Link href={create.url(namespace.id)}>
+                                New Post
+                            </Link>
+                        </Button>
+                    </div>
                 </div>
+
+                {children.length > 0 && (
+                    <div className="space-y-2">
+                        <h2 className="text-sm font-medium text-muted-foreground">
+                            Child Namespaces
+                        </h2>
+                        <div className="rounded-xl border">
+                            <table className="w-full text-sm">
+                                <tbody>
+                                    {children.map((child) => (
+                                        <tr
+                                            key={child.id}
+                                            className="border-b last:border-0"
+                                        >
+                                            <td className="px-4 py-3">
+                                                <div className="flex items-center gap-2">
+                                                    <FolderOpen className="size-4 text-muted-foreground" />
+                                                    <Link
+                                                        href={namespaceRoute.url(
+                                                            child.id,
+                                                        )}
+                                                        className="font-medium text-primary hover:underline"
+                                                    >
+                                                        {child.name}
+                                                    </Link>
+                                                </div>
+                                            </td>
+                                            <td className="px-4 py-3 text-muted-foreground">
+                                                /{child.full_path}
+                                            </td>
+                                            <td className="px-4 py-3">
+                                                {child.is_published ? (
+                                                    <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
+                                                        <CheckCircle2 className="size-3" />
+                                                        Published
+                                                    </span>
+                                                ) : (
+                                                    <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                                                        <FilePen className="size-3" />
+                                                        Draft
+                                                    </span>
+                                                )}
+                                            </td>
+                                            <td className="px-4 py-3 text-muted-foreground">
+                                                {child.posts_count}{' '}
+                                                {child.posts_count === 1
+                                                    ? 'post'
+                                                    : 'posts'}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                )}
 
                 {posts.length === 0 ? (
                     <div className="rounded-xl border border-dashed p-12 text-center">
                         <p className="text-muted-foreground">
                             No posts in this namespace yet.
                         </p>
-                        <Button asChild className="mt-4">
-                            <Link href={create.url(namespace.id)}>
-                                Create your first post
-                            </Link>
-                        </Button>
+                        <div className="mt-4 flex items-center justify-center gap-2">
+                            <Button variant="outline" asChild>
+                                <Link href={childNamespaceCreateUrl}>
+                                    Create a child namespace
+                                </Link>
+                            </Button>
+                            <Button asChild>
+                                <Link href={create.url(namespace.id)}>
+                                    Create your first post
+                                </Link>
+                            </Button>
+                        </div>
                     </div>
                 ) : (
                     <div className="rounded-xl border">

--- a/tests/Feature/Admin/NamespaceControllerTest.php
+++ b/tests/Feature/Admin/NamespaceControllerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Post;
 use App\Models\PostNamespace;
 use App\Models\User;
 use App\Support\ReservedContentPath;
@@ -13,6 +14,23 @@ test('authenticated users can view the create form', function () {
     $user = User::factory()->create();
 
     $this->actingAs($user)->get(route('admin.namespaces.create'))->assertOk();
+});
+
+test('create form accepts a parent namespace query', function () {
+    $user = User::factory()->create();
+    $parent = PostNamespace::factory()->create([
+        'name' => 'Guides',
+        'slug' => 'guides',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.namespaces.create', ['parent' => $parent->id]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('parentNamespace.id', $parent->id)
+            ->where('parentNamespace.name', 'Guides')
+            ->where('parentNamespace.full_path', 'guides')
+        );
 });
 
 test('guests are redirected from the create form', function () {
@@ -123,6 +141,23 @@ test('storing a namespace allows the same slug under a different parent', functi
     ]);
 });
 
+test('storing a namespace rejects a slug used by a page in the same parent namespace', function () {
+    $user = User::factory()->create();
+    $parent = PostNamespace::factory()->create(['slug' => 'guide']);
+    Post::factory()->for($user)->create([
+        'namespace_id' => $parent->id,
+        'slug' => 'markdown',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('admin.namespaces.store'), [
+            'parent_id' => $parent->id,
+            'slug' => 'markdown',
+            'name' => 'Markdown',
+        ])
+        ->assertSessionHasErrors('slug');
+});
+
 test('storing a namespace requires a slug', function () {
     $user = User::factory()->create();
 
@@ -223,6 +258,27 @@ test('updating a namespace rejects using itself as a parent', function () {
             'name' => $namespace->name,
         ])
         ->assertSessionHasErrors('parent_id');
+});
+
+test('updating a namespace rejects a slug used by a page in the same parent namespace', function () {
+    $user = User::factory()->create();
+    $parent = PostNamespace::factory()->create(['slug' => 'guide']);
+    $namespace = PostNamespace::factory()->create([
+        'parent_id' => $parent->id,
+        'slug' => 'drafts',
+    ]);
+    Post::factory()->for($user)->create([
+        'namespace_id' => $parent->id,
+        'slug' => 'markdown',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.namespaces.update', $namespace), [
+            'parent_id' => $parent->id,
+            'slug' => 'markdown',
+            'name' => 'Markdown',
+        ])
+        ->assertSessionHasErrors('slug');
 });
 
 test('authenticated users can delete a namespace', function () {

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -17,6 +17,22 @@ test('authenticated users can view the posts index (namespace list)', function (
     $this->actingAs($user)->get(route('admin.posts.index'))->assertOk();
 });
 
+test('posts index only shows root namespaces with children nested', function () {
+    $user = User::factory()->create();
+    $root = PostNamespace::factory()->create(['name' => 'Root', 'parent_id' => null]);
+    $child = PostNamespace::factory()->create(['name' => 'Child', 'parent_id' => $root->id]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.index'))
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/index')
+            ->has('namespaces', 1)
+            ->where('namespaces.0.id', $root->id)
+            ->has('namespaces.0.children', 1)
+            ->where('namespaces.0.children.0.id', $child->id)
+        );
+});
+
 test('posts index defaults to namespace sort order', function () {
     $user = User::factory()->create();
     $first = PostNamespace::factory()->create(['name' => 'Beta', 'sort_order' => 1]);
@@ -64,6 +80,47 @@ test('authenticated users can view the namespace post list', function () {
     $this->actingAs($user)->get(route('admin.posts.namespace', $namespace))->assertOk();
 });
 
+test('namespace post list exposes ancestors for breadcrumb', function () {
+    $user = User::factory()->create();
+    $root = PostNamespace::factory()->create(['name' => 'Guides']);
+    $child = PostNamespace::factory()->create(['name' => 'Laravel', 'parent_id' => $root->id]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.namespace', $child))
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/namespace')
+            ->has('ancestors', 1)
+            ->where('ancestors.0.id', $root->id)
+            ->where('ancestors.0.name', 'Guides')
+        );
+});
+
+test('root namespace post list has empty ancestors', function () {
+    $user = User::factory()->create();
+    $root = PostNamespace::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.namespace', $root))
+        ->assertInertia(fn ($page) => $page
+            ->has('ancestors', 0)
+        );
+});
+
+test('namespace post list includes child namespaces', function () {
+    $user = User::factory()->create();
+    $parent = PostNamespace::factory()->create();
+    $child = PostNamespace::factory()->create(['parent_id' => $parent->id]);
+    $other = PostNamespace::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.namespace', $parent))
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/namespace')
+            ->has('children', 1)
+            ->where('children.0.id', $child->id)
+        );
+});
+
 test('namespace post list defaults to latest posts when no custom order exists', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create();
@@ -89,6 +146,28 @@ test('authenticated users can view the create form', function () {
     $namespace = PostNamespace::factory()->create();
 
     $this->actingAs($user)->get(route('admin.posts.create', $namespace))->assertOk();
+});
+
+test('create form exposes a slug prefix for nested namespaces', function () {
+    $user = User::factory()->create();
+    $parentNamespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'full_path' => 'guides',
+    ]);
+    $namespace = PostNamespace::factory()->create([
+        'parent_id' => $parentNamespace->id,
+        'slug' => 'laravel',
+        'full_path' => 'guides/laravel',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.create', $namespace))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/create')
+            ->where('namespace.id', $namespace->id)
+            ->where('slugPrefix', 'guides/laravel/')
+        );
 });
 
 test('authenticated users can store a post', function () {
@@ -156,6 +235,23 @@ test('the same slug is allowed in different namespaces', function () {
     $this->actingAs($user)
         ->post(route('admin.posts.store', $namespaceB), ['title' => 'My Post', 'slug' => 'shared-slug', 'content' => 'Some content'])
         ->assertRedirect(route('admin.posts.show', [$namespaceB, 'shared-slug']));
+});
+
+test('storing a post rejects a slug used by a child namespace in the same namespace', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create(['slug' => 'guide']);
+    PostNamespace::factory()->create([
+        'parent_id' => $namespace->id,
+        'slug' => 'markdown',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('admin.posts.store', $namespace), [
+            'title' => 'Markdown',
+            'slug' => 'markdown',
+            'content' => 'Some content',
+        ])
+        ->assertSessionHasErrors('slug');
 });
 
 test('storing a post requires content', function () {
@@ -251,6 +347,27 @@ test('updating a post allows keeping the same slug', function () {
         ->assertRedirect(route('admin.posts.show', [$namespace, 'my-slug']));
 
     expect($post->fresh()->slug)->toBe('my-slug');
+});
+
+test('updating a post rejects a slug used by a child namespace in the same namespace', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create(['slug' => 'guide']);
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'draft',
+    ]);
+    PostNamespace::factory()->create([
+        'parent_id' => $namespace->id,
+        'slug' => 'markdown',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.posts.update', [$namespace, $post]), [
+            'title' => 'Markdown',
+            'slug' => 'markdown',
+            'content' => 'Updated content.',
+        ])
+        ->assertSessionHasErrors('slug');
 });
 
 test('authenticated users can delete a post', function () {


### PR DESCRIPTION
Introduces ContentPathConflict utility to prevent namespace slugs and post slugs from colliding across the full_path tree. FormRequests for both namespace and post store/update now run an after() hook that rejects slugs already occupied by another page or sibling namespace anywhere in the path hierarchy.

Controller improvements: NamespaceController.create now accepts a ?parent query param and passes parentNamespace to the view; PostController.create exposes a slugPrefix for nested namespaces; store/update flash Inertia toast messages on success.

Frontend: namespace create form handles parent context and IME-safe slug generation; post create/edit forms add scheduled-publishing controls and a View Live button; posts index gains DnD reorder, collapsible child rows, and column sorting; namespace detail page lists child namespaces and posts with Draft/Scheduled/Published badges.