### PR TITLE
Refine namespace and post navigation UI

### DIFF
--- a/resources/js/components/app-shell.tsx
+++ b/resources/js/components/app-shell.tsx
@@ -17,5 +17,9 @@ export function AppShell({ children, variant = 'sidebar' }: Props) {
         );
     }
 
-    return <SidebarProvider defaultOpen={isOpen}>{children}</SidebarProvider>;
+    return (
+        <SidebarProvider defaultOpen={isOpen} className="overflow-x-hidden">
+            {children}
+        </SidebarProvider>
+    );
 }

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -24,7 +24,7 @@ const mainNavItems: NavItem[] = [
         icon: LayoutGrid,
     },
     {
-        title: 'Posts',
+        title: 'Namespaces',
         href: adminPostsIndex.url(),
         icon: NotebookPen,
     },

--- a/resources/js/components/breadcrumbs.tsx
+++ b/resources/js/components/breadcrumbs.tsx
@@ -26,7 +26,7 @@ export function Breadcrumbs({
                             return (
                                 <Fragment key={index}>
                                     <BreadcrumbItem>
-                                        {isLast ? (
+                                        {isLast || !item.href ? (
                                             <BreadcrumbPage>
                                                 {item.title}
                                             </BreadcrumbPage>

--- a/resources/js/components/table-of-contents.tsx
+++ b/resources/js/components/table-of-contents.tsx
@@ -106,10 +106,16 @@ export default function TableOfContents({
             return;
         }
 
-        activeItem.scrollIntoView({
-            block: 'nearest',
-            inline: 'nearest',
-        });
+        const containerTop = scrollContainer.getBoundingClientRect().top;
+        const itemTop = activeItem.getBoundingClientRect().top;
+        const offset = itemTop - containerTop;
+        const scrollTop = scrollContainer.scrollTop + offset;
+        const clampedTop =
+            scrollTop -
+            scrollContainer.clientHeight / 2 +
+            activeItem.offsetHeight / 2;
+
+        scrollContainer.scrollTop = Math.max(0, clampedTop);
     }, [activeId]);
 
     const registerItemRef =

--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -11,7 +11,7 @@ export default function AppSidebarLayout({
     return (
         <AppShell variant="sidebar">
             <AppSidebar />
-            <AppContent variant="sidebar" className="overflow-x-hidden">
+            <AppContent variant="sidebar">
                 <AppSidebarHeader breadcrumbs={breadcrumbs} />
                 {children}
             </AppContent>

--- a/resources/js/lib/markdown-components.tsx
+++ b/resources/js/lib/markdown-components.tsx
@@ -104,9 +104,30 @@ function makeHeadingComponents(
     };
 }
 
+function MarkdownLink({
+    href,
+    children,
+    ...props
+}: ComponentPropsWithoutRef<'a'>) {
+    const isExternal = href?.startsWith('http');
+
+    return (
+        <a
+            href={href}
+            className="underline underline-offset-2 hover:opacity-70"
+            target={isExternal ? '_blank' : undefined}
+            rel={isExternal ? 'noopener noreferrer' : undefined}
+            {...props}
+        >
+            {children}
+        </a>
+    );
+}
+
 export function createMarkdownComponents(postSlug?: string): Components {
     return {
         ...makeHeadingComponents(postSlug),
+        a: MarkdownLink,
         code: CodeBlock,
         img: MarkdownImage,
         p: MarkdownParagraph,

--- a/resources/js/pages/admin/posts/create.tsx
+++ b/resources/js/pages/admin/posts/create.tsx
@@ -43,7 +43,7 @@ export default function Create({
     setLayoutProps({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
-            { title: 'Posts', href: index.url() },
+            { title: 'Namespaces', href: index.url() },
             { title: namespace.name, href: namespaceRoute.url(namespace.id) },
             { title: 'New Post', href: create.url(namespace.id) },
         ],

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -90,12 +90,13 @@ export default function Edit({
     setLayoutProps({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
-            { title: 'Posts', href: index.url() },
+            { title: 'Namespaces', href: index.url() },
             { title: namespace.name, href: namespaceRoute.url(namespace.id) },
             {
                 title: post.title,
-                href: edit.url({ namespace: namespace.id, post: post.slug }),
+                href: show.url({ namespace: namespace.id, post: post.slug }),
             },
+            { title: 'Edit' },
         ],
     });
 

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -12,7 +12,6 @@ import { dashboard } from '@/routes';
 import {
     index,
     namespace as namespaceRoute,
-    edit,
     show,
     update,
     uploadImage,

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -402,12 +402,12 @@ export default function Index({
 
     return (
         <>
-            <Head title="Posts" />
+            <Head title="Namespaces" />
 
             <div className="space-y-6 p-4">
                 <div className="flex items-center justify-between">
                     <div>
-                        <h1 className="text-2xl font-semibold">Posts</h1>
+                        <h1 className="text-2xl font-semibold">Namespaces</h1>
                         <p className="text-sm text-muted-foreground">
                             Manage namespaces and their posts
                         </p>
@@ -547,6 +547,6 @@ export default function Index({
 Index.layout = {
     breadcrumbs: [
         { title: 'Dashboard', href: dashboard() },
-        { title: 'Posts', href: index.url() },
+        { title: 'Namespaces', href: index.url() },
     ],
 };

--- a/resources/js/pages/admin/posts/namespace.tsx
+++ b/resources/js/pages/admin/posts/namespace.tsx
@@ -65,7 +65,7 @@ export default function Namespace({
     setLayoutProps({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
-            { title: 'Posts', href: index.url() },
+            { title: 'Namespaces', href: index.url() },
             ...ancestors.map((ancestor) => ({
                 title: ancestor.name,
                 href: namespaceRoute.url(ancestor.id),

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -58,7 +58,7 @@ export default function Show({
     setLayoutProps({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
-            { title: 'Posts', href: index.url() },
+            { title: 'Namespaces', href: index.url() },
             { title: namespace.name, href: namespaceRoute.url(namespace.id) },
             {
                 title: post.title,

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -14,7 +14,10 @@ import TableOfContents from '@/components/table-of-contents';
 import { useMarkdownToc } from '@/hooks/use-markdown-toc';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { login } from '@/routes';
-import { index as adminPosts } from '@/routes/admin/posts';
+import {
+    edit as adminPostEdit,
+    index as adminPosts,
+} from '@/routes/admin/posts';
 import { path as contentPath } from '@/routes/posts';
 
 type PostNamespace = {
@@ -162,12 +165,23 @@ export default function Show({
                                 </button>
                             )}
                             {auth.user ? (
-                                <Link
-                                    href={adminPosts.url()}
-                                    className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-                                >
-                                    Admin
-                                </Link>
+                                <>
+                                    <Link
+                                        href={adminPostEdit.url({
+                                            namespace: namespace.id,
+                                            post: post.slug,
+                                        })}
+                                        className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                                    >
+                                        Edit
+                                    </Link>
+                                    <Link
+                                        href={adminPosts.url()}
+                                        className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                                    >
+                                        Admin
+                                    </Link>
+                                </>
                             ) : (
                                 <Link
                                     href={login.url()}

--- a/resources/js/types/navigation.ts
+++ b/resources/js/types/navigation.ts
@@ -3,7 +3,7 @@ import type { LucideIcon } from 'lucide-react';
 
 export type BreadcrumbItem = {
     title: string;
-    href: NonNullable<InertiaLinkProps['href']>;
+    href?: NonNullable<InertiaLinkProps['href']>;
 };
 
 export type NavItem = {

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -71,6 +71,35 @@ MARKDOWN,
         );
 });
 
+test('markdown external links open in a new tab safely', function () {
+    $post = Post::factory()->published()->create([
+        'slug' => 'external-links',
+        'title' => 'External Links',
+        'content' => <<<'MARKDOWN'
+[External Docs](https://example.com/docs)
+
+[Internal Docs](/guides/internal)
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
+
+    $page
+        ->assertSee('External Links')
+        ->assertAttribute(
+            'a[href="https://example.com/docs"]',
+            'target',
+            '_blank',
+        )
+        ->assertAttribute(
+            'a[href="https://example.com/docs"]',
+            'rel',
+            'noopener noreferrer',
+        )
+        ->assertAttributeMissing('a[href="/guides/internal"]', 'target')
+        ->assertAttributeMissing('a[href="/guides/internal"]', 'rel');
+});
+
 test('table of contents supports encoded hashes for japanese headings', function () {
     $post = Post::factory()->published()->create([
         'slug' => 'upgrade-12-to-13',


### PR DESCRIPTION
## Summary
- relabel the admin post management surfaces as namespaces and allow breadcrumb leaves without links
- refine public/admin post navigation with edit access, safer markdown links, and improved TOC centering
- keep the sidebar shell from introducing horizontal overflow and cover the external markdown link behavior in browser tests