### PR TITLE
Fix markdown TOC anchor generation

### DIFF
--- a/resources/js/hooks/use-markdown-toc.tsx
+++ b/resources/js/hooks/use-markdown-toc.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import type { Components } from 'react-markdown';
 import { createMarkdownComponents } from '@/lib/markdown-components';
+import { normalizeMarkdownHeadingText } from '@/lib/markdown-heading-text';
+import { slugify } from '@/lib/slugify';
 
 export type Heading = { level: number; text: string; id: string };
 
@@ -8,13 +10,6 @@ export type TocEntry = {
     headings: Heading[];
     components: Components;
 };
-
-function slugify(text: string): string {
-    return text
-        .toLowerCase()
-        .replace(/[^\w\s-]/g, '')
-        .replace(/[\s_]+/g, '-');
-}
 
 function extractHeadings(content: string, postSlug: string): Heading[] {
     const headings: Heading[] = [];
@@ -55,7 +50,7 @@ function extractHeadings(content: string, postSlug: string): Heading[] {
             continue;
         }
 
-        const text = match[2].trim();
+        const text = normalizeMarkdownHeadingText(match[2].trim());
 
         headings.push({
             level: match[1].length,

--- a/resources/js/lib/markdown-components.tsx
+++ b/resources/js/lib/markdown-components.tsx
@@ -4,14 +4,9 @@ import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 import type { Components } from 'react-markdown';
 import { CodeBlock } from '@/components/code-block';
 import { MarkdownImage } from '@/components/markdown-image';
+import { extractRenderedHeadingText } from '@/lib/markdown-heading-text';
 import { parseMarkdownImageMetadata } from '@/lib/markdown-syntax';
-
-function slugify(text: string): string {
-    return text
-        .toLowerCase()
-        .replace(/[^\w\s-]/g, '')
-        .replace(/[\s_]+/g, '-');
-}
+import { slugify } from '@/lib/slugify';
 
 function copyAnchorUrl(id: string): void {
     if (typeof window === 'undefined') {
@@ -77,10 +72,7 @@ function makeHeadingComponents(
 ): Pick<Components, 'h1' | 'h2' | 'h3'> {
     const makeTag = (level: 1 | 2 | 3) =>
         function Heading({ children }: { children?: ReactNode }) {
-            const text =
-                typeof children === 'string'
-                    ? children
-                    : String(children ?? '');
+            const text = extractRenderedHeadingText(children);
             const id = postSlug
                 ? `${postSlug}-${slugify(text)}`
                 : slugify(text);

--- a/resources/js/lib/markdown-heading-text.ts
+++ b/resources/js/lib/markdown-heading-text.ts
@@ -1,0 +1,41 @@
+import { Children, isValidElement } from 'react';
+import type { ReactNode } from 'react';
+
+export function normalizeMarkdownHeadingText(text: string): string {
+    return text
+        .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+        .replace(/!\[([^\]]*)\]\[[^\]]*\]/g, '$1')
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+        .replace(/\[([^\]]+)\]\[[^\]]*\]/g, '$1')
+        .replace(/<[^>]+>/g, '')
+        .trim();
+}
+
+export function extractRenderedHeadingText(node: ReactNode): string {
+    if (typeof node === 'string' || typeof node === 'number') {
+        return String(node);
+    }
+
+    if (typeof node === 'boolean' || node === null || node === undefined) {
+        return '';
+    }
+
+    if (Array.isArray(node)) {
+        return node.map(extractRenderedHeadingText).join('');
+    }
+
+    if (!isValidElement<{ children?: ReactNode; alt?: string }>(node)) {
+        return '';
+    }
+
+    if (
+        typeof node.props.alt === 'string' &&
+        node.props.children === undefined
+    ) {
+        return node.props.alt;
+    }
+
+    return Children.toArray(node.props.children)
+        .map(extractRenderedHeadingText)
+        .join('');
+}

--- a/resources/js/lib/slugify.ts
+++ b/resources/js/lib/slugify.ts
@@ -1,0 +1,9 @@
+export function slugify(text: string): string {
+    return text
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}\s_-]/gu, '')
+        .trim()
+        .replace(/[\s_]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+}

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -1,8 +1,17 @@
 import { Form, Head, Link, setLayoutProps } from '@inertiajs/react';
-import { CheckCircle2, Clock, FilePen } from 'lucide-react';
+import {
+    CheckCircle2,
+    Clock,
+    FilePen,
+    PanelRightClose,
+    PanelRightOpen,
+} from 'lucide-react';
+import { useMemo, useState } from 'react';
 import MarkdownContent from '@/components/markdown-content';
+import TableOfContents from '@/components/table-of-contents';
 import { Button } from '@/components/ui/button';
-import { createMarkdownComponents } from '@/lib/markdown-components';
+import { useMarkdownToc } from '@/hooks/use-markdown-toc';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { dashboard } from '@/routes';
 import {
     destroy,
@@ -35,6 +44,17 @@ export default function Show({
     namespace: Namespace;
     post: Post;
 }) {
+    const isMobile = useIsMobile();
+    const [tocOverride, setTocOverride] = useState<boolean | null>(null);
+    const tocPosts = useMemo(
+        () => [{ slug: post.slug, content: post.content }],
+        [post.content, post.slug],
+    );
+    const toc = useMarkdownToc(tocPosts);
+    const entry = toc.get(post.slug);
+    const hasHeadings = (entry?.headings.length ?? 0) > 0;
+    const tocVisible = tocOverride ?? !isMobile;
+
     setLayoutProps({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
@@ -80,7 +100,25 @@ export default function Show({
                         </div>
                     </div>
 
-                    <div className="flex shrink-0 gap-2">
+                    <div className="flex shrink-0 items-center gap-2">
+                        {hasHeadings && (
+                            <button
+                                type="button"
+                                onClick={() =>
+                                    setTocOverride(
+                                        (prev) => !(prev ?? !isMobile),
+                                    )
+                                }
+                                className="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                            >
+                                {tocVisible ? (
+                                    <PanelRightClose size={16} />
+                                ) : (
+                                    <PanelRightOpen size={16} />
+                                )}
+                                TOC
+                            </button>
+                        )}
                         <Button variant="outline" asChild>
                             <Link
                                 href={edit.url({
@@ -110,13 +148,52 @@ export default function Show({
                     </div>
                 </div>
 
-                <div className="rounded-xl border p-6">
-                    <div className="prose max-w-none prose-neutral dark:prose-invert">
-                        <MarkdownContent
-                            content={post.content}
-                            components={createMarkdownComponents()}
+                {tocVisible && hasHeadings && (
+                    <div className="lg:hidden">
+                        <TableOfContents
+                            posts={[
+                                {
+                                    id: post.id,
+                                    title: post.title,
+                                    slug: post.slug,
+                                    headings: entry!.headings,
+                                },
+                            ]}
                         />
                     </div>
+                )}
+
+                <div
+                    className={
+                        tocVisible && hasHeadings
+                            ? 'lg:grid lg:grid-cols-[1fr_240px] lg:gap-8'
+                            : ''
+                    }
+                >
+                    <div className="rounded-xl border p-6">
+                        <div className="prose max-w-none prose-neutral dark:prose-invert">
+                            <MarkdownContent
+                                content={post.content}
+                                components={entry?.components}
+                            />
+                        </div>
+                    </div>
+
+                    {tocVisible && hasHeadings && (
+                        <aside className="hidden lg:block">
+                            <TableOfContents
+                                sticky
+                                posts={[
+                                    {
+                                        id: post.id,
+                                        title: post.title,
+                                        slug: post.slug,
+                                        headings: entry!.headings,
+                                    },
+                                ]}
+                            />
+                        </aside>
+                    )}
                 </div>
             </div>
         </>

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -6,10 +6,9 @@ import {
     PanelRightClose,
     PanelRightOpen,
 } from 'lucide-react';
-import { useState } from 'react';
-import ContentNavTree, {
-    type ContentNavNode,
-} from '@/components/content-nav-tree';
+import { useMemo, useState } from 'react';
+import type { ContentNavNode } from '@/components/content-nav-tree';
+import ContentNavTree from '@/components/content-nav-tree';
 import MarkdownContent from '@/components/markdown-content';
 import TableOfContents from '@/components/table-of-contents';
 import { useMarkdownToc } from '@/hooks/use-markdown-toc';
@@ -49,7 +48,11 @@ export default function Show({
     const { auth } = usePage<{
         auth: { user: { id: number; name: string } | null };
     }>().props;
-    const toc = useMarkdownToc([post]);
+    const tocPosts = useMemo(
+        () => [{ slug: post.slug, content: post.content }],
+        [post.content, post.slug],
+    );
+    const toc = useMarkdownToc(tocPosts);
     const entry = toc.get(post.slug);
     const isMobile = useIsMobile();
     const [tocOverride, setTocOverride] = useState<boolean | null>(null);

--- a/tests-node/markdown/slugify.test.ts
+++ b/tests-node/markdown/slugify.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createElement } from 'react';
+import {
+    extractRenderedHeadingText,
+    normalizeMarkdownHeadingText,
+} from '../../resources/js/lib/markdown-heading-text.ts';
+import { slugify } from '../../resources/js/lib/slugify.ts';
+
+test('slugify converts underscores into dashes while preserving unicode letters', () => {
+    assert.equal(slugify('The `foo_bar` Method'), 'the-foo-bar-method');
+    assert.equal(slugify('snake_case Naming'), 'snake-case-naming');
+    assert.equal(slugify('日本語 foo_bar'), '日本語-foo-bar');
+});
+
+test('slugify trims repeated separators', () => {
+    assert.equal(slugify('  already---slugged__value  '), 'already-slugged-value');
+    assert.equal(slugify('---'), '');
+});
+
+test('markdown heading text normalization matches rendered heading text', () => {
+    const sourceText = normalizeMarkdownHeadingText(
+        'The `foo_bar` [Guide](https://example.com/docs)',
+    );
+    const renderedText = extractRenderedHeadingText([
+        'The ',
+        createElement('code', {}, 'foo_bar'),
+        ' ',
+        createElement('a', { href: 'https://example.com/docs' }, 'Guide'),
+    ]);
+
+    assert.equal(slugify(sourceText), 'the-foo-bar-guide');
+    assert.equal(slugify(renderedText), 'the-foo-bar-guide');
+});

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -42,6 +42,35 @@ MARKDOWN,
         );
 });
 
+test('formatted headings keep anchor ids and toc links in sync', function () {
+    $post = Post::factory()->published()->create([
+        'slug' => 'formatted-headings',
+        'title' => 'Formatted Headings',
+        'content' => <<<'MARKDOWN'
+## The `foo_bar` [Guide](https://example.com/docs)
+
+Body
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.path', ['path' => $post->full_path]))->resize(1600, 900);
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="heading-anchor-formatted-headings-the-foo-bar-guide"]')
+        ->assertPresent('[data-test="table-of-contents"][data-sticky="true"] [data-test="toc-link-formatted-headings-the-foo-bar-guide"]')
+        ->assertAttribute(
+            '[data-test="heading-anchor-formatted-headings-the-foo-bar-guide"]',
+            'href',
+            '#formatted-headings-the-foo-bar-guide',
+        )
+        ->assertAttribute(
+            '[data-test="table-of-contents"][data-sticky="true"] [data-test="toc-link-formatted-headings-the-foo-bar-guide"]',
+            'href',
+            '#formatted-headings-the-foo-bar-guide',
+        );
+});
+
 test('post navigation toggle stays within the viewport after page scroll', function () {
     $namespace = PostNamespace::factory()->create([
         'slug' => 'guides',


### PR DESCRIPTION
## Summary
- keep markdown heading anchors stable for underscores, inline code, and markdown links
- avoid re-parsing TOC data on every render by memoizing single-post inputs in show pages
- add node and browser coverage for slug generation and formatted heading anchor/TOC sync

## Testing
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail bash -lc './node_modules/.bin/eslint resources/js/hooks/use-markdown-toc.tsx resources/js/lib/markdown-components.tsx resources/js/lib/markdown-heading-text.ts resources/js/lib/slugify.ts resources/js/pages/posts/show.tsx resources/js/pages/admin/posts/show.tsx tests-node/markdown/slugify.test.ts'
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail artisan test --compact tests/Browser/SmokeTest.php