### PR TITLE
Add post revision history and backup restore support

### DIFF
--- a/app/Console/Commands/NamespaceBackupCommand.php
+++ b/app/Console/Commands/NamespaceBackupCommand.php
@@ -11,7 +11,8 @@ class NamespaceBackupCommand extends Command
 {
     protected $signature = 'namespace:backup
                             {namespace : Namespace slug or ID}
-                            {--output= : Output zip path (defaults to storage/app/private/backups/slug-timestamp.zip)}';
+                            {--output= : Output zip path (defaults to storage/app/private/backups/slug-timestamp.zip)}
+                            {--with-revisions : Include post revision history in the backup}';
 
     protected $description = 'Backup a namespace and its posts as a zip archive';
 
@@ -52,7 +53,8 @@ class NamespaceBackupCommand extends Command
             return self::FAILURE;
         }
 
-        $postCount = $this->addNamespaceToZip($zip, $namespace, '');
+        $withRevisions = (bool) $this->option('with-revisions');
+        $postCount = $this->addNamespaceToZip($zip, $namespace, '', $withRevisions);
 
         $zip->close();
 
@@ -62,7 +64,7 @@ class NamespaceBackupCommand extends Command
         return self::SUCCESS;
     }
 
-    private function addNamespaceToZip(ZipArchive $zip, PostNamespace $namespace, string $prefix): int
+    private function addNamespaceToZip(ZipArchive $zip, PostNamespace $namespace, string $prefix, bool $withRevisions): int
     {
         $namespaceData = [
             'name' => $namespace->name,
@@ -77,7 +79,9 @@ class NamespaceBackupCommand extends Command
 
         $zip->addFromString($prefix.'_namespace.yaml', Yaml::dump($namespaceData, 4));
 
-        $posts = $namespace->posts()->get();
+        $posts = $withRevisions
+            ? $namespace->posts()->with('revisions.user')->get()
+            : $namespace->posts()->get();
 
         foreach ($posts as $post) {
             $frontmatter = [
@@ -91,12 +95,30 @@ class NamespaceBackupCommand extends Command
             $content = "---\n".Yaml::dump($frontmatter)."---\n\n".$post->content."\n";
 
             $zip->addFromString($prefix.$post->slug.'.md', $content);
+
+            if ($withRevisions && $post->revisions->isNotEmpty()) {
+                $revisionsData = $post->revisions
+                    ->sortBy('id')
+                    ->map(fn ($revision) => [
+                        'title' => $revision->title,
+                        'content' => $revision->content,
+                        'user_name' => $revision->user?->name,
+                        'created_at' => $revision->created_at->toIso8601String(),
+                    ])
+                    ->values()
+                    ->all();
+
+                $zip->addFromString(
+                    $prefix.$post->slug.'.revisions.json',
+                    json_encode($revisionsData, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+                );
+            }
         }
 
         $postCount = $posts->count();
 
         foreach ($namespace->children()->get() as $child) {
-            $postCount += $this->addNamespaceToZip($zip, $child, $prefix.$child->slug.'/');
+            $postCount += $this->addNamespaceToZip($zip, $child, $prefix.$child->slug.'/', $withRevisions);
         }
 
         return $postCount;

--- a/app/Console/Commands/NamespaceRestoreCommand.php
+++ b/app/Console/Commands/NamespaceRestoreCommand.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Models\Post;
 use App\Models\PostNamespace;
+use App\Models\PostRevision;
 use App\Models\User;
 use Illuminate\Console\Command;
 use Symfony\Component\Yaml\Yaml;
@@ -11,7 +12,9 @@ use ZipArchive;
 
 class NamespaceRestoreCommand extends Command
 {
-    protected $signature = 'namespace:restore {path : Path to a backup zip or directory}';
+    protected $signature = 'namespace:restore
+                            {path : Path to a backup zip or directory}
+                            {--with-revisions : Import post revision history if present in the backup}';
 
     protected $description = 'Restore a namespace and its posts from a backup zip or directory';
 
@@ -90,14 +93,15 @@ class NamespaceRestoreCommand extends Command
             return self::FAILURE;
         }
 
-        $postCount = $this->restoreDirectory($path, null, $user);
+        $withRevisions = (bool) $this->option('with-revisions');
+        $postCount = $this->restoreDirectory($path, null, $user, $withRevisions);
 
         $this->info("Restored {$postCount} posts.");
 
         return self::SUCCESS;
     }
 
-    private function restoreDirectory(string $path, ?PostNamespace $parent, User $user): int
+    private function restoreDirectory(string $path, ?PostNamespace $parent, User $user, bool $withRevisions): int
     {
         $namespaceData = Yaml::parseFile($path.'/_namespace.yaml');
 
@@ -132,7 +136,7 @@ class NamespaceRestoreCommand extends Command
             $frontmatter = Yaml::parse($matches[1]);
             $body = trim(substr($raw, strlen($matches[0])));
 
-            Post::updateOrCreate(
+            $post = Post::updateOrCreate(
                 ['namespace_id' => $namespace->id, 'slug' => $frontmatter['slug']],
                 [
                     'user_id' => $user->id,
@@ -143,6 +147,10 @@ class NamespaceRestoreCommand extends Command
                 ],
             );
 
+            if ($withRevisions) {
+                $this->restoreRevisions($post, $path.'/'.$frontmatter['slug'].'.revisions.json');
+            }
+
             $postCount++;
         }
 
@@ -150,11 +158,39 @@ class NamespaceRestoreCommand extends Command
 
         foreach (glob($path.'/*/') as $childDir) {
             if (file_exists($childDir.'_namespace.yaml')) {
-                $postCount += $this->restoreDirectory($childDir, $namespace, $user);
+                $postCount += $this->restoreDirectory($childDir, $namespace, $user, $withRevisions);
             }
         }
 
         return $postCount;
+    }
+
+    private function restoreRevisions(Post $post, string $revisionsPath): void
+    {
+        if (! file_exists($revisionsPath)) {
+            return;
+        }
+
+        $data = json_decode(file_get_contents($revisionsPath), true);
+
+        if (! is_array($data) || empty($data)) {
+            return;
+        }
+
+        $post->revisions()->delete();
+
+        $now = now();
+
+        $records = array_map(fn (array $revision) => [
+            'post_id' => $post->id,
+            'user_id' => null,
+            'title' => $revision['title'],
+            'content' => $revision['content'],
+            'created_at' => $revision['created_at'],
+            'updated_at' => $now,
+        ], $data);
+
+        PostRevision::insert($records);
     }
 
     private function removeDirectory(string $path): void

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -3,11 +3,13 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\RestorePostRevisionRequest;
 use App\Http\Requests\Admin\StorePostRequest;
 use App\Http\Requests\Admin\UpdatePostRequest;
 use App\Http\Requests\Admin\UploadPostImageRequest;
 use App\Models\Post;
 use App\Models\PostNamespace;
+use App\Models\PostRevision;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -108,7 +110,19 @@ class PostController extends Controller
 
     public function update(UpdatePostRequest $request, PostNamespace $namespace, Post $post): RedirectResponse
     {
-        $post->update($request->validated());
+        $data = $request->validated();
+        $hasChanges = $post->title !== ($data['title'] ?? $post->title)
+            || $post->content !== ($data['content'] ?? $post->content);
+
+        if ($hasChanges) {
+            $post->revisions()->create([
+                'user_id' => $request->user()->id,
+                'title' => $post->title,
+                'content' => $post->content,
+            ]);
+        }
+
+        $post->update($data);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => 'Post saved.']);
 
@@ -117,6 +131,63 @@ class PostController extends Controller
 
         return redirect()->route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug])
             ->setTargetUrl(route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug]).$hash);
+    }
+
+    public function revisions(PostNamespace $namespace, Post $post): Response
+    {
+        $revisions = $post->revisions()
+            ->with('user')
+            ->latest()
+            ->limit(50)
+            ->get()
+            ->map(fn (PostRevision $revision) => [
+                'id' => $revision->id,
+                'title' => $revision->title,
+                'content' => $revision->content,
+                'created_at' => $revision->created_at->toISOString(),
+                'user' => $revision->user ? [
+                    'id' => $revision->user->id,
+                    'name' => $revision->user->name,
+                ] : null,
+                'is_current' => false,
+            ]);
+
+        $currentRevision = [
+            'id' => 0,
+            'title' => $post->title,
+            'content' => $post->content,
+            'created_at' => $post->updated_at?->toISOString(),
+            'user' => null,
+            'is_current' => true,
+        ];
+
+        return Inertia::render('admin/posts/revisions', [
+            'namespace' => $namespace,
+            'post' => $post->only(['id', 'slug', 'title']),
+            'revisions' => $revisions->prepend($currentRevision)->values(),
+        ]);
+    }
+
+    public function restore(
+        RestorePostRevisionRequest $request,
+        PostNamespace $namespace,
+        Post $post,
+        PostRevision $revision
+    ): RedirectResponse {
+        $post->revisions()->create([
+            'user_id' => $request->user()->id,
+            'title' => $post->title,
+            'content' => $post->content,
+        ]);
+
+        $post->update([
+            'title' => $revision->title,
+            'content' => $revision->content,
+        ]);
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => 'Revision restored.']);
+
+        return to_route('admin.posts.revisions', ['namespace' => $namespace, 'post' => $post->slug]);
     }
 
     public function uploadNamespaceImage(UploadPostImageRequest $request, PostNamespace $namespace): RedirectResponse

--- a/app/Http/Requests/Admin/RestorePostRevisionRequest.php
+++ b/app/Http/Requests/Admin/RestorePostRevisionRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RestorePostRevisionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -6,6 +6,7 @@ use Database\Factories\PostFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Post extends Model
 {
@@ -44,5 +45,10 @@ class Post extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(PostRevision::class);
     }
 }

--- a/app/Models/PostRevision.php
+++ b/app/Models/PostRevision.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\PostRevisionFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PostRevision extends Model
+{
+    /** @use HasFactory<PostRevisionFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'post_id',
+        'user_id',
+        'title',
+        'content',
+    ];
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/factories/PostRevisionFactory.php
+++ b/database/factories/PostRevisionFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Post;
+use App\Models\PostRevision;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PostRevision>
+ */
+class PostRevisionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $title = fake()->sentence(4);
+
+        return [
+            'post_id' => Post::factory(),
+            'user_id' => User::factory(),
+            'title' => $title,
+            'content' => implode("\n\n", fake()->paragraphs(2)),
+        ];
+    }
+}

--- a/database/migrations/2026_04_20_055210_create_post_revisions_table.php
+++ b/database/migrations/2026_04_20_055210_create_post_revisions_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('post_revisions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('title');
+            $table->longText('content');
+            $table->timestamps();
+
+            $table->index(['post_id', 'created_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('post_revisions');
+    }
+};

--- a/database/seeders/NamespaceBackupSeeder.php
+++ b/database/seeders/NamespaceBackupSeeder.php
@@ -11,7 +11,7 @@ class NamespaceBackupSeeder extends Seeder
 {
     public function run(): void
     {
-        $backupDir = database_path('backups');
+        $backupDir = storage_path('app/private/backups');
 
         $zips = glob($backupDir.'/*.zip');
 

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -12,6 +12,7 @@ import { dashboard } from '@/routes';
 import {
     index,
     namespace as namespaceRoute,
+    revisions,
     show,
     update,
     uploadImage,
@@ -126,20 +127,32 @@ export default function Edit({
                             {namespace.slug}/{post.slug}
                         </p>
                     </div>
-                    {!post.is_draft &&
-                        post.published_at &&
-                        new Date(post.published_at) <= new Date() && (
-                            <Button variant="outline" size="sm" asChild>
-                                <a
-                                    href={`/${post.full_path}`}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                >
-                                    <ExternalLink className="size-4" />
-                                    View Live
-                                </a>
-                            </Button>
-                        )}
+                    <div className="flex items-center gap-2">
+                        <Button variant="ghost" size="sm" asChild>
+                            <Link
+                                href={revisions.url({
+                                    namespace: namespace.id,
+                                    post: post.slug,
+                                })}
+                            >
+                                変更履歴
+                            </Link>
+                        </Button>
+                        {!post.is_draft &&
+                            post.published_at &&
+                            new Date(post.published_at) <= new Date() && (
+                                <Button variant="outline" size="sm" asChild>
+                                    <a
+                                        href={`/${post.full_path}`}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                    >
+                                        <ExternalLink className="size-4" />
+                                        View Live
+                                    </a>
+                                </Button>
+                            )}
+                    </div>
                 </div>
 
                 <Form

--- a/resources/js/pages/admin/posts/revisions.tsx
+++ b/resources/js/pages/admin/posts/revisions.tsx
@@ -8,7 +8,6 @@ import {
     edit,
     index,
     namespace as namespaceRoute,
-    revisions,
     show,
 } from '@/routes/admin/posts';
 import { restore } from '@/routes/admin/posts/revisions';

--- a/resources/js/pages/admin/posts/revisions.tsx
+++ b/resources/js/pages/admin/posts/revisions.tsx
@@ -1,0 +1,298 @@
+import { Form, Head, Link, setLayoutProps } from '@inertiajs/react';
+import { History } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { dashboard } from '@/routes';
+import {
+    edit,
+    index,
+    namespace as namespaceRoute,
+    revisions,
+    show,
+} from '@/routes/admin/posts';
+import { restore } from '@/routes/admin/posts/revisions';
+
+type Namespace = {
+    id: number;
+    slug: string;
+    name: string;
+};
+
+type Post = {
+    id: number;
+    slug: string;
+    title: string;
+};
+
+type Revision = {
+    id: number;
+    title: string;
+    content: string | null;
+    created_at: string;
+    user?: {
+        id: number;
+        name: string;
+    };
+    is_current?: boolean;
+};
+
+type DiffLine = {
+    type: 'add' | 'remove' | 'same';
+    text: string;
+};
+
+function buildLineDiff(previous: string, next: string): DiffLine[] {
+    const previousLines = previous.split('\n');
+    const nextLines = next.split('\n');
+    const matrix = Array.from({ length: previousLines.length + 1 }, () =>
+        Array(nextLines.length + 1).fill(0),
+    );
+
+    for (let i = 1; i <= previousLines.length; i += 1) {
+        for (let j = 1; j <= nextLines.length; j += 1) {
+            if (previousLines[i - 1] === nextLines[j - 1]) {
+                matrix[i][j] = matrix[i - 1][j - 1] + 1;
+            } else {
+                matrix[i][j] = Math.max(matrix[i - 1][j], matrix[i][j - 1]);
+            }
+        }
+    }
+
+    const diff: DiffLine[] = [];
+    let i = previousLines.length;
+    let j = nextLines.length;
+
+    while (i > 0 && j > 0) {
+        if (previousLines[i - 1] === nextLines[j - 1]) {
+            diff.unshift({ type: 'same', text: previousLines[i - 1] });
+            i -= 1;
+            j -= 1;
+        } else if (matrix[i - 1][j] >= matrix[i][j - 1]) {
+            diff.unshift({ type: 'remove', text: previousLines[i - 1] });
+            i -= 1;
+        } else {
+            diff.unshift({ type: 'add', text: nextLines[j - 1] });
+            j -= 1;
+        }
+    }
+
+    while (i > 0) {
+        diff.unshift({ type: 'remove', text: previousLines[i - 1] });
+        i -= 1;
+    }
+
+    while (j > 0) {
+        diff.unshift({ type: 'add', text: nextLines[j - 1] });
+        j -= 1;
+    }
+
+    return diff;
+}
+
+export default function Revisions({
+    namespace,
+    post,
+    revisions: revisionList,
+}: {
+    namespace: Namespace;
+    post: Post;
+    revisions: Revision[];
+}) {
+    const [selectedIds, setSelectedIds] = useState<number[]>([]);
+
+    setLayoutProps({
+        breadcrumbs: [
+            { title: 'Dashboard', href: dashboard() },
+            { title: 'Namespaces', href: index.url() },
+            { title: namespace.name, href: namespaceRoute.url(namespace.id) },
+            {
+                title: post.title,
+                href: show.url({ namespace: namespace.id, post: post.slug }),
+            },
+            {
+                title: 'Edit',
+                href: edit.url({ namespace: namespace.id, post: post.slug }),
+            },
+            { title: '変更履歴' },
+        ],
+    });
+
+    const toggleRevision = (revisionId: number) => {
+        setSelectedIds((current) => {
+            if (current.includes(revisionId)) {
+                return current.filter((id) => id !== revisionId);
+            }
+
+            if (current.length >= 2) {
+                return [current[1], revisionId];
+            }
+
+            return [...current, revisionId];
+        });
+    };
+
+    const selectedRevisions = revisionList.filter((revision) =>
+        selectedIds.includes(revision.id),
+    );
+
+    const [olderRevision, newerRevision] = [...selectedRevisions].sort(
+        (a, b) =>
+            new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+    );
+
+    const diffLines =
+        olderRevision && newerRevision
+            ? buildLineDiff(
+                  olderRevision.content ?? '',
+                  newerRevision.content ?? '',
+              )
+            : [];
+
+    return (
+        <>
+            <Head title={`変更履歴: ${post.title}`} />
+
+            <div className="space-y-4 p-4">
+                <div className="flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-2">
+                        <History className="size-5" />
+                        <h1 className="text-2xl font-semibold">変更履歴</h1>
+                    </div>
+                    <Button asChild variant="outline" size="sm">
+                        <Link
+                            href={edit.url({
+                                namespace: namespace.id,
+                                post: post.slug,
+                            })}
+                        >
+                            編集に戻る
+                        </Link>
+                    </Button>
+                </div>
+
+                <Card className="space-y-3 p-4">
+                    <p className="text-sm text-muted-foreground">
+                        2つのバージョンにチェックを入れると差分が表示されます。
+                    </p>
+                    {selectedRevisions.length !== 2 ? (
+                        <div className="rounded-md border border-dashed border-muted-foreground/40 p-4 text-sm text-muted-foreground">
+                            {selectedRevisions.length === 0
+                                ? 'まだ選択されていません。'
+                                : 'あと1つ選択してください。'}
+                        </div>
+                    ) : (
+                        <div className="rounded-md border p-4">
+                            <div className="mb-3 flex flex-col gap-1 text-sm">
+                                <span className="font-semibold">
+                                    {olderRevision.title || '無題'} →{' '}
+                                    {newerRevision.title || '無題'}
+                                </span>
+                                <span className="text-muted-foreground">
+                                    {new Date(
+                                        olderRevision.created_at,
+                                    ).toLocaleString()}{' '}
+                                    →{' '}
+                                    {new Date(
+                                        newerRevision.created_at,
+                                    ).toLocaleString()}
+                                </span>
+                            </div>
+                            <div className="max-h-[420px] overflow-auto font-mono text-xs leading-relaxed">
+                                {diffLines.map((line, index) => (
+                                    <div
+                                        key={`${line.type}-${index}`}
+                                        className={`grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-1 ${
+                                            line.type === 'add'
+                                                ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300'
+                                                : line.type === 'remove'
+                                                  ? 'bg-rose-50 text-rose-700 dark:bg-rose-500/10 dark:text-rose-300'
+                                                  : 'text-muted-foreground'
+                                        }`}
+                                    >
+                                        <span className="text-center">
+                                            {line.type === 'add'
+                                                ? '+'
+                                                : line.type === 'remove'
+                                                  ? '-'
+                                                  : ' '}
+                                        </span>
+                                        <span className="break-words whitespace-pre-wrap">
+                                            {line.text || ' '}
+                                        </span>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                </Card>
+
+                <Card className="divide-y">
+                    {revisionList.length === 0 ? (
+                        <div className="p-4 text-sm text-muted-foreground">
+                            まだ履歴はありません。
+                        </div>
+                    ) : (
+                        revisionList.map((revision) => (
+                            <div
+                                key={revision.id}
+                                className="flex flex-col gap-2 p-4 sm:flex-row sm:items-center sm:justify-between"
+                            >
+                                <div className="flex min-w-0 flex-col gap-1">
+                                    <label className="flex items-center gap-2">
+                                        <input
+                                            type="checkbox"
+                                            checked={selectedIds.includes(
+                                                revision.id,
+                                            )}
+                                            onChange={() =>
+                                                toggleRevision(revision.id)
+                                            }
+                                            className="size-4 accent-foreground"
+                                        />
+                                        <span className="truncate font-medium">
+                                            {revision.title || '無題'}
+                                        </span>
+                                        {revision.is_current && (
+                                            <span className="rounded bg-muted px-2 py-0.5 text-[11px] font-semibold text-muted-foreground">
+                                                現在
+                                            </span>
+                                        )}
+                                    </label>
+                                    <p className="pl-6 text-xs text-muted-foreground">
+                                        {new Date(
+                                            revision.created_at,
+                                        ).toLocaleString()}
+                                        {revision.user && (
+                                            <> · {revision.user.name}</>
+                                        )}
+                                    </p>
+                                </div>
+                                {!revision.is_current && (
+                                    <Form
+                                        {...restore.form({
+                                            namespace: namespace.id,
+                                            post: post.slug,
+                                            revision: revision.id,
+                                        })}
+                                    >
+                                        {({ processing }) => (
+                                            <Button
+                                                type="submit"
+                                                variant="outline"
+                                                size="sm"
+                                                disabled={processing}
+                                            >
+                                                復元
+                                            </Button>
+                                        )}
+                                    </Form>
+                                )}
+                            </div>
+                        ))
+                    )}
+                </Card>
+            </div>
+        </>
+    );
+}

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -20,6 +20,8 @@ Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () 
         Route::get('/{namespace}/{post:slug}/edit', [PostController::class, 'edit'])->name('edit')->scopeBindings();
         Route::put('/{namespace}/{post:slug}', [PostController::class, 'update'])->name('update')->scopeBindings();
         Route::delete('/{namespace}/{post:slug}', [PostController::class, 'destroy'])->name('destroy')->scopeBindings();
+        Route::get('/{namespace}/{post:slug}/revisions', [PostController::class, 'revisions'])->name('revisions')->scopeBindings();
+        Route::post('/{namespace}/{post:slug}/revisions/{revision}/restore', [PostController::class, 'restore'])->name('revisions.restore')->scopeBindings();
         Route::post('/{namespace}/{post:slug}/image', [PostController::class, 'uploadImage'])->name('uploadImage')->scopeBindings();
     });
 });

--- a/tests/Feature/Admin/PostRevisionTest.php
+++ b/tests/Feature/Admin/PostRevisionTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+use App\Models\PostRevision;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('guests are redirected from the revisions page', function () {
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->recycle($namespace)->create();
+
+    $this->get(route('admin.posts.revisions', [$namespace, $post->slug]))
+        ->assertRedirect(route('login'));
+});
+
+test('authenticated users can view the revisions page', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->recycle($namespace)->create();
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.revisions', [$namespace, $post->slug]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/revisions')
+            ->has('revisions', 1)
+            ->where('revisions.0.is_current', true)
+        );
+});
+
+test('revisions page includes the current post and historical revisions', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->recycle($namespace)->create([
+        'title' => 'Current Title',
+        'content' => 'Current content.',
+        'updated_at' => now(),
+    ]);
+
+    PostRevision::factory()->create([
+        'post_id' => $post->id,
+        'user_id' => $user->id,
+        'title' => 'First draft',
+        'content' => 'First content.',
+        'created_at' => now()->subHours(2),
+    ]);
+
+    PostRevision::factory()->create([
+        'post_id' => $post->id,
+        'user_id' => $user->id,
+        'title' => 'Second draft',
+        'content' => 'Second content.',
+        'created_at' => now()->subHour(),
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.revisions', [$namespace, $post->slug]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/revisions')
+            ->has('revisions', 3)
+            ->where('revisions.0.is_current', true)
+            ->where('revisions.0.title', 'Current Title')
+            ->where('revisions.1.title', 'Second draft')
+            ->where('revisions.1.user.name', $user->name)
+            ->where('revisions.2.title', 'First draft')
+        );
+});
+
+test('updating a post creates a revision when content changes', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->recycle($namespace)->create([
+        'title' => 'Original Title',
+        'content' => 'Original content.',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.posts.update', [$namespace, $post->slug]), [
+            'title' => 'Updated Title',
+            'content' => 'Updated content.',
+            'slug' => $post->slug,
+            'is_draft' => false,
+            'published_at' => $post->published_at,
+        ])
+        ->assertRedirect();
+
+    expect($post->revisions()->count())->toBe(1);
+
+    $revision = $post->revisions()->first();
+    expect($revision->title)->toBe('Original Title')
+        ->and($revision->content)->toBe('Original content.')
+        ->and($revision->user_id)->toBe($user->id);
+});
+
+test('updating a post without changes does not create a revision', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->recycle($namespace)->create([
+        'title' => 'Same Title',
+        'content' => 'Same content.',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.posts.update', [$namespace, $post->slug]), [
+            'title' => 'Same Title',
+            'content' => 'Same content.',
+            'slug' => $post->slug,
+            'is_draft' => false,
+            'published_at' => $post->published_at,
+        ])
+        ->assertRedirect();
+
+    expect($post->revisions()->count())->toBe(0);
+});
+
+test('restoring a revision saves current content as a revision and applies old content', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->recycle($namespace)->create([
+        'title' => 'Current Title',
+        'content' => 'Current content.',
+    ]);
+    $revision = PostRevision::factory()->create([
+        'post_id' => $post->id,
+        'user_id' => $user->id,
+        'title' => 'Old Title',
+        'content' => 'Old content.',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('admin.posts.revisions.restore', [$namespace, $post->slug, $revision]))
+        ->assertRedirect(route('admin.posts.revisions', [$namespace, $post->slug]));
+
+    $post->refresh();
+    expect($post->title)->toBe('Old Title')
+        ->and($post->content)->toBe('Old content.')
+        ->and($post->revisions()->count())->toBe(2);
+});
+
+test('restoring a revision from another post returns 404', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->recycle($namespace)->create();
+    $otherPost = Post::factory()->recycle($namespace)->create();
+    $revision = PostRevision::factory()->create(['post_id' => $otherPost->id]);
+
+    $this->actingAs($user)
+        ->post(route('admin.posts.revisions.restore', [$namespace, $post->slug, $revision]))
+        ->assertNotFound();
+});

--- a/tests/Feature/NamespaceBackupCommandTest.php
+++ b/tests/Feature/NamespaceBackupCommandTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Post;
 use App\Models\PostNamespace;
+use App\Models\PostRevision;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
@@ -48,6 +49,13 @@ function addNamespaceBackupTreeToZip(ZipArchive $zip, array $tree, string $prefi
                 'published_at' => $post['published_at'] ?? now()->toIso8601String(),
             ])."---\n\n".rtrim($post['content'])."\n"
         );
+
+        if (! empty($post['revisions'])) {
+            $zip->addFromString(
+                $prefix.$post['slug'].'.revisions.json',
+                json_encode($post['revisions'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+            );
+        }
     }
 
     foreach ($tree['children'] ?? [] as $child) {
@@ -256,6 +264,141 @@ test('namespace restore command fails when no user exists', function () {
 
         expect(PostNamespace::query()->where('slug', 'laravel-13')->exists())->toBeFalse()
             ->and(Post::query()->count())->toBe(0);
+    } finally {
+        File::delete($zipPath);
+    }
+});
+
+test('namespace backup --with-revisions includes revision json files', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create(['slug' => 'docs', 'name' => 'Docs']);
+    $post = Post::factory()->for($user)->for($namespace, 'namespace')->published()->create([
+        'title' => 'Intro',
+        'slug' => 'intro',
+        'content' => 'Hello.',
+    ]);
+    PostRevision::factory()->create([
+        'post_id' => $post->id,
+        'user_id' => $user->id,
+        'title' => 'Old Intro',
+        'content' => 'Old hello.',
+        'created_at' => now()->subHour(),
+    ]);
+
+    $zipPath = storage_path('framework/testing/'.Str::uuid().'.zip');
+
+    $this->artisan('namespace:backup', [
+        'namespace' => $namespace->slug,
+        '--output' => $zipPath,
+        '--with-revisions' => true,
+    ])->assertSuccessful();
+
+    $zip = new ZipArchive;
+    expect($zip->open($zipPath))->toBeTrue();
+    $revisionsJson = $zip->getFromName('intro.revisions.json');
+    $zip->close();
+
+    expect($revisionsJson)->not->toBeFalse();
+    $revisions = json_decode($revisionsJson, true);
+    expect($revisions)->toHaveCount(1)
+        ->and($revisions[0]['title'])->toBe('Old Intro')
+        ->and($revisions[0]['content'])->toBe('Old hello.')
+        ->and($revisions[0]['user_name'])->toBe($user->name);
+
+    File::delete($zipPath);
+});
+
+test('namespace backup without --with-revisions does not include revision files', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create(['slug' => 'docs2', 'name' => 'Docs2']);
+    $post = Post::factory()->for($user)->for($namespace, 'namespace')->published()->create([
+        'slug' => 'intro',
+        'content' => 'Hello.',
+    ]);
+    PostRevision::factory()->create(['post_id' => $post->id]);
+
+    $zipPath = storage_path('framework/testing/'.Str::uuid().'.zip');
+
+    $this->artisan('namespace:backup', [
+        'namespace' => $namespace->slug,
+        '--output' => $zipPath,
+    ])->assertSuccessful();
+
+    $zip = new ZipArchive;
+    expect($zip->open($zipPath))->toBeTrue();
+    $revisionsJson = $zip->getFromName('intro.revisions.json');
+    $zip->close();
+
+    expect($revisionsJson)->toBeFalse();
+
+    File::delete($zipPath);
+});
+
+test('namespace restore --with-revisions imports revisions from backup', function () {
+    $user = User::factory()->create();
+    $zipPath = createNamespaceBackupZip([
+        'slug' => 'my-ns',
+        'name' => 'My NS',
+        'full_path' => 'my-ns',
+        'posts' => [
+            [
+                'title' => 'Guide',
+                'slug' => 'guide',
+                'content' => '# Guide',
+                'revisions' => [
+                    [
+                        'title' => 'Old Guide',
+                        'content' => '# Old Guide',
+                        'user_name' => 'Alice',
+                        'created_at' => now()->subDay()->toIso8601String(),
+                    ],
+                ],
+            ],
+        ],
+    ]);
+
+    try {
+        $this->artisan('namespace:restore', [
+            'path' => $zipPath,
+            '--with-revisions' => true,
+        ])->assertSuccessful();
+
+        $post = Post::query()->where('slug', 'guide')->firstOrFail();
+        expect($post->revisions()->count())->toBe(1);
+        $revision = $post->revisions()->first();
+        expect($revision->title)->toBe('Old Guide')
+            ->and($revision->content)->toBe('# Old Guide')
+            ->and($revision->user_id)->toBeNull();
+    } finally {
+        File::delete($zipPath);
+    }
+});
+
+test('namespace restore without --with-revisions skips revision files', function () {
+    $user = User::factory()->create();
+    $zipPath = createNamespaceBackupZip([
+        'slug' => 'my-ns2',
+        'name' => 'My NS2',
+        'full_path' => 'my-ns2',
+        'posts' => [
+            [
+                'title' => 'Guide',
+                'slug' => 'guide',
+                'content' => '# Guide',
+                'revisions' => [
+                    ['title' => 'Old', 'content' => 'Old', 'user_name' => null, 'created_at' => now()->subDay()->toIso8601String()],
+                ],
+            ],
+        ],
+    ]);
+
+    try {
+        $this->artisan('namespace:restore', [
+            'path' => $zipPath,
+        ])->assertSuccessful();
+
+        $post = Post::query()->where('slug', 'guide')->firstOrFail();
+        expect($post->revisions()->count())->toBe(0);
     } finally {
         File::delete($zipPath);
     }


### PR DESCRIPTION
## Summary
- add post revision history storage, restore flow, and admin revisions UI
- include optional revision export/import support in namespace backup and restore commands
- add feature coverage for revision page payloads and revision backup/restore behavior