### PR TITLE
Fix admin post heading deep links

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -112,7 +112,11 @@ class PostController extends Controller
 
         Inertia::flash('toast', ['type' => 'success', 'message' => 'Post saved.']);
 
-        return to_route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug]);
+        $fragment = $request->string('return_heading')->toString();
+        $hash = $fragment !== '' ? '#'.ltrim($fragment, '#') : '';
+
+        return redirect()->route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug])
+            ->setTargetUrl(route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug]).$hash);
     }
 
     public function uploadNamespaceImage(UploadPostImageRequest $request, PostNamespace $namespace): RedirectResponse

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -1,4 +1,4 @@
-import { createInertiaApp } from '@inertiajs/react';
+import { createInertiaApp, router } from '@inertiajs/react';
 import { Toaster } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { initializeTheme } from '@/hooks/use-appearance';
@@ -36,6 +36,39 @@ createInertiaApp({
         color: '#4B5563',
     },
 });
+
+function restoreHashTarget(): void {
+    if (typeof window === 'undefined' || !window.location.hash) {
+        return;
+    }
+
+    const id = decodeURIComponent(window.location.hash.slice(1));
+    let attempts = 0;
+
+    const scrollIntoView = () => {
+        const element = document.getElementById(id);
+
+        if (element) {
+            element.scrollIntoView();
+
+            return;
+        }
+
+        if (attempts >= 60) {
+            return;
+        }
+
+        attempts += 1;
+        requestAnimationFrame(scrollIntoView);
+    };
+
+    requestAnimationFrame(scrollIntoView);
+}
+
+if (typeof window !== 'undefined') {
+    restoreHashTarget();
+    router.on('navigate', restoreHashTarget);
+}
 
 // This will set light / dark mode on load...
 initializeTheme();

--- a/resources/js/components/markdown-editor.tsx
+++ b/resources/js/components/markdown-editor.tsx
@@ -2,7 +2,9 @@ import { useEffect, useRef, useState } from 'react';
 import InputError from '@/components/input-error';
 import MarkdownContent from '@/components/markdown-content';
 import { Label } from '@/components/ui/label';
+import { normalizeMarkdownHeadingText } from '@/lib/markdown-heading-text';
 import { createMarkdownComponents } from '@/lib/markdown-components';
+import { slugify } from '@/lib/slugify';
 import { cn } from '@/lib/utils';
 import { router, usePage } from '@inertiajs/react';
 
@@ -12,6 +14,7 @@ type Props = {
     defaultValue?: string;
     error?: string;
     uploadUrl?: string;
+    jumpTo?: number;
 };
 
 export default function MarkdownEditor({
@@ -20,11 +23,14 @@ export default function MarkdownEditor({
     defaultValue = '',
     error,
     uploadUrl,
+    jumpTo,
 }: Props) {
     const [value, setValue] = useState(defaultValue);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const previewRef = useRef<HTMLDivElement>(null);
     const { props } = usePage<{ imageUrl?: string }>();
     const previousImageUrlRef = useRef<string | undefined>(undefined);
+    const hasJumpedRef = useRef(false);
 
     useEffect(() => {
         if (
@@ -54,6 +60,51 @@ export default function MarkdownEditor({
             });
         }
     }, [props.imageUrl]);
+
+    useEffect(() => {
+        if (hasJumpedRef.current || jumpTo === undefined) {
+            return;
+        }
+
+        const textarea = textareaRef.current;
+
+        if (!textarea) {
+            return;
+        }
+
+        const clamped = Math.max(0, Math.min(jumpTo, textarea.value.length));
+        const lineEnd = textarea.value.indexOf('\n', clamped);
+        const selectionEnd = lineEnd === -1 ? textarea.value.length : lineEnd;
+        textarea.focus();
+        textarea.setSelectionRange(clamped, selectionEnd);
+
+        const lineHeight =
+            Number.parseFloat(window.getComputedStyle(textarea).lineHeight) ||
+            20;
+        const lineIndex =
+            textarea.value.slice(0, clamped).split(/\r?\n/).length - 1;
+        textarea.scrollTop = Math.max(
+            0,
+            lineIndex * lineHeight - lineHeight * 2,
+        );
+
+        const line = textarea.value.slice(clamped, selectionEnd);
+        const headingMatch = /^(#{1,6})\s+(.+?)(?:\s+#+\s*)?$/.exec(line);
+
+        if (headingMatch && previewRef.current) {
+            const id = slugify(normalizeMarkdownHeadingText(headingMatch[2]));
+            const el = previewRef.current.querySelector(`#${CSS.escape(id)}`);
+
+            if (el) {
+                const containerTop =
+                    previewRef.current.getBoundingClientRect().top;
+                const elTop = el.getBoundingClientRect().top;
+                previewRef.current.scrollTop += elTop - containerTop - 16;
+            }
+        }
+
+        hasJumpedRef.current = true;
+    }, [jumpTo]);
 
     const handleImageUpload = (file: File) => {
         if (!uploadUrl || !file.type.startsWith('image/')) {
@@ -131,7 +182,10 @@ export default function MarkdownEditor({
                 </div>
                 <div className="grid gap-1">
                     <p className="text-xs text-muted-foreground">Preview</p>
-                    <div className="h-[600px] overflow-y-auto rounded-md border border-input bg-transparent px-3 py-2 text-sm">
+                    <div
+                        ref={previewRef}
+                        className="h-[600px] overflow-y-auto rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+                    >
                         {value ? (
                             <div className="prose prose-sm max-w-none dark:prose-invert">
                                 <MarkdownContent

--- a/resources/js/hooks/use-markdown-toc.tsx
+++ b/resources/js/hooks/use-markdown-toc.tsx
@@ -1,6 +1,9 @@
 import { useMemo } from 'react';
 import type { Components } from 'react-markdown';
-import { createMarkdownComponents } from '@/lib/markdown-components';
+import {
+    createMarkdownComponents,
+    type MarkdownComponentOptions,
+} from '@/lib/markdown-components';
 import { normalizeMarkdownHeadingText } from '@/lib/markdown-heading-text';
 import { slugify } from '@/lib/slugify';
 
@@ -68,6 +71,7 @@ function extractHeadings(content: string, postSlug: string): Heading[] {
  */
 export function useMarkdownToc(
     posts: Array<{ slug: string; content: string }>,
+    componentOptions: MarkdownComponentOptions = {},
 ): Map<string, TocEntry> {
     return useMemo(() => {
         const map = new Map<string, TocEntry>();
@@ -75,10 +79,13 @@ export function useMarkdownToc(
         for (const post of posts) {
             map.set(post.slug, {
                 headings: extractHeadings(post.content, post.slug),
-                components: createMarkdownComponents(post.slug),
+                components: createMarkdownComponents(
+                    post.slug,
+                    componentOptions,
+                ),
             });
         }
 
         return map;
-    }, [posts]);
+    }, [componentOptions, posts]);
 }

--- a/resources/js/lib/markdown-components.tsx
+++ b/resources/js/lib/markdown-components.tsx
@@ -1,4 +1,4 @@
-import { Link as LinkIcon } from 'lucide-react';
+import { Link as LinkIcon, Pencil } from 'lucide-react';
 import { Children, isValidElement } from 'react';
 import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 import type { Components } from 'react-markdown';
@@ -7,6 +7,16 @@ import { MarkdownImage } from '@/components/markdown-image';
 import { extractRenderedHeadingText } from '@/lib/markdown-heading-text';
 import { parseMarkdownImageMetadata } from '@/lib/markdown-syntax';
 import { slugify } from '@/lib/slugify';
+import { cn } from '@/lib/utils';
+
+export type MarkdownComponentOptions = {
+    headingAnchorPlacement?: 'inline' | 'gutter';
+    onEditHeading?: (payload: {
+        level: number;
+        text: string;
+        id: string;
+    }) => void;
+};
 
 function copyAnchorUrl(id: string): void {
     if (typeof window === 'undefined') {
@@ -69,6 +79,10 @@ function MarkdownParagraph({
 
 function makeHeadingComponents(
     postSlug?: string,
+    {
+        headingAnchorPlacement = 'inline',
+        onEditHeading,
+    }: MarkdownComponentOptions = {},
 ): Pick<Components, 'h1' | 'h2' | 'h3'> {
     const makeTag = (level: 1 | 2 | 3) =>
         function Heading({ children }: { children?: ReactNode }) {
@@ -79,20 +93,59 @@ function makeHeadingComponents(
             const Tag = `h${level}` as 'h1' | 'h2' | 'h3';
 
             return (
-                <Tag id={id} className="group scroll-mt-24">
-                    <span className="inline-flex items-center gap-2">
-                        {children}
+                <Tag
+                    id={id}
+                    className={cn(
+                        'group scroll-mt-24',
+                        headingAnchorPlacement === 'gutter' && 'relative',
+                    )}
+                >
+                    {headingAnchorPlacement === 'gutter' && (
                         <a
                             href={`#${encodeURIComponent(id)}`}
                             onClick={() => copyAnchorUrl(id)}
                             aria-label={`Copy link to ${text}`}
                             title="Copy link to this section"
                             data-test={`heading-anchor-${id}`}
-                            className="text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none"
+                            data-anchor-placement={headingAnchorPlacement}
+                            className="absolute top-1/2 left-0 hidden -translate-x-[calc(100%+0.5rem)] -translate-y-1/2 rounded p-1 text-muted-foreground/60 opacity-0 transition-all group-hover:opacity-100 hover:bg-accent hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none md:inline-flex"
                         >
                             <LinkIcon className="size-4" />
                         </a>
-                    </span>
+                    )}
+                    {headingAnchorPlacement === 'inline' ? (
+                        <span className="inline-flex items-center gap-2">
+                            {children}
+                            <a
+                                href={`#${encodeURIComponent(id)}`}
+                                onClick={() => copyAnchorUrl(id)}
+                                aria-label={`Copy link to ${text}`}
+                                title="Copy link to this section"
+                                data-test={`heading-anchor-${id}`}
+                                data-anchor-placement={headingAnchorPlacement}
+                                className="text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none"
+                            >
+                                <LinkIcon className="size-4" />
+                            </a>
+                        </span>
+                    ) : onEditHeading && (level === 2 || level === 3) ? (
+                        <span className="inline-flex items-center gap-1.5">
+                            {children}
+                            <button
+                                type="button"
+                                onClick={() =>
+                                    onEditHeading({ level, text, id })
+                                }
+                                aria-label={`Edit section: ${text}`}
+                                title="Edit this section"
+                                className="rounded p-1 text-muted-foreground/50 opacity-0 transition-all group-hover:opacity-100 hover:bg-accent hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none"
+                            >
+                                <Pencil className="size-3.5" />
+                            </button>
+                        </span>
+                    ) : (
+                        children
+                    )}
                 </Tag>
             );
         };
@@ -124,9 +177,12 @@ function MarkdownLink({
     );
 }
 
-export function createMarkdownComponents(postSlug?: string): Components {
+export function createMarkdownComponents(
+    postSlug?: string,
+    options: MarkdownComponentOptions = {},
+): Components {
     return {
-        ...makeHeadingComponents(postSlug),
+        ...makeHeadingComponents(postSlug, options),
         a: MarkdownLink,
         code: CodeBlock,
         img: MarkdownImage,

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -1,6 +1,6 @@
 import { Form, Head, Link, setLayoutProps } from '@inertiajs/react';
 import { ExternalLink } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import InputError from '@/components/input-error';
 import MarkdownEditor from '@/components/markdown-editor';
 import { Button } from '@/components/ui/button';
@@ -48,6 +48,21 @@ export default function Edit({
     const isFutureDate = post.published_at
         ? new Date(post.published_at) > new Date()
         : false;
+
+    const { jumpTo, returnHeading } = useMemo(() => {
+        if (typeof window === 'undefined') {
+            return { jumpTo: undefined, returnHeading: null };
+        }
+
+        const params = new URLSearchParams(window.location.search);
+        const jumpParam = params.get('jump');
+        const n = Number(jumpParam);
+
+        return {
+            jumpTo: Number.isFinite(n) && jumpParam !== null ? n : undefined,
+            returnHeading: params.get('return_heading'),
+        };
+    }, []);
 
     const [isDraft, setIsDraft] = useState(post.is_draft);
     const [scheduleEnabled, setScheduleEnabled] = useState(isFutureDate);
@@ -136,6 +151,13 @@ export default function Edit({
                 >
                     {({ processing, errors }) => (
                         <>
+                            {returnHeading && (
+                                <input
+                                    type="hidden"
+                                    name="return_heading"
+                                    value={returnHeading}
+                                />
+                            )}
                             <div className="grid gap-2">
                                 <Label htmlFor="title">Title</Label>
                                 <Input
@@ -176,6 +198,7 @@ export default function Edit({
                                     namespace: namespace.id,
                                     post: post.slug,
                                 })}
+                                jumpTo={jumpTo}
                             />
 
                             <div className="flex items-center gap-2">

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -1,4 +1,4 @@
-import { Form, Head, Link, setLayoutProps } from '@inertiajs/react';
+import { Form, Head, Link, router, setLayoutProps } from '@inertiajs/react';
 import {
     CheckCircle2,
     Clock,
@@ -11,6 +11,7 @@ import MarkdownContent from '@/components/markdown-content';
 import TableOfContents from '@/components/table-of-contents';
 import { Button } from '@/components/ui/button';
 import { useMarkdownToc } from '@/hooks/use-markdown-toc';
+import { normalizeMarkdownHeadingText } from '@/lib/markdown-heading-text';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { dashboard } from '@/routes';
 import {
@@ -20,6 +21,67 @@ import {
     namespace as namespaceRoute,
     show,
 } from '@/routes/admin/posts';
+
+function findHeadingOffset(
+    content: string,
+    headingText: string,
+    level: number,
+): number | null {
+    const normalizedTarget = normalizeMarkdownHeadingText(headingText);
+
+    if (!normalizedTarget) {
+        return null;
+    }
+
+    const normalizedContent = content.replace(/\r\n/g, '\n');
+    const lines = normalizedContent.split('\n');
+    let offset = 0;
+    let activeFence: string | null = null;
+
+    for (const line of lines) {
+        const trimmedLine = line.trimStart();
+        const fenceMatch = /^(`{3,}|~{3,})/.exec(trimmedLine);
+
+        if (fenceMatch) {
+            const fence = fenceMatch[1];
+            const remainder = trimmedLine.slice(fence.length);
+
+            if (activeFence === null) {
+                activeFence = fence;
+            } else if (
+                fence[0] === activeFence[0] &&
+                fence.length >= activeFence.length &&
+                remainder.trim() === ''
+            ) {
+                activeFence = null;
+            }
+
+            offset += line.length + (offset + line.length < normalizedContent.length ? 1 : 0);
+
+            continue;
+        }
+
+        if (activeFence !== null) {
+            offset += line.length + (offset + line.length < normalizedContent.length ? 1 : 0);
+
+            continue;
+        }
+
+        const m = /^(#{1,6})\s+(.+?)(?:\s+#+\s*)?$/.exec(trimmedLine);
+
+        if (
+            m &&
+            m[1].length === level &&
+            normalizeMarkdownHeadingText(m[2]) === normalizedTarget
+        ) {
+            return offset;
+        }
+
+        offset += line.length + (offset + line.length < normalizedContent.length ? 1 : 0);
+    }
+
+    return null;
+}
 
 type Namespace = {
     id: number;
@@ -50,7 +112,42 @@ export default function Show({
         () => [{ slug: post.slug, content: post.content }],
         [post.content, post.slug],
     );
-    const toc = useMarkdownToc(tocPosts);
+
+    const handleEditHeading = ({
+        level,
+        text,
+        id,
+    }: {
+        level: number;
+        text: string;
+        id: string;
+    }) => {
+        const offset = findHeadingOffset(post.content, text, level);
+        const editUrl = edit.url({ namespace: namespace.id, post: post.slug });
+
+        if (typeof offset !== 'number') {
+            router.visit(editUrl);
+
+            return;
+        }
+
+        const clampedOffset = Math.max(
+            0,
+            Math.min(offset, post.content.length),
+        );
+        const params = new URLSearchParams({ jump: clampedOffset.toString() });
+
+        if (id) {
+            params.set('return_heading', id);
+        }
+
+        router.visit(`${editUrl}?${params.toString()}`);
+    };
+
+    const toc = useMarkdownToc(tocPosts, {
+        headingAnchorPlacement: 'gutter',
+        onEditHeading: handleEditHeading,
+    });
     const entry = toc.get(post.slug);
     const hasHeadings = (entry?.headings.length ?? 0) > 0;
     const tocVisible = tocOverride ?? !isMobile;

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -56,13 +56,17 @@ function findHeadingOffset(
                 activeFence = null;
             }
 
-            offset += line.length + (offset + line.length < normalizedContent.length ? 1 : 0);
+            offset +=
+                line.length +
+                (offset + line.length < normalizedContent.length ? 1 : 0);
 
             continue;
         }
 
         if (activeFence !== null) {
-            offset += line.length + (offset + line.length < normalizedContent.length ? 1 : 0);
+            offset +=
+                line.length +
+                (offset + line.length < normalizedContent.length ? 1 : 0);
 
             continue;
         }
@@ -77,7 +81,9 @@ function findHeadingOffset(
             return offset;
         }
 
-        offset += line.length + (offset + line.length < normalizedContent.length ? 1 : 0);
+        offset +=
+            line.length +
+            (offset + line.length < normalizedContent.length ? 1 : 0);
     }
 
     return null;

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Post;
 use App\Models\PostNamespace;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
@@ -289,4 +290,227 @@ test('table of contents highlights the active heading and stays scrollable', fun
     expect($page->script(<<<'JS'
         (() => document.querySelector('[data-test="table-of-contents"][data-sticky="true"] [data-test="toc-link-index-section-12"]')?.getAttribute('data-active'))()
     JS))->toBe('true');
+});
+
+test('admin post deep links restore hashed headings and use gutter anchors', function () {
+    $user = User::factory()->create([
+        'email' => 'test@example.com',
+    ]);
+
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+    ]);
+
+    $post = Post::factory()->for($namespace, 'namespace')->create([
+        'slug' => 'index',
+        'title' => 'Index',
+        'content' => collect(range(1, 20))
+            ->map(
+                fn (int $section): string => "## Intro {$section}\n\n".str_repeat(
+                    'Long body content. ',
+                    90,
+                ),
+            )
+            ->push("## Line Breaks\n\n".str_repeat('Long body content. ', 90))
+            ->implode("\n\n"),
+    ]);
+
+    $headingId = 'index-line-breaks';
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.posts.show', [
+        'namespace' => $namespace->id,
+        'post' => $post->slug,
+    ], absolute: false))->resize(1600, 900);
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->wait(0.5);
+
+    $page->script(<<<JS
+        (() => {
+            const url = new URL(window.location.href);
+            url.hash = '{$headingId}';
+            window.location.assign(url.toString());
+
+            return true;
+        })()
+    JS);
+
+    $page->wait(0.8);
+
+    expect($page->script(<<<JS
+        (() => {
+            const anchor = document.querySelector('[data-test="heading-anchor-{$headingId}"]');
+            const tocLink = document.querySelector('[data-test="table-of-contents"][data-sticky="true"] [data-test="toc-link-{$headingId}"]');
+
+            if (! anchor || ! tocLink) {
+                return null;
+            }
+
+            return {
+                anchorPlacement: anchor.getAttribute('data-anchor-placement'),
+                tocHref: tocLink.getAttribute('href'),
+            };
+        })()
+    JS))->toBe([
+        'anchorPlacement' => 'gutter',
+        'tocHref' => "#{$headingId}",
+    ]);
+
+    $metrics = $page->script(<<<JS
+        (() => {
+            const heading = document.getElementById('{$headingId}');
+
+            if (! heading) {
+                return null;
+            }
+
+            const top = heading.getBoundingClientRect().top;
+
+            return {
+                top,
+                scrollY: window.scrollY,
+                innerHeight: window.innerHeight,
+                hash: window.location.hash,
+            };
+        })()
+    JS);
+
+    expect($metrics['hash'])->toBe("#{$headingId}");
+    expect($metrics['scrollY'])->toBeGreaterThan(0);
+    expect($metrics['top'])->toBeGreaterThanOrEqual(0);
+    expect($metrics['top'])->toBeLessThanOrEqual($metrics['innerHeight']);
+
+    expect($page->script(<<<JS
+        (() => {
+            const heading = document.getElementById('{$headingId}');
+            const anchor = document.querySelector('[data-test="heading-anchor-{$headingId}"]');
+
+            if (! heading || ! anchor) {
+                return null;
+            }
+
+            const headingRect = heading.getBoundingClientRect();
+            const anchorRect = anchor.getBoundingClientRect();
+
+            return anchorRect.right <= headingRect.left + 8;
+        })()
+    JS))->toBeTrue();
+});
+
+test('admin section edit returns to the heading after saving', function () {
+    $user = User::factory()->create([
+        'email' => 'test@example.com',
+    ]);
+
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+    ]);
+
+    $post = Post::factory()->for($namespace, 'namespace')->create([
+        'slug' => 'index',
+        'title' => 'Index',
+        'content' => implode("\r\n\r\n", [
+            ...collect(range(1, 20))
+                ->map(
+                    fn (int $section): string => "## Intro {$section}\r\n\r\n".str_repeat(
+                        'Long body content. ',
+                        90,
+                    ),
+                )
+                ->all(),
+            implode("\n", [
+                '````md',
+                '## Not a heading',
+                '````',
+                '',
+                '## Line Breaks',
+                '',
+                str_repeat('Long body content. ', 90),
+            ]),
+        ]),
+    ]);
+
+    $headingId = 'index-line-breaks';
+    $expectedOffset = strpos(str_replace("\r\n", "\n", $post->content), '## Line Breaks');
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.posts.show', [
+        'namespace' => $namespace->id,
+        'post' => $post->slug,
+    ], absolute: false))->resize(1600, 900);
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->wait(0.5);
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const button = document.querySelector('button[aria-label="Edit section: Line Breaks"]');
+
+            if (! button) {
+                return null;
+            }
+
+            button.click();
+
+            return true;
+        })()
+    JS))->toBeTrue();
+
+    $page
+        ->wait(0.8)
+        ->assertSee('Edit Post');
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const textarea = document.querySelector('textarea[name="content"]');
+
+            if (! textarea) {
+                return null;
+            }
+
+            return {
+                selectionStart: textarea.selectionStart,
+                selectedText: textarea.value.slice(textarea.selectionStart, textarea.selectionEnd),
+            };
+        })()
+    JS))->toBe([
+        'selectionStart' => $expectedOffset,
+        'selectedText' => '## Line Breaks',
+    ]);
+
+    $page
+        ->click('Save Changes')
+        ->wait(0.8)
+        ->assertSee('Index');
+
+    $metrics = $page->script(<<<JS
+        (() => {
+            const heading = document.getElementById('{$headingId}');
+
+            if (! heading) {
+                return null;
+            }
+
+            const top = heading.getBoundingClientRect().top;
+
+            return {
+                hash: window.location.hash,
+                scrollY: window.scrollY,
+                top,
+                innerHeight: window.innerHeight,
+            };
+        })()
+    JS);
+
+    expect($metrics['hash'])->toBe("#{$headingId}");
+    expect($metrics['scrollY'])->toBeGreaterThan(0);
+    expect($metrics['top'])->toBeGreaterThanOrEqual(0);
+    expect($metrics['top'])->toBeLessThanOrEqual($metrics['innerHeight']);
 });

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -351,6 +351,25 @@ test('updating a post allows keeping the same slug', function () {
     expect($post->fresh()->slug)->toBe('my-slug');
 });
 
+test('updating a post redirects back to the requested heading fragment', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'my-slug',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.posts.update', [$namespace, $post]), [
+            'title' => 'Updated Title',
+            'slug' => 'my-slug',
+            'content' => 'Updated content.',
+            'return_heading' => 'my-slug-section-title',
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('admin.posts.show', [$namespace, 'my-slug']).'#my-slug-section-title');
+});
+
 test('updating a post rejects a slug used by a child namespace in the same namespace', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create(['slug' => 'guide']);


### PR DESCRIPTION
## Summary
- preserve admin post heading fragments through edit/save redirects and restore hash scrolling after Inertia navigation
- add gutter heading anchors plus section edit actions for admin post previews, including editor jump support
- cover the redirect, jump offset, and hash restoration flows with feature and browser tests

## Testing
- vendor/bin/sail artisan wayfinder:generate --with-form --no-interaction
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build
- vendor/bin/sail artisan test --compact tests/Feature/Admin/PostControllerTest.php --filter='requested heading fragment'
- vendor/bin/sail artisan test --compact tests/Browser/SmokeTest.php