### PR TITLE
Fix TOC anchors for non-ASCII headings

### DIFF
--- a/resources/js/components/table-of-contents.tsx
+++ b/resources/js/components/table-of-contents.tsx
@@ -121,6 +121,17 @@ export default function TableOfContents({
             }
         };
 
+    const handleTocClick =
+        (id: string) => (e: React.MouseEvent<HTMLAnchorElement>) => {
+            e.preventDefault();
+            const target = document.getElementById(id);
+            if (target) {
+                target.scrollIntoView({ block: 'start' });
+            }
+            window.history.pushState(null, '', `#${encodeURIComponent(id)}`);
+            setActiveId(id);
+        };
+
     return (
         <nav
             ref={scrollContainerRef}
@@ -137,7 +148,8 @@ export default function TableOfContents({
                 <div key={post.id} className="space-y-1">
                     <a
                         ref={registerItemRef(`post-${post.slug}`)}
-                        href={`#post-${post.slug}`}
+                        href={`#${encodeURIComponent(`post-${post.slug}`)}`}
+                        onClick={handleTocClick(`post-${post.slug}`)}
                         data-test={`toc-link-post-${post.slug}`}
                         data-active={activeId === `post-${post.slug}`}
                         aria-current={
@@ -165,7 +177,8 @@ export default function TableOfContents({
                                 >
                                     <a
                                         ref={registerItemRef(h.id)}
-                                        href={`#${h.id}`}
+                                        href={`#${encodeURIComponent(h.id)}`}
+                                        onClick={handleTocClick(h.id)}
                                         data-test={`toc-link-${h.id}`}
                                         data-active={activeId === h.id}
                                         aria-current={

--- a/resources/js/lib/markdown-components.tsx
+++ b/resources/js/lib/markdown-components.tsx
@@ -79,11 +79,11 @@ function makeHeadingComponents(
             const Tag = `h${level}` as 'h1' | 'h2' | 'h3';
 
             return (
-                <Tag id={id} className="group scroll-mt-6">
+                <Tag id={id} className="group scroll-mt-24">
                     <span className="inline-flex items-center gap-2">
                         {children}
                         <a
-                            href={`#${id}`}
+                            href={`#${encodeURIComponent(id)}`}
                             onClick={() => copyAnchorUrl(id)}
                             aria-label={`Copy link to ${text}`}
                             title="Copy link to this section"

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -71,6 +71,75 @@ MARKDOWN,
         );
 });
 
+test('table of contents supports encoded hashes for japanese headings', function () {
+    $post = Post::factory()->published()->create([
+        'slug' => 'upgrade-12-to-13',
+        'title' => 'Upgrade 12 to 13',
+        'content' => collect([
+            '## Installation',
+            str_repeat('Setup steps. ', 120),
+            '## キャッシュ',
+            str_repeat('Cache migration notes. ', 120),
+        ])->implode("\n\n"),
+    ]);
+
+    $headingId = 'upgrade-12-to-13-キャッシュ';
+    $encodedHeadingId = rawurlencode($headingId);
+
+    $page = visit(route('posts.path', ['path' => $post->full_path]))->resize(1600, 900);
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent("[data-test=\"heading-anchor-{$headingId}\"]")
+        ->assertPresent("[data-test=\"table-of-contents\"][data-sticky=\"true\"] [data-test=\"toc-link-{$headingId}\"]")
+        ->assertAttribute(
+            "[data-test=\"heading-anchor-{$headingId}\"]",
+            'href',
+            "#{$encodedHeadingId}",
+        )
+        ->assertAttribute(
+            "[data-test=\"table-of-contents\"][data-sticky=\"true\"] [data-test=\"toc-link-{$headingId}\"]",
+            'href',
+            "#{$encodedHeadingId}",
+        );
+
+    expect($page->script(<<<JS
+        (() => {
+            const link = document.querySelector('[data-test="table-of-contents"][data-sticky="true"] [data-test="toc-link-{$headingId}"]');
+
+            if (! link) {
+                return null;
+            }
+
+            link.click();
+
+            return window.location.hash;
+        })()
+    JS))->toBe("#{$encodedHeadingId}");
+
+    $page->wait(0.5);
+
+    expect($page->script(<<<JS
+        (() => {
+            return document.querySelector('[data-test="table-of-contents"][data-sticky="true"] [data-test="toc-link-{$headingId}"]')?.getAttribute('data-active');
+        })()
+    JS))->toBe('true');
+
+    expect($page->script(<<<JS
+        (() => {
+            const heading = document.getElementById('{$headingId}');
+
+            if (! heading) {
+                return null;
+            }
+
+            const top = heading.getBoundingClientRect().top;
+
+            return top >= 0 && top <= 160;
+        })()
+    JS))->toBeTrue();
+});
+
 test('post navigation toggle stays within the viewport after page scroll', function () {
     $namespace = PostNamespace::factory()->create([
         'slug' => 'guides',


### PR DESCRIPTION
## Summary
- encode TOC and heading anchor hashes so section links stay URL-safe for non-ASCII IDs
- handle TOC clicks with JavaScript scrolling and history updates to avoid Chromium skipping Japanese anchor navigation
- increase heading scroll margin and add a browser regression test for Japanese TOC anchors

This follows the anchor-navigation behavior documented in `toc-anchor-system.md`.

## Testing
- `vendor/bin/sail npm run build`
- `vendor/bin/sail npm run types:check`
- `vendor/bin/sail npm run markdown:test`
- `APP_URL=http://localhost:8000 vendor/bin/sail artisan test --compact tests/Browser/SmokeTest.php --filter='published post headings expose copyable anchor links|formatted headings keep anchor ids and toc links in sync|table of contents supports encoded hashes for japanese headings|table of contents highlights the active heading and stays scrollable'