### PR TITLE
Add private mode for public content

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+THINKSTREAM_PRIVATE_MODE=false
 APP_PORT=8000
 
 APP_LOCALE=en

--- a/app/Http/Middleware/HandlePrivateMode.php
+++ b/app/Http/Middleware/HandlePrivateMode.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class HandlePrivateMode
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (config('thinkstream.private_mode') && ! Auth::check()) {
+            return redirect()->guest(route('login'));
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\HandlePrivateMode;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -20,6 +21,10 @@ return Application::configure(basePath: dirname(__DIR__))
             HandleAppearance::class,
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
+        ]);
+
+        $middleware->alias([
+            'private.mode' => HandlePrivateMode::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/config/thinkstream.php
+++ b/config/thinkstream.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'private_mode' => (bool) env('THINKSTREAM_PRIVATE_MODE', false),
+
+];

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,11 +6,13 @@ use App\Http\Controllers\PostController;
 use App\Support\ReservedContentPath;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', [PostController::class, 'index'])->name('home');
+Route::middleware('private.mode')->group(function () {
+    Route::get('/', [PostController::class, 'index'])->name('home');
 
-Route::get('/images/{path}', [ImageController::class, 'show'])
-    ->where('path', '.+')
-    ->name('images.show');
+    Route::get('/images/{path}', [ImageController::class, 'show'])
+        ->where('path', '.+')
+        ->name('images.show');
+});
 
 Route::get('/api/ogp', [OgpController::class, 'fetch'])
     ->middleware('throttle:60,1')
@@ -24,6 +26,7 @@ require __DIR__.'/settings.php';
 require __DIR__.'/admin.php';
 
 // Wildcard routes must remain last so admin, auth, and API endpoints take precedence.
-Route::get('/{path}', [PostController::class, 'resolve'])
+Route::middleware('private.mode')
+    ->get('/{path}', [PostController::class, 'resolve'])
     ->where('path', ReservedContentPath::wildcardConstraint())
     ->name('posts.path');

--- a/tests/Feature/PrivateModeTest.php
+++ b/tests/Feature/PrivateModeTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+describe('private mode disabled', function () {
+    beforeEach(fn () => config(['thinkstream.private_mode' => false]));
+
+    test('unauthenticated user can access homepage', function () {
+        $this->get(route('home'))->assertSuccessful();
+    });
+
+    test('unauthenticated user can access post path', function () {
+        $namespace = PostNamespace::factory()->create(['is_published' => true]);
+        $post = Post::factory()->for($namespace, 'namespace')->published()->create();
+
+        $this->get(route('posts.path', ['path' => $post->full_path]))->assertSuccessful();
+    });
+
+    test('unauthenticated user can access images', function () {
+        Storage::fake('public');
+        Storage::disk('public')->put('test.png', 'fake-image');
+
+        $this->get(route('images.show', ['path' => 'test.png']))->assertSuccessful();
+    });
+});
+
+describe('private mode enabled', function () {
+    beforeEach(fn () => config(['thinkstream.private_mode' => true]));
+
+    test('unauthenticated user is redirected to login from homepage', function () {
+        $this->get(route('home'))->assertRedirect(route('login'));
+    });
+
+    test('unauthenticated user is redirected to login from post path', function () {
+        $namespace = PostNamespace::factory()->create(['is_published' => true]);
+        $post = Post::factory()->for($namespace, 'namespace')->published()->create();
+
+        $this->get(route('posts.path', ['path' => $post->full_path]))->assertRedirect(route('login'));
+    });
+
+    test('unauthenticated user is redirected to login from images', function () {
+        Storage::fake('public');
+        Storage::disk('public')->put('test.png', 'fake-image');
+
+        $this->get(route('images.show', ['path' => 'test.png']))->assertRedirect(route('login'));
+    });
+
+    test('authenticated user can access homepage', function () {
+        $this->actingAs(User::factory()->create())
+            ->get(route('home'))
+            ->assertSuccessful();
+    });
+
+    test('authenticated user can access post path', function () {
+        $namespace = PostNamespace::factory()->create(['is_published' => true]);
+        $post = Post::factory()->for($namespace, 'namespace')->published()->create();
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('posts.path', ['path' => $post->full_path]))
+            ->assertSuccessful();
+    });
+
+    test('authenticated user can access images', function () {
+        Storage::fake('public');
+        Storage::disk('public')->put('test.png', 'fake-image');
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('images.show', ['path' => 'test.png']))
+            ->assertSuccessful();
+    });
+
+    test('login page remains accessible and redirects back to the intended page after authentication', function () {
+        $namespace = PostNamespace::factory()->create(['is_published' => true]);
+        $post = Post::factory()->for($namespace, 'namespace')->published()->create();
+        $user = User::factory()->create();
+
+        $this->get(route('posts.path', ['path' => $post->full_path]))->assertRedirect(route('login'));
+        $this->get(route('login'))->assertSuccessful();
+
+        $this->post(route('login.store'), [
+            'email' => $user->email,
+            'password' => 'password',
+        ])->assertRedirect(route('posts.path', ['path' => $post->full_path], absolute: false));
+    });
+});


### PR DESCRIPTION
## Summary
- add a ThinkStream private mode flag and middleware to gate public content routes
- apply the middleware to the homepage, image route, and wildcard content route
- cover guest redirects, authenticated access, and intended redirect behavior with feature tests

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/PrivateModeTest.php tests/Feature/Auth/AuthenticationTest.php