### PR TITLE
Add admin post image uploads

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\StorePostRequest;
 use App\Http\Requests\Admin\UpdatePostRequest;
+use App\Http\Requests\Admin\UploadPostImageRequest;
 use App\Models\Post;
 use App\Models\PostNamespace;
 use Illuminate\Http\RedirectResponse;
@@ -112,6 +113,21 @@ class PostController extends Controller
         Inertia::flash('toast', ['type' => 'success', 'message' => 'Post saved.']);
 
         return to_route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug]);
+    }
+
+    public function uploadNamespaceImage(UploadPostImageRequest $request, PostNamespace $namespace): RedirectResponse
+    {
+        $path = $request->file('image')->store("posts/{$namespace->full_path}", 'public');
+
+        return to_route('admin.posts.create', $namespace)->with('imageUrl', '/images/'.$path);
+    }
+
+    public function uploadImage(UploadPostImageRequest $request, PostNamespace $namespace, Post $post): RedirectResponse
+    {
+        $path = $request->file('image')->store("posts/{$post->id}", 'public');
+
+        return to_route('admin.posts.edit', ['namespace' => $namespace, 'post' => $post->slug])
+            ->with('imageUrl', '/images/'.$path);
     }
 
     public function destroy(PostNamespace $namespace, Post $post): RedirectResponse

--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ImageController extends Controller
+{
+    public function show(string $path): StreamedResponse
+    {
+        abort_unless(Storage::disk('public')->exists($path), 404);
+
+        return Storage::disk('public')->response($path);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -42,6 +42,7 @@ class HandleInertiaRequests extends Middleware
                 'user' => $request->user(),
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
+            'imageUrl' => session('imageUrl'),
         ];
     }
 }

--- a/app/Http/Requests/Admin/UploadPostImageRequest.php
+++ b/app/Http/Requests/Admin/UploadPostImageRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UploadPostImageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'image' => ['required', 'image', 'max:5120', 'mimes:jpg,jpeg,png,gif,webp'],
+        ];
+    }
+}

--- a/app/Support/ReservedContentPath.php
+++ b/app/Support/ReservedContentPath.php
@@ -7,6 +7,7 @@ class ReservedContentPath
     public const ROOT_SEGMENTS = [
         'admin',
         'api',
+        'images',
         'login',
         'register',
     ];

--- a/resources/js/components/markdown-editor.tsx
+++ b/resources/js/components/markdown-editor.tsx
@@ -1,15 +1,17 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import InputError from '@/components/input-error';
 import MarkdownContent from '@/components/markdown-content';
 import { Label } from '@/components/ui/label';
 import { createMarkdownComponents } from '@/lib/markdown-components';
 import { cn } from '@/lib/utils';
+import { router, usePage } from '@inertiajs/react';
 
 type Props = {
     name: string;
     label?: string;
     defaultValue?: string;
     error?: string;
+    uploadUrl?: string;
 };
 
 export default function MarkdownEditor({
@@ -17,8 +19,85 @@ export default function MarkdownEditor({
     label = 'Content',
     defaultValue = '',
     error,
+    uploadUrl,
 }: Props) {
     const [value, setValue] = useState(defaultValue);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const { props } = usePage<{ imageUrl?: string }>();
+    const previousImageUrlRef = useRef<string | undefined>(undefined);
+
+    useEffect(() => {
+        if (
+            props.imageUrl &&
+            props.imageUrl !== previousImageUrlRef.current &&
+            textareaRef.current
+        ) {
+            previousImageUrlRef.current = props.imageUrl;
+
+            const textarea = textareaRef.current;
+            const { selectionStart, selectionEnd } = textarea;
+            const markdown = `![image](${props.imageUrl})`;
+
+            setValue((prevContent) => {
+                const newContent =
+                    prevContent.substring(0, selectionStart) +
+                    markdown +
+                    prevContent.substring(selectionEnd);
+
+                setTimeout(() => {
+                    const newPosition = selectionStart + markdown.length;
+                    textarea.setSelectionRange(newPosition, newPosition);
+                    textarea.focus();
+                }, 0);
+
+                return newContent;
+            });
+        }
+    }, [props.imageUrl]);
+
+    const handleImageUpload = (file: File) => {
+        if (!uploadUrl || !file.type.startsWith('image/')) {
+            return;
+        }
+
+        router.post(
+            uploadUrl,
+            { image: file },
+            {
+                preserveState: true,
+                preserveScroll: true,
+                onError: (errors) => {
+                    alert(errors.image ?? 'Image upload failed.');
+                },
+            },
+        );
+    };
+
+    const handleDrop = (e: React.DragEvent<HTMLTextAreaElement>) => {
+        e.preventDefault();
+        const imageFile = Array.from(e.dataTransfer.files).find((file) =>
+            file.type.startsWith('image/'),
+        );
+
+        if (imageFile) {
+            handleImageUpload(imageFile);
+        }
+    };
+
+    const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+        const imageItem = Array.from(e.clipboardData.items).find((item) =>
+            item.type.startsWith('image/'),
+        );
+
+        if (imageItem) {
+            e.preventDefault();
+            const file = imageItem.getAsFile();
+
+            if (file) {
+                handleImageUpload(file);
+            }
+        }
+    };
 
     return (
         <div className="grid gap-2">
@@ -27,10 +106,16 @@ export default function MarkdownEditor({
                 <div className="grid gap-1">
                     <p className="text-xs text-muted-foreground">Markdown</p>
                     <textarea
+                        ref={textareaRef}
                         id={name}
                         name={name}
                         value={value}
                         onChange={(e) => setValue(e.target.value)}
+                        onDrop={uploadUrl ? handleDrop : undefined}
+                        onDragOver={
+                            uploadUrl ? (e) => e.preventDefault() : undefined
+                        }
+                        onPaste={uploadUrl ? handlePaste : undefined}
                         className={cn(
                             'h-[600px] w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 font-mono text-sm shadow-xs outline-none placeholder:text-muted-foreground',
                             'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
@@ -38,6 +123,11 @@ export default function MarkdownEditor({
                         )}
                         placeholder="Write markdown here..."
                     />
+                    {uploadUrl && (
+                        <p className="text-xs text-muted-foreground">
+                            Tip: Drag & drop or paste images to upload
+                        </p>
+                    )}
                 </div>
                 <div className="grid gap-1">
                     <p className="text-xs text-muted-foreground">Preview</p>

--- a/resources/js/pages/admin/posts/create.tsx
+++ b/resources/js/pages/admin/posts/create.tsx
@@ -14,6 +14,7 @@ import {
     namespace as namespaceRoute,
     create,
     store,
+    uploadNamespaceImage,
 } from '@/routes/admin/posts';
 
 type Namespace = {
@@ -164,6 +165,9 @@ export default function Create({
                             <MarkdownEditor
                                 name="content"
                                 error={errors.content}
+                                uploadUrl={uploadNamespaceImage.url(
+                                    namespace.id,
+                                )}
                             />
 
                             <div className="flex items-center gap-2">

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -15,6 +15,7 @@ import {
     edit,
     show,
     update,
+    uploadImage,
 } from '@/routes/admin/posts';
 
 type Namespace = {
@@ -171,6 +172,10 @@ export default function Edit({
                                 name="content"
                                 defaultValue={post.content}
                                 error={errors.content}
+                                uploadUrl={uploadImage.url({
+                                    namespace: namespace.id,
+                                    post: post.slug,
+                                })}
                             />
 
                             <div className="flex items-center gap-2">

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -14,10 +14,12 @@ Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () 
         Route::get('/', [PostController::class, 'index'])->name('index');
         Route::get('/{namespace}', [PostController::class, 'namespaceIndex'])->name('namespace');
         Route::get('/{namespace}/create', [PostController::class, 'create'])->name('create');
+        Route::post('/{namespace}/image', [PostController::class, 'uploadNamespaceImage'])->name('uploadNamespaceImage');
         Route::post('/{namespace}', [PostController::class, 'store'])->name('store');
         Route::get('/{namespace}/{post:slug}', [PostController::class, 'show'])->name('show')->scopeBindings();
         Route::get('/{namespace}/{post:slug}/edit', [PostController::class, 'edit'])->name('edit')->scopeBindings();
         Route::put('/{namespace}/{post:slug}', [PostController::class, 'update'])->name('update')->scopeBindings();
         Route::delete('/{namespace}/{post:slug}', [PostController::class, 'destroy'])->name('destroy')->scopeBindings();
+        Route::post('/{namespace}/{post:slug}/image', [PostController::class, 'uploadImage'])->name('uploadImage')->scopeBindings();
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,11 +1,16 @@
 <?php
 
 use App\Http\Controllers\Api\OgpController;
+use App\Http\Controllers\ImageController;
 use App\Http\Controllers\PostController;
 use App\Support\ReservedContentPath;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', [PostController::class, 'index'])->name('home');
+
+Route::get('/images/{path}', [ImageController::class, 'show'])
+    ->where('path', '.+')
+    ->name('images.show');
 
 Route::get('/api/ogp', [OgpController::class, 'fetch'])
     ->middleware('throttle:60,1')

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -4,6 +4,8 @@ use App\Models\Post;
 use App\Models\PostNamespace;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 
 uses(RefreshDatabase::class);
 
@@ -385,4 +387,59 @@ test('authenticated users can delete a post', function () {
         ->assertRedirect(route('admin.posts.namespace', $namespace));
 
     expect($post->fresh())->toBeNull();
+});
+
+test('authenticated users can upload an image to a post', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($user)->create(['namespace_id' => $namespace->id]);
+    $image = UploadedFile::fake()->image('photo.jpg');
+
+    $this->actingAs($user)
+        ->post(route('admin.posts.uploadImage', [$namespace, $post]), ['image' => $image])
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('imageUrl', "/images/posts/{$post->id}/{$image->hashName()}")
+        ->assertRedirect(route('admin.posts.edit', [$namespace, $post]));
+
+    Storage::disk('public')->assertExists("posts/{$post->id}/{$image->hashName()}");
+});
+
+test('guests cannot upload images', function () {
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->create(['namespace_id' => $namespace->id]);
+
+    $this->post(route('admin.posts.uploadImage', [$namespace, $post]), [])
+        ->assertRedirect(route('login'));
+});
+
+test('image upload rejects non-image files', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($user)->create(['namespace_id' => $namespace->id]);
+
+    $this->actingAs($user)
+        ->post(route('admin.posts.uploadImage', [$namespace, $post]), [
+            'image' => UploadedFile::fake()->create('document.pdf', 100, 'application/pdf'),
+        ])
+        ->assertSessionHasErrors('image');
+});
+
+test('authenticated users can upload an image during post creation', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $image = UploadedFile::fake()->image('photo.jpg');
+
+    $this->actingAs($user)
+        ->post(route('admin.posts.uploadNamespaceImage', $namespace), ['image' => $image])
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('imageUrl', "/images/posts/{$namespace->full_path}/{$image->hashName()}")
+        ->assertRedirect(route('admin.posts.create', $namespace));
+
+    Storage::disk('public')->assertExists("posts/{$namespace->full_path}/{$image->hashName()}");
 });


### PR DESCRIPTION
## Summary
- add admin routes, request validation, and image serving for post markdown image uploads
- support drag-and-drop and paste uploads in the markdown editor for create/edit forms
- cover image upload flows with feature tests
