### PR TITLE
Bundle markdown, namespace, and TOC fixes

### DIFF
--- a/database/seeders/SyntaxSeeder.php
+++ b/database/seeders/SyntaxSeeder.php
@@ -39,13 +39,13 @@ class SyntaxSeeder extends Seeder
                 'user_id' => $user->id,
                 'title' => 'Markdown Syntax Guide',
                 'content' => trim(<<<'MD'
-# What is Markdown?
+## What is Markdown?
 
 Markdown is a lightweight markup language for formatting plain text. You use simple symbols like `#`, `*`, and `-` to define structure, and it converts to HTML for display. The goal is to keep source text readable as-is, even before rendering.
 
 ---
 
-# Headings
+## Headings
 
 Use `#` symbols to define heading levels. The number of `#` characters sets the level.
 
@@ -58,16 +58,16 @@ Use `#` symbols to define heading levels. The number of `#` characters sets the 
 
 The above renders as:
 
-### Heading 3
-#### Heading 4
+#### Heading 3
+##### Heading 4
 
 > Heading 1 is typically reserved for the page title and used only once per document.
 
 ---
 
-# Paragraphs and Line Breaks
+## Paragraphs and Line Breaks
 
-### Paragraphs
+#### Paragraphs
 
 Separate paragraphs with a **blank line**. A single newline without a blank line does not create a new paragraph — the lines are joined.
 
@@ -81,7 +81,7 @@ This is the first paragraph.
 
 This is the second paragraph.
 
-### Line Breaks
+#### Line Breaks
 
 To force a line break **within** a paragraph (without starting a new paragraph), end the line with **two or more spaces** before pressing Enter.
 
@@ -95,9 +95,9 @@ Line two (same paragraph, new line)
 
 ---
 
-# Text Formatting
+## Text Formatting
 
-### Bold
+#### Bold
 
 ```
 **This text is bold.**
@@ -107,7 +107,7 @@ __This also works.__
 **This text is bold.**
 __This also works.__
 
-### Italic
+#### Italic
 
 ```
 *This text is italic.*
@@ -117,7 +117,7 @@ _This also works._
 *This text is italic.*
 _This also works._
 
-### Bold and Italic
+#### Bold and Italic
 
 ```
 ***This text is bold and italic.***
@@ -125,7 +125,7 @@ _This also works._
 
 ***This text is bold and italic.***
 
-### Strikethrough
+#### Strikethrough
 
 ```
 ~~This text is crossed out.~~
@@ -133,7 +133,7 @@ _This also works._
 
 ~~This text is crossed out.~~
 
-### Inline Code
+#### Inline Code
 
 Wrap code in single backticks to render it as monospace inline code. Useful for referencing variable names, commands, or short snippets.
 
@@ -149,9 +149,9 @@ Set `DEBUG=true` in your environment.
 
 ---
 
-# Lists
+## Lists
 
-### Unordered Lists
+#### Unordered Lists
 
 Use `-`, `*`, or `+` to create bullet points. They are interchangeable.
 
@@ -165,7 +165,7 @@ Use `-`, `*`, or `+` to create bullet points. They are interchangeable.
 - Oranges
 - Bananas
 
-### Nested Lists
+#### Nested Lists
 
 Indent with two or four spaces to create sub-items.
 
@@ -189,7 +189,7 @@ Indent with two or four spaces to create sub-items.
   - Carrots
   - Spinach
 
-### Ordered Lists
+#### Ordered Lists
 
 ```
 1. First step
@@ -203,7 +203,7 @@ Indent with two or four spaces to create sub-items.
 
 > The actual numbers don't matter — Markdown will renumber them in order. You can use `1.` for every item and it still renders correctly.
 
-### Task Lists
+#### Task Lists
 
 Use `- [ ]` for an unchecked box and `- [x]` for a checked box.
 
@@ -221,9 +221,9 @@ Use `- [ ]` for an unchecked box and `- [x]` for a checked box.
 
 ---
 
-# Code Blocks
+## Code Blocks
 
-### Fenced Code Blocks
+#### Fenced Code Blocks
 
 Wrap code in triple backticks. Optionally add a language identifier after the opening fence for syntax highlighting.
 
@@ -323,7 +323,7 @@ JSON:
 }
 ```
 
-### Long Lines
+#### Long Lines
 
 Long lines scroll horizontally rather than wrapping, so the code block never distorts your layout.
 
@@ -333,9 +333,9 @@ SELECT users.id, users.name, orders.id AS order_id, orders.total, orders.status 
 
 ---
 
-# Links
+## Links
 
-### Inline Links
+#### Inline Links
 
 The basic form is `[visible text](URL)`.
 
@@ -345,7 +345,7 @@ The basic form is `[visible text](URL)`.
 
 [Visit the Markdown Guide](https://www.markdownguide.org)
 
-### Links with Titles
+#### Links with Titles
 
 Add a quoted title after the URL. It appears as a tooltip on hover.
 
@@ -355,7 +355,7 @@ Add a quoted title after the URL. It appears as a tooltip on hover.
 
 [Markdown Guide](https://www.markdownguide.org "The best Markdown reference")
 
-### Bare URLs
+#### Bare URLs
 
 Wrap a URL in angle brackets to turn it into a clickable link without custom text.
 
@@ -367,7 +367,7 @@ Wrap a URL in angle brackets to turn it into a clickable link without custom tex
 <https://www.example.com>
 <hello@example.com>
 
-### Reference-Style Links
+#### Reference-Style Links
 
 Define the URL separately and reference it by label. Useful for keeping long URLs out of the prose.
 
@@ -385,7 +385,7 @@ Check out [GitHub][gh] and [MDN][mdn] for documentation.
 
 ---
 
-# Blockquotes
+## Blockquotes
 
 Use `>` to create a blockquote. Add multiple `>` characters for nested quotes.
 
@@ -417,7 +417,7 @@ Blockquotes can contain other Markdown elements:
 
 ---
 
-# Tables
+## Tables
 
 Use `|` to separate columns and `-` for the header separator row.
 
@@ -435,7 +435,7 @@ Use `|` to separate columns and `-` for the header separator row.
 | Bob        | Editor    | No     |
 | Carol      | Viewer    | Yes    |
 
-### Column Alignment
+#### Column Alignment
 
 Add `:` to the separator row to control alignment per column.
 
@@ -461,7 +461,7 @@ MD),
                 'user_id' => $user->id,
                 'title' => 'Extended Markdown Syntax',
                 'content' => trim(<<<'MD'
-# Extended Markdown Syntax
+## Extended Markdown Syntax
 
 Extended syntax adds features beyond the core Markdown spec. This page covers GitHub Flavored Markdown (GFM) extensions, which are supported by this renderer.
 
@@ -469,7 +469,7 @@ Extended syntax adds features beyond the core Markdown spec. This page covers Gi
 
 ---
 
-# Strikethrough ✓ Renders here
+## Strikethrough ✓ Renders here
 
 Wrap text in `~~double tildes~~`.
 
@@ -481,7 +481,7 @@ The price was ~~$99~~ now **$49**.
 
 ---
 
-# Task Lists ✓ Renders here
+## Task Lists ✓ Renders here
 
 Use `- [ ]` for unchecked and `- [x]` for checked items.
 
@@ -499,7 +499,7 @@ Use `- [ ]` for unchecked and `- [x]` for checked items.
 
 ---
 
-# Tables ✓ Renders here
+## Tables ✓ Renders here
 
 Tables use `|` for column separators and `:` in the divider row for alignment.
 
@@ -521,7 +521,7 @@ Tables use `|` for column separators and `:` in the divider row for alignment.
 
 ---
 
-# Autolinks ✓ Renders here
+## Autolinks ✓ Renders here
 
 Angle-bracket autolinks turn a raw URL or email into a clickable link.
 
@@ -535,7 +535,7 @@ Contact us at <hello@example.com>.
 
 ---
 
-# Footnotes ✓ Renders here
+## Footnotes ✓ Renders here
 
 Add `[^label]` inline, then define the footnote anywhere in the document. The renderer collects them at the bottom.
 
@@ -566,7 +566,7 @@ The spec[^spec] describes the syntax. There are many implementations[^impl].
 
 ---
 
-# Highlight ✗ Requires plugin
+## Highlight ✗ Requires plugin
 
 The `==highlight==` syntax is **not** part of GFM. It requires a plugin such as `remark-mark-and-unmark`. Without it, the `==` delimiters are rendered as plain text.
 
@@ -578,7 +578,7 @@ With the plugin active it renders as a `<mark>` element (yellow background by de
 
 ---
 
-# Subscript and Superscript ✗ Requires plugin
+## Subscript and Superscript ✗ Requires plugin
 
 `~sub~` and `^sup^` are not standard GFM. They need `remark-sub` / `remark-sup` or similar.
 
@@ -591,7 +591,7 @@ Without the plugins the delimiters appear literally.
 
 ---
 
-# Definition Lists ✗ Requires plugin
+## Definition Lists ✗ Requires plugin
 
 Definition lists use a term followed by `:` definitions. Not supported in GFM — requires `remark-definition-list` or Pandoc.
 
@@ -605,7 +605,7 @@ HTML
 
 ---
 
-# Heading IDs ✗ Renderer-dependent
+## Heading IDs ✗ Renderer-dependent
 
 Some renderers accept `{#custom-id}` after a heading to set an explicit `id` attribute for deep linking.
 
@@ -617,7 +617,7 @@ GFM renderers (like GitHub) auto-generate IDs from heading text. Explicit IDs ar
 
 ---
 
-# Emoji Shortcodes ✗ Requires plugin
+## Emoji Shortcodes ✗ Requires plugin
 
 `:shortcode:` syntax is popular on GitHub but requires `remark-emoji` or similar to convert to actual emoji characters.
 
@@ -637,13 +637,13 @@ MD),
                 'user_id' => $user->id,
                 'title' => 'Zenn Syntax',
                 'content' => trim(<<<'MD'
-# Zenn Syntax
+## Zenn Syntax
 
 > Reference: https://zenn.dev/zenn/articles/markdown-guide
 
 Zenn supports a few convenient image patterns on top of regular Markdown.
 
-### Basic Image
+#### Basic Image
 
 ```md
 ![](/storage/namespaces/guide.png)
@@ -651,7 +651,7 @@ Zenn supports a few convenient image patterns on top of regular Markdown.
 
 ![](/storage/namespaces/guide.png)
 
-### Sized Image
+#### Sized Image
 
 Use `=250x` after the image URL to set the width in pixels.
 
@@ -661,7 +661,7 @@ Use `=250x` after the image URL to set the width in pixels.
 
 ![](/storage/namespaces/guide.png =250x)
 
-### Alt Text
+#### Alt Text
 
 ```md
 ![Guide cover](/storage/namespaces/guide.png =250x)
@@ -669,7 +669,7 @@ Use `=250x` after the image URL to set the width in pixels.
 
 ![Guide cover](/storage/namespaces/guide.png =250x)
 
-### Caption
+#### Caption
 
 Place italic text on the next line to display it like a caption.
 
@@ -681,7 +681,7 @@ Place italic text on the next line to display it like a caption.
 ![](/storage/namespaces/guide.png =250x)
 *Guide cover image*
 
-### Linked Image
+#### Linked Image
 
 ```md
 [![](/storage/namespaces/guide.png =250x)](https://zenn.dev)
@@ -689,7 +689,7 @@ Place italic text on the next line to display it like a caption.
 
 [![](/storage/namespaces/guide.png =250x)](https://zenn.dev)
 
-### Message
+#### Message
 
 Wrap content in `:::message` to display an info callout.
 
@@ -743,7 +743,7 @@ Helpful tip.
 Success or confirmation.
 :::
 
-### Details (Collapsible)
+#### Details (Collapsible)
 
 Wrap content in `:::details` followed by a title to create a collapsible block. The content is hidden until the reader clicks to expand it.
 
@@ -807,7 +807,7 @@ This note is inside a collapsible section.
 :::
 ::::
 
-### Link Card
+#### Link Card
 
 A URL placed alone on its own line is automatically displayed as a card.
 
@@ -833,7 +833,7 @@ https://www.youtube.com/watch?v=WRVsOCh907o
 
 https://www.youtube.com/watch?v=WRVsOCh907o
 
-### Code Block with Filename
+#### Code Block with Filename
 
 Add `:filename` after the language name to display a filename label above the code block.
 
@@ -853,7 +853,7 @@ export function greet(name: string): string {
 }
 ```
 
-### Diff Highlighting
+#### Diff Highlighting
 
 Start the fence with `diff` followed by the language name to enable diff highlighting. Lines beginning with `+` are shown in green and lines beginning with `-` in red.
 
@@ -876,7 +876,7 @@ You can combine `diff` with a filename using `` ```diff ts:src/utils.ts ``:
  }
 ```
 
-### GitHub Embed
+#### GitHub Embed
 
 A GitHub file URL placed alone on its own line is automatically embedded as a code block.
 
@@ -911,7 +911,7 @@ MD),
                 'user_id' => $user->id,
                 'title' => 'Mintlify Syntax',
                 'content' => trim(<<<'MD'
-# Mintlify Syntax
+## Mintlify Syntax
 
 > References:
 > - https://starter.mintlify.com/essentials/markdown
@@ -922,7 +922,7 @@ Mintlify ships with MDX-flavored components for docs sites. This page covers the
 
 ---
 
-# Callouts
+## Callouts
 
 Mintlify provides five callout types. Each maps to a Zenn-style `:::message` directive internally.
 
@@ -996,7 +996,7 @@ Check content here.
 
 ---
 
-# Cards
+## Cards
 
 Mintlify uses `<Card>` blocks to create linked navigation tiles.
 
@@ -1020,7 +1020,7 @@ Source:
 
 ---
 
-# Card Groups
+## Card Groups
 
 Cards are often grouped to create documentation indexes.
 
@@ -1075,7 +1075,7 @@ Rendered result for the same source:
 
 ---
 
-# Tabs
+## Tabs
 
 Mintlify commonly uses `<Tabs>` and `<Tab>` to switch between examples.
 
@@ -1125,7 +1125,7 @@ Possible fallback if tabs are unsupported: split content into headings such as `
 
 ---
 
-# Accordions
+## Accordions
 
 Accordion components create collapsible sections. The `title` attribute sets the visible label. An optional `icon` attribute is accepted but ignored by this renderer.
 
@@ -1161,7 +1161,7 @@ Mintlify is a documentation platform.
 
 ---
 
-# Steps
+## Steps
 
 Step-based walkthroughs use `<Steps>` and `<Step title="...">` to produce a numbered sequential guide.
 
@@ -1203,7 +1203,7 @@ Source:
 
 ---
 
-# Badge
+## Badge
 
 Use `<Badge>` to display status indicators, labels, and metadata inline within prose or as standalone elements.
 
@@ -1233,9 +1233,9 @@ This feature requires a <Badge color="orange" size="sm">Premium</Badge> subscrip
 
 ---
 
-# API Fields
+## API Fields
 
-### ResponseField
+#### ResponseField
 
 Use `<ResponseField>` to describe the fields of an API response. Supports `name`, `type`, `required`, `default`, and `deprecated`.
 
@@ -1273,7 +1273,7 @@ Source:
 </ResponseField>
 ```
 
-### ParamField
+#### ParamField
 
 Use `<ParamField>` to describe request parameters. The attribute key (`path`, `query`, or `body`) indicates where the parameter appears, and its value is the parameter name.
 
@@ -1309,7 +1309,7 @@ Source:
 
 ---
 
-# CodeGroup
+## CodeGroup
 
 `<CodeGroup>` displays multiple code blocks as a tabbed interface. The tab title comes from the meta string after the language identifier. Add `icon="..."` to the meta string when you want an icon in the tab label. Selecting a tab persists the choice across all CodeGroup instances on the page.
 
@@ -1401,7 +1401,7 @@ $data = $response->json();
 
 ---
 
-# Tooltip
+## Tooltip
 
 `<Tooltip>` wraps inline text and shows a popover on hover. Use `tip` for the tooltip body, `headline` for a bold title, and `cta` + `href` for an optional call-to-action link.
 
@@ -1421,7 +1421,7 @@ Simple tooltip: hover over <Tooltip tip="Hypertext Markup Language — the stand
 
 ---
 
-# Tree
+## Tree
 
 `<Tree>` displays a file-system hierarchy with collapsible folders. Use `<Tree.Folder>` for directories and `<Tree.File>` for files. Add `defaultOpen` to a folder to expand it on load.
 
@@ -1471,7 +1471,7 @@ Source:
 
 ---
 
-# Update
+## Update
 
 `<Update>` displays a changelog entry in a timeline layout. Use `label` for the date or version (it also becomes an anchor link), `description` for a subtitle, and `tags` for filter labels.
 
@@ -1479,7 +1479,7 @@ Live example:
 
 <Update label="2024-10-11" description="v0.2.0" tags={["Feature", "Improvement"]}>
 
-### Improved card icon support
+#### Improved card icon support
 
 Cards now support brand icons from the `simple-icons` library in addition to Lucide icons. Pass any brand name as the `icon` prop on `<Card>`.
 
@@ -1487,7 +1487,7 @@ Cards now support brand icons from the `simple-icons` library in addition to Luc
 
 <Update label="2024-09-01" description="v0.1.0" tags={["Initial release"]}>
 
-### First release
+#### First release
 
 Initial launch of Thinkstream with support for Markdown, GFM, Zenn syntax, and core Mintlify components including callouts, cards, tabs, steps, and code groups.
 

--- a/database/seeders/SyntaxSeeder.php
+++ b/database/seeders/SyntaxSeeder.php
@@ -58,7 +58,6 @@ Use `#` symbols to define heading levels. The number of `#` characters sets the 
 
 The above renders as:
 
-## Heading 2
 ### Heading 3
 #### Heading 4
 
@@ -68,7 +67,7 @@ The above renders as:
 
 # Paragraphs and Line Breaks
 
-## Paragraphs
+### Paragraphs
 
 Separate paragraphs with a **blank line**. A single newline without a blank line does not create a new paragraph — the lines are joined.
 
@@ -82,7 +81,7 @@ This is the first paragraph.
 
 This is the second paragraph.
 
-## Line Breaks
+### Line Breaks
 
 To force a line break **within** a paragraph (without starting a new paragraph), end the line with **two or more spaces** before pressing Enter.
 
@@ -98,7 +97,7 @@ Line two (same paragraph, new line)
 
 # Text Formatting
 
-## Bold
+### Bold
 
 ```
 **This text is bold.**
@@ -108,7 +107,7 @@ __This also works.__
 **This text is bold.**
 __This also works.__
 
-## Italic
+### Italic
 
 ```
 *This text is italic.*
@@ -118,7 +117,7 @@ _This also works._
 *This text is italic.*
 _This also works._
 
-## Bold and Italic
+### Bold and Italic
 
 ```
 ***This text is bold and italic.***
@@ -126,7 +125,7 @@ _This also works._
 
 ***This text is bold and italic.***
 
-## Strikethrough
+### Strikethrough
 
 ```
 ~~This text is crossed out.~~
@@ -134,7 +133,7 @@ _This also works._
 
 ~~This text is crossed out.~~
 
-## Inline Code
+### Inline Code
 
 Wrap code in single backticks to render it as monospace inline code. Useful for referencing variable names, commands, or short snippets.
 
@@ -152,7 +151,7 @@ Set `DEBUG=true` in your environment.
 
 # Lists
 
-## Unordered Lists
+### Unordered Lists
 
 Use `-`, `*`, or `+` to create bullet points. They are interchangeable.
 
@@ -166,7 +165,7 @@ Use `-`, `*`, or `+` to create bullet points. They are interchangeable.
 - Oranges
 - Bananas
 
-## Nested Lists
+### Nested Lists
 
 Indent with two or four spaces to create sub-items.
 
@@ -190,7 +189,7 @@ Indent with two or four spaces to create sub-items.
   - Carrots
   - Spinach
 
-## Ordered Lists
+### Ordered Lists
 
 ```
 1. First step
@@ -204,7 +203,7 @@ Indent with two or four spaces to create sub-items.
 
 > The actual numbers don't matter — Markdown will renumber them in order. You can use `1.` for every item and it still renders correctly.
 
-## Task Lists
+### Task Lists
 
 Use `- [ ]` for an unchecked box and `- [x]` for a checked box.
 
@@ -224,7 +223,7 @@ Use `- [ ]` for an unchecked box and `- [x]` for a checked box.
 
 # Code Blocks
 
-## Fenced Code Blocks
+### Fenced Code Blocks
 
 Wrap code in triple backticks. Optionally add a language identifier after the opening fence for syntax highlighting.
 
@@ -324,7 +323,7 @@ JSON:
 }
 ```
 
-## Long Lines
+### Long Lines
 
 Long lines scroll horizontally rather than wrapping, so the code block never distorts your layout.
 
@@ -336,7 +335,7 @@ SELECT users.id, users.name, orders.id AS order_id, orders.total, orders.status 
 
 # Links
 
-## Inline Links
+### Inline Links
 
 The basic form is `[visible text](URL)`.
 
@@ -346,7 +345,7 @@ The basic form is `[visible text](URL)`.
 
 [Visit the Markdown Guide](https://www.markdownguide.org)
 
-## Links with Titles
+### Links with Titles
 
 Add a quoted title after the URL. It appears as a tooltip on hover.
 
@@ -356,7 +355,7 @@ Add a quoted title after the URL. It appears as a tooltip on hover.
 
 [Markdown Guide](https://www.markdownguide.org "The best Markdown reference")
 
-## Bare URLs
+### Bare URLs
 
 Wrap a URL in angle brackets to turn it into a clickable link without custom text.
 
@@ -368,7 +367,7 @@ Wrap a URL in angle brackets to turn it into a clickable link without custom tex
 <https://www.example.com>
 <hello@example.com>
 
-## Reference-Style Links
+### Reference-Style Links
 
 Define the URL separately and reference it by label. Useful for keeping long URLs out of the prose.
 
@@ -436,7 +435,7 @@ Use `|` to separate columns and `-` for the header separator row.
 | Bob        | Editor    | No     |
 | Carol      | Viewer    | Yes    |
 
-## Column Alignment
+### Column Alignment
 
 Add `:` to the separator row to control alignment per column.
 
@@ -644,7 +643,7 @@ MD),
 
 Zenn supports a few convenient image patterns on top of regular Markdown.
 
-## Basic Image
+### Basic Image
 
 ```md
 ![](/storage/namespaces/guide.png)
@@ -652,7 +651,7 @@ Zenn supports a few convenient image patterns on top of regular Markdown.
 
 ![](/storage/namespaces/guide.png)
 
-## Sized Image
+### Sized Image
 
 Use `=250x` after the image URL to set the width in pixels.
 
@@ -662,7 +661,7 @@ Use `=250x` after the image URL to set the width in pixels.
 
 ![](/storage/namespaces/guide.png =250x)
 
-## Alt Text
+### Alt Text
 
 ```md
 ![Guide cover](/storage/namespaces/guide.png =250x)
@@ -670,7 +669,7 @@ Use `=250x` after the image URL to set the width in pixels.
 
 ![Guide cover](/storage/namespaces/guide.png =250x)
 
-## Caption
+### Caption
 
 Place italic text on the next line to display it like a caption.
 
@@ -682,7 +681,7 @@ Place italic text on the next line to display it like a caption.
 ![](/storage/namespaces/guide.png =250x)
 *Guide cover image*
 
-## Linked Image
+### Linked Image
 
 ```md
 [![](/storage/namespaces/guide.png =250x)](https://zenn.dev)
@@ -690,7 +689,7 @@ Place italic text on the next line to display it like a caption.
 
 [![](/storage/namespaces/guide.png =250x)](https://zenn.dev)
 
-## Message
+### Message
 
 Wrap content in `:::message` to display an info callout.
 
@@ -744,7 +743,7 @@ Helpful tip.
 Success or confirmation.
 :::
 
-## Details (Collapsible)
+### Details (Collapsible)
 
 Wrap content in `:::details` followed by a title to create a collapsible block. The content is hidden until the reader clicks to expand it.
 
@@ -808,7 +807,7 @@ This note is inside a collapsible section.
 :::
 ::::
 
-## Link Card
+### Link Card
 
 A URL placed alone on its own line is automatically displayed as a card.
 
@@ -834,7 +833,7 @@ https://www.youtube.com/watch?v=WRVsOCh907o
 
 https://www.youtube.com/watch?v=WRVsOCh907o
 
-## Code Block with Filename
+### Code Block with Filename
 
 Add `:filename` after the language name to display a filename label above the code block.
 
@@ -854,7 +853,7 @@ export function greet(name: string): string {
 }
 ```
 
-## Diff Highlighting
+### Diff Highlighting
 
 Start the fence with `diff` followed by the language name to enable diff highlighting. Lines beginning with `+` are shown in green and lines beginning with `-` in red.
 
@@ -877,7 +876,7 @@ You can combine `diff` with a filename using `` ```diff ts:src/utils.ts ``:
  }
 ```
 
-## GitHub Embed
+### GitHub Embed
 
 A GitHub file URL placed alone on its own line is automatically embedded as a code block.
 
@@ -1122,7 +1121,7 @@ Source example:
 </Tabs>
 ````
 
-Possible fallback if tabs are unsupported: split content into headings such as `## npm` and `## pnpm`.
+Possible fallback if tabs are unsupported: split content into headings such as `### npm` and `### pnpm`.
 
 ---
 
@@ -1236,7 +1235,7 @@ This feature requires a <Badge color="orange" size="sm">Premium</Badge> subscrip
 
 # API Fields
 
-## ResponseField
+### ResponseField
 
 Use `<ResponseField>` to describe the fields of an API response. Supports `name`, `type`, `required`, `default`, and `deprecated`.
 
@@ -1274,7 +1273,7 @@ Source:
 </ResponseField>
 ```
 
-## ParamField
+### ParamField
 
 Use `<ParamField>` to describe request parameters. The attribute key (`path`, `query`, or `body`) indicates where the parameter appears, and its value is the parameter name.
 
@@ -1480,7 +1479,7 @@ Live example:
 
 <Update label="2024-10-11" description="v0.2.0" tags={["Feature", "Improvement"]}>
 
-## Improved card icon support
+### Improved card icon support
 
 Cards now support brand icons from the `simple-icons` library in addition to Lucide icons. Pass any brand name as the `icon` prop on `<Card>`.
 
@@ -1488,7 +1487,7 @@ Cards now support brand icons from the `simple-icons` library in addition to Luc
 
 <Update label="2024-09-01" description="v0.1.0" tags={["Initial release"]}>
 
-## First release
+### First release
 
 Initial launch of Thinkstream with support for Markdown, GFM, Zenn syntax, and core Mintlify components including callouts, cards, tabs, steps, and code groups.
 
@@ -1499,7 +1498,7 @@ Source:
 ```mdx
 <Update label="2024-10-11" description="v0.2.0" tags={["Feature", "Improvement"]}>
 
-## Improved card icon support
+### Improved card icon support
 
 Cards now support brand icons from the `simple-icons` library in addition to Lucide icons. Pass any brand name as the `icon` prop on `<Card>`.
 
@@ -1507,7 +1506,7 @@ Cards now support brand icons from the `simple-icons` library in addition to Luc
 
 <Update label="2024-09-01" description="v0.1.0" tags={["Initial release"]}>
 
-## First release
+### First release
 
 Initial launch of Thinkstream with support for Markdown, GFM, Zenn syntax, and core Mintlify components including callouts, cards, tabs, steps, and code groups.
 

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -29,6 +29,8 @@ import {
     MARKDOWN_CALLOUT_VARIANTS,
     MARKDOWN_CUSTOM_COMPONENT_NAMES,
 } from '@/lib/markdown-syntax-manifest';
+import { createHeadingIdDispenser } from '@/lib/markdown-heading-ids';
+import { HeadingIdContext } from '@/lib/markdown-components';
 import {
     preprocessMarkdownContent,
     preprocessMarkdownSyntax,
@@ -158,6 +160,8 @@ export default function MarkdownContent({
     content,
     components,
 }: MarkdownContentProps) {
+    const dispenseHeadingId = createHeadingIdDispenser();
+
     const customMarkdownComponents: Record<
         CustomMarkdownComponentName,
         (props: Record<string, unknown>) => React.ReactElement
@@ -255,41 +259,43 @@ export default function MarkdownContent({
     };
 
     return (
-        <ReactMarkdown
-            remarkPlugins={[
-                [remarkGfm, { singleTilde: false }],
-                remarkCodeMeta,
-                remarkDirective,
-                remarkZennDirective,
-                remarkTabsDirective,
-                remarkCardDirective,
-                remarkStepsDirective,
-                remarkApiFieldsDirective,
-                remarkBadgeDirective,
-                remarkTooltipDirective,
-                remarkUpdateDirective,
-                remarkTreeDirective,
-                remarkCodeGroupDirective,
-                remarkLinkifyToCard,
-                remarkSupersub,
-                remarkDefinitionList,
-                remarkEmoji,
-                remarkMark,
-            ]}
-            remarkRehypeOptions={{
-                handlers: {
-                    ...defListHastHandlers,
-                    mark: (state: any, node: any) => ({
-                        type: 'element' as const,
-                        tagName: 'mark',
-                        properties: {},
-                        children: state.all(node),
-                    }),
-                } as any,
-            }}
-            components={markdownComponents}
-        >
-            {preprocessMarkdownContent(preprocessMarkdownSyntax(content))}
-        </ReactMarkdown>
+        <HeadingIdContext.Provider value={dispenseHeadingId}>
+            <ReactMarkdown
+                remarkPlugins={[
+                    [remarkGfm, { singleTilde: false }],
+                    remarkCodeMeta,
+                    remarkDirective,
+                    remarkZennDirective,
+                    remarkTabsDirective,
+                    remarkCardDirective,
+                    remarkStepsDirective,
+                    remarkApiFieldsDirective,
+                    remarkBadgeDirective,
+                    remarkTooltipDirective,
+                    remarkUpdateDirective,
+                    remarkTreeDirective,
+                    remarkCodeGroupDirective,
+                    remarkLinkifyToCard,
+                    remarkSupersub,
+                    remarkDefinitionList,
+                    remarkEmoji,
+                    remarkMark,
+                ]}
+                remarkRehypeOptions={{
+                    handlers: {
+                        ...defListHastHandlers,
+                        mark: (state: any, node: any) => ({
+                            type: 'element' as const,
+                            tagName: 'mark',
+                            properties: {},
+                            children: state.all(node),
+                        }),
+                    } as any,
+                }}
+                components={markdownComponents}
+            >
+                {preprocessMarkdownContent(preprocessMarkdownSyntax(content))}
+            </ReactMarkdown>
+        </HeadingIdContext.Provider>
     );
 }

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -25,12 +25,8 @@ import { MarkdownTab, MarkdownTabs } from '@/components/markdown-tabs';
 import { MarkdownTooltip } from '@/components/markdown-tooltip';
 import { MarkdownTree } from '@/components/markdown-tree';
 import { MarkdownUpdate } from '@/components/markdown-update';
-import {
-    MARKDOWN_CALLOUT_VARIANTS,
-    MARKDOWN_CUSTOM_COMPONENT_NAMES,
-} from '@/lib/markdown-syntax-manifest';
-import { createHeadingIdDispenser } from '@/lib/markdown-heading-ids';
 import { HeadingIdContext } from '@/lib/markdown-components';
+import { createHeadingIdDispenser } from '@/lib/markdown-heading-ids';
 import {
     preprocessMarkdownContent,
     preprocessMarkdownSyntax,
@@ -79,6 +75,8 @@ function SummaryEl({
     );
 }
 
+type CalloutType = keyof typeof CALLOUT_CONFIG;
+
 const CALLOUT_CONFIG = {
     note: {
         Icon: Info,
@@ -111,10 +109,6 @@ const CALLOUT_CONFIG = {
         iconColor: 'text-green-500',
     },
 } as const;
-
-type CalloutType = (typeof MARKDOWN_CALLOUT_VARIANTS)[number];
-type CustomMarkdownComponentName =
-    (typeof MARKDOWN_CUSTOM_COMPONENT_NAMES)[number];
 
 function MessageBox({
     children,
@@ -162,10 +156,7 @@ export default function MarkdownContent({
 }: MarkdownContentProps) {
     const dispenseHeadingId = createHeadingIdDispenser();
 
-    const customMarkdownComponents: Record<
-        CustomMarkdownComponentName,
-        (props: Record<string, unknown>) => React.ReactElement
-    > = {
+    const customMarkdownComponents = {
         tabs: (props: Record<string, unknown>) => <MarkdownTabs {...props} />,
         tab: (props: Record<string, unknown>) => <MarkdownTab {...props} />,
         card: (props: Record<string, unknown>) => (
@@ -217,7 +208,10 @@ export default function MarkdownContent({
         tree: (props: Record<string, unknown>) => (
             <MarkdownTree {...(props as Parameters<typeof MarkdownTree>[0])} />
         ),
-    };
+    } satisfies Record<
+        string,
+        (props: Record<string, unknown>) => React.ReactElement
+    >;
 
     const markdownComponents: Components &
         Partial<typeof customMarkdownComponents> = {

--- a/resources/js/hooks/use-markdown-toc.tsx
+++ b/resources/js/hooks/use-markdown-toc.tsx
@@ -1,13 +1,9 @@
 import { useMemo } from 'react';
 import type { Components } from 'react-markdown';
-import {
-    createMarkdownComponents,
-    type MarkdownComponentOptions,
-} from '@/lib/markdown-components';
-import {
-    extractMarkdownHeadings,
-    type MarkdownHeading,
-} from '@/lib/markdown-headings';
+import { createMarkdownComponents } from '@/lib/markdown-components';
+import type { MarkdownComponentOptions } from '@/lib/markdown-components';
+import { extractMarkdownHeadings } from '@/lib/markdown-headings';
+import type { MarkdownHeading } from '@/lib/markdown-headings';
 
 export type Heading = MarkdownHeading;
 

--- a/resources/js/hooks/use-markdown-toc.tsx
+++ b/resources/js/hooks/use-markdown-toc.tsx
@@ -4,66 +4,17 @@ import {
     createMarkdownComponents,
     type MarkdownComponentOptions,
 } from '@/lib/markdown-components';
-import { normalizeMarkdownHeadingText } from '@/lib/markdown-heading-text';
-import { slugify } from '@/lib/slugify';
+import {
+    extractMarkdownHeadings,
+    type MarkdownHeading,
+} from '@/lib/markdown-headings';
 
-export type Heading = { level: number; text: string; id: string };
+export type Heading = MarkdownHeading;
 
 export type TocEntry = {
     headings: Heading[];
     components: Components;
 };
-
-function extractHeadings(content: string, postSlug: string): Heading[] {
-    const headings: Heading[] = [];
-
-    // Track the exact opening fence (e.g. "```" or "````") so nested shorter
-    // fences inside quad-backtick meta-examples don't prematurely close it.
-    let activeFence: string | null = null;
-
-    for (const line of content.split('\n')) {
-        const trimmedLine = line.trimStart();
-
-        const fenceMatch = /^(`{3,}|~{3,})/.exec(trimmedLine);
-
-        if (fenceMatch) {
-            const fence = fenceMatch[1];
-            const remainder = trimmedLine.slice(fence.length);
-
-            if (activeFence === null) {
-                activeFence = fence;
-            } else if (
-                fence[0] === activeFence[0] &&
-                fence.length >= activeFence.length &&
-                remainder.trim() === ''
-            ) {
-                activeFence = null;
-            }
-
-            continue;
-        }
-
-        if (activeFence !== null) {
-            continue;
-        }
-
-        const match = /^(#{1,3})\s+(.+)$/.exec(trimmedLine);
-
-        if (match === null) {
-            continue;
-        }
-
-        const text = normalizeMarkdownHeadingText(match[2].trim());
-
-        headings.push({
-            level: match[1].length,
-            text,
-            id: `${postSlug}-${slugify(text)}`,
-        });
-    }
-
-    return headings;
-}
 
 /**
  * Pre-computes TOC headings and custom heading components for a list of markdown posts.
@@ -78,7 +29,7 @@ export function useMarkdownToc(
 
         for (const post of posts) {
             map.set(post.slug, {
-                headings: extractHeadings(post.content, post.slug),
+                headings: extractMarkdownHeadings(post.content, post.slug),
                 components: createMarkdownComponents(
                     post.slug,
                     componentOptions,

--- a/resources/js/lib/markdown-components.tsx
+++ b/resources/js/lib/markdown-components.tsx
@@ -1,5 +1,11 @@
 import { Link as LinkIcon, Pencil } from 'lucide-react';
-import { Children, createContext, isValidElement, useContext, useRef } from 'react';
+import {
+    Children,
+    createContext,
+    isValidElement,
+    useContext,
+    useRef,
+} from 'react';
 import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 import type { Components } from 'react-markdown';
 import { CodeBlock } from '@/components/code-block';
@@ -103,7 +109,9 @@ function makeHeadingComponents(
             const baseId = postSlug
                 ? `${postSlug}-${slugify(text)}`
                 : slugify(text);
-            const id = dispenseId ? dispenseId(baseId, selfRef.current) : baseId;
+            const id = dispenseId
+                ? dispenseId(baseId, selfRef.current)
+                : baseId;
             const Tag = `h${level}` as 'h1' | 'h2' | 'h3';
 
             return (

--- a/resources/js/lib/markdown-components.tsx
+++ b/resources/js/lib/markdown-components.tsx
@@ -1,5 +1,5 @@
 import { Link as LinkIcon, Pencil } from 'lucide-react';
-import { Children, isValidElement } from 'react';
+import { Children, createContext, isValidElement, useContext, useRef } from 'react';
 import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 import type { Components } from 'react-markdown';
 import { CodeBlock } from '@/components/code-block';
@@ -8,6 +8,15 @@ import { extractRenderedHeadingText } from '@/lib/markdown-heading-text';
 import { parseMarkdownImageMetadata } from '@/lib/markdown-syntax';
 import { slugify } from '@/lib/slugify';
 import { cn } from '@/lib/utils';
+
+/**
+ * Provides a function that dispenses deduplicated heading IDs.
+ * Accepts a stable per-component identity object to avoid double-counting
+ * in React Strict Mode's double-invoke.
+ */
+export const HeadingIdContext = createContext<
+    ((baseId: string, self: object) => string) | null
+>(null);
 
 export type MarkdownComponentOptions = {
     headingAnchorPlacement?: 'inline' | 'gutter';
@@ -86,10 +95,15 @@ function makeHeadingComponents(
 ): Pick<Components, 'h1' | 'h2' | 'h3'> {
     const makeTag = (level: 1 | 2 | 3) =>
         function Heading({ children }: { children?: ReactNode }) {
+            const dispenseId = useContext(HeadingIdContext);
+            // Stable per-instance identity so Strict Mode's double-invoke
+            // doesn't increment the shared counter twice for the same heading.
+            const selfRef = useRef<object>({});
             const text = extractRenderedHeadingText(children);
-            const id = postSlug
+            const baseId = postSlug
                 ? `${postSlug}-${slugify(text)}`
                 : slugify(text);
+            const id = dispenseId ? dispenseId(baseId, selfRef.current) : baseId;
             const Tag = `h${level}` as 'h1' | 'h2' | 'h3';
 
             return (

--- a/resources/js/lib/markdown-heading-ids.ts
+++ b/resources/js/lib/markdown-heading-ids.ts
@@ -1,0 +1,22 @@
+export type HeadingIdDispenser = (baseId: string, self: object) => string;
+
+export function createHeadingIdDispenser(): HeadingIdDispenser {
+    const idCounts = new Map<string, number>();
+    const assignedIds = new WeakMap<object, string>();
+
+    return (baseId: string, self: object): string => {
+        const existingId = assignedIds.get(self);
+
+        if (existingId) {
+            return existingId;
+        }
+
+        const count = (idCounts.get(baseId) ?? 0) + 1;
+        const id = count === 1 ? baseId : `${baseId}-${count}`;
+
+        idCounts.set(baseId, count);
+        assignedIds.set(self, id);
+
+        return id;
+    };
+}

--- a/resources/js/lib/markdown-headings.ts
+++ b/resources/js/lib/markdown-headings.ts
@@ -1,0 +1,62 @@
+import { normalizeMarkdownHeadingText } from './markdown-heading-text.js';
+import { slugify } from './slugify.js';
+
+export type MarkdownHeading = {
+    level: number;
+    text: string;
+    id: string;
+};
+
+export function extractMarkdownHeadings(
+    content: string,
+    postSlug: string,
+): MarkdownHeading[] {
+    const headings: MarkdownHeading[] = [];
+    const idCounts = new Map<string, number>();
+    let activeFence: string | null = null;
+
+    for (const line of content.split('\n')) {
+        const trimmedLine = line.trimStart();
+        const fenceMatch = /^(`{3,}|~{3,})/.exec(trimmedLine);
+
+        if (fenceMatch) {
+            const fence = fenceMatch[1];
+            const remainder = trimmedLine.slice(fence.length);
+
+            if (activeFence === null) {
+                activeFence = fence;
+            } else if (
+                fence[0] === activeFence[0] &&
+                fence.length >= activeFence.length &&
+                remainder.trim() === ''
+            ) {
+                activeFence = null;
+            }
+
+            continue;
+        }
+
+        if (activeFence !== null) {
+            continue;
+        }
+
+        const match = /^(#{1,3})\s+(.+)$/.exec(trimmedLine);
+
+        if (match === null) {
+            continue;
+        }
+
+        const text = normalizeMarkdownHeadingText(match[2].trim());
+        const baseId = `${postSlug}-${slugify(text)}`;
+        const count = (idCounts.get(baseId) ?? 0) + 1;
+
+        idCounts.set(baseId, count);
+        headings.push({
+            level: match[1].length,
+            text,
+            id: count === 1 ? baseId : `${baseId}-${count}`,
+        });
+    }
+
+    return headings;
+}

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -11,8 +11,8 @@ import MarkdownContent from '@/components/markdown-content';
 import TableOfContents from '@/components/table-of-contents';
 import { Button } from '@/components/ui/button';
 import { useMarkdownToc } from '@/hooks/use-markdown-toc';
-import { normalizeMarkdownHeadingText } from '@/lib/markdown-heading-text';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { normalizeMarkdownHeadingText } from '@/lib/markdown-heading-text';
 import { dashboard } from '@/routes';
 import {
     destroy,
@@ -273,7 +273,7 @@ export default function Show({
                             : ''
                     }
                 >
-                    <div className="rounded-xl border p-6">
+                    <div className="min-w-0 rounded-xl border p-6">
                         <div className="prose max-w-none prose-neutral dark:prose-invert">
                             <MarkdownContent
                                 content={post.content}

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -6,9 +6,8 @@ import {
     PanelLeftOpen,
 } from 'lucide-react';
 import { useState } from 'react';
-import ContentNavTree, {
-    type ContentNavNode,
-} from '@/components/content-nav-tree';
+import type { ContentNavNode } from '@/components/content-nav-tree';
+import ContentNavTree from '@/components/content-nav-tree';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { login } from '@/routes';
@@ -139,9 +138,15 @@ export default function Namespace({
                     </div>
                 </header>
 
-                <div className="mx-auto max-w-7xl px-4 py-10 lg:grid lg:grid-cols-[240px_1fr] lg:gap-12">
+                <div
+                    data-test="namespace-layout"
+                    className={`mx-auto max-w-7xl px-4 py-10 ${navVisible ? 'lg:grid lg:grid-cols-[240px_1fr] lg:gap-12' : ''}`}
+                >
                     {navVisible && (
-                        <aside className="mb-8 lg:mb-0 lg:block">
+                        <aside
+                            data-test="namespace-nav"
+                            className="mb-8 lg:mb-0 lg:block"
+                        >
                             <div className="lg:sticky lg:top-24">
                                 <p className="mb-3 text-xs font-semibold tracking-wider text-muted-foreground uppercase">
                                     {navRoot.name}
@@ -156,7 +161,7 @@ export default function Namespace({
                         </aside>
                     )}
 
-                    <main className="space-y-12">
+                    <main data-test="namespace-main" className="space-y-12">
                         <section className="space-y-3">
                             <p className="text-sm text-muted-foreground">
                                 /{namespace.full_path}

--- a/tests-node/markdown/markdown-heading-ids.test.ts
+++ b/tests-node/markdown/markdown-heading-ids.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createHeadingIdDispenser } from '../../resources/js/lib/markdown-heading-ids.ts';
+
+test('heading id dispenser reuses the same id for the same heading instance', () => {
+    const dispenseHeadingId = createHeadingIdDispenser();
+    const firstHeading = {};
+    const secondHeading = {};
+
+    assert.equal(
+        dispenseHeadingId('post-installation', firstHeading),
+        'post-installation',
+    );
+    assert.equal(
+        dispenseHeadingId('post-installation', firstHeading),
+        'post-installation',
+    );
+    assert.equal(
+        dispenseHeadingId('post-installation', secondHeading),
+        'post-installation-2',
+    );
+});

--- a/tests-node/markdown/markdown-headings.test.ts
+++ b/tests-node/markdown/markdown-headings.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { extractMarkdownHeadings } from '../../resources/js/lib/markdown-headings.ts';
+
+test('extractMarkdownHeadings deduplicates repeated formatted headings', () => {
+    const headings = extractMarkdownHeadings(
+        `# Intro
+
+## The \`foo_bar\` Guide
+
+## The \`foo_bar\` [Guide](https://example.com/docs)`,
+        'duplicate-headings',
+    );
+
+    assert.deepEqual(headings, [
+        {
+            level: 1,
+            text: 'Intro',
+            id: 'duplicate-headings-intro',
+        },
+        {
+            level: 2,
+            text: 'The `foo_bar` Guide',
+            id: 'duplicate-headings-the-foo-bar-guide',
+        },
+        {
+            level: 2,
+            text: 'The `foo_bar` Guide',
+            id: 'duplicate-headings-the-foo-bar-guide-2',
+        },
+    ]);
+});
+
+test('extractMarkdownHeadings ignores headings inside longer fenced code blocks', () => {
+    const headings = extractMarkdownHeadings(
+        `## Installation
+
+\`\`\`\`md
+## Installation
+\`\`\`\`
+
+## Installation`,
+        'install',
+    );
+
+    assert.deepEqual(headings.map((heading) => heading.id), [
+        'install-installation',
+        'install-installation-2',
+    ]);
+});

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -229,6 +229,82 @@ test('post navigation toggle stays within the viewport after page scroll', funct
     JS))->toBeTrue();
 });
 
+test('namespace navigation toggle removes the empty desktop gutter', function () {
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+        'description' => 'Practical guides, walkthroughs, and reference notes for writing and publishing posts.',
+        'is_published' => true,
+    ]);
+
+    Post::factory()->for($namespace, 'namespace')->published()->create([
+        'slug' => 'index',
+        'title' => 'Markdown Syntax Guide',
+    ]);
+
+    Post::factory()->for($namespace, 'namespace')->published()->create([
+        'slug' => 'zenn-syntax',
+        'title' => 'Zenn Syntax',
+    ]);
+
+    $page = visit(route('posts.path', ['path' => $namespace->full_path]))->resize(1280, 720);
+
+    $page
+        ->assertSee('Guides')
+        ->assertSee('Toggle Nav');
+
+    $before = $page->script(<<<'JS'
+        (() => {
+            const layout = document.querySelector('[data-test="namespace-layout"]');
+
+            if (! layout) {
+                return null;
+            }
+
+            const style = window.getComputedStyle(layout);
+
+            return {
+                display: style.display,
+                gridTemplateColumns: style.gridTemplateColumns,
+            };
+        })()
+    JS);
+
+    $page
+        ->click('Toggle Nav')
+        ->wait(0.3);
+
+    $after = $page->script(<<<'JS'
+        (() => {
+            const layout = document.querySelector('[data-test="namespace-layout"]');
+
+            if (! layout) {
+                return null;
+            }
+
+            const style = window.getComputedStyle(layout);
+
+            return {
+                display: style.display,
+                gridTemplateColumns: style.gridTemplateColumns,
+                asideExists: !! document.querySelector('[data-test="namespace-nav"]'),
+                scrollWidth: document.documentElement.scrollWidth,
+                viewportWidth: window.innerWidth,
+            };
+        })()
+    JS);
+
+    expect($before['display'])->toBe('grid');
+    expect($before['gridTemplateColumns'])->toContain('240px');
+    expect($after)->toBe([
+        'display' => 'block',
+        'gridTemplateColumns' => 'none',
+        'asideExists' => false,
+        'scrollWidth' => 1280,
+        'viewportWidth' => 1280,
+    ]);
+});
+
 test('table of contents highlights the active heading and stays scrollable', function () {
     $namespace = PostNamespace::factory()->create([
         'slug' => 'guides',
@@ -397,6 +473,64 @@ test('admin post deep links restore hashed headings and use gutter anchors', fun
             const anchorRect = anchor.getBoundingClientRect();
 
             return anchorRect.right <= headingRect.left + 8;
+        })()
+    JS))->toBeTrue();
+});
+
+test('admin post table of contents stays within the viewport for wide markdown', function () {
+    $user = User::factory()->create([
+        'email' => 'test@example.com',
+    ]);
+
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+    ]);
+
+    $post = Post::factory()->for($namespace, 'namespace')->create([
+        'slug' => 'index',
+        'title' => 'Index',
+        'content' => implode("\n\n", [
+            '## What is Markdown?',
+            str_repeat('Long body content with inline code like `DEBUG=true` and `<div>` references. ', 20),
+            '## SQL Example',
+            '```sql',
+            "SELECT users.id, users.name, orders.id AS order_id, orders.total, orders.status FROM users INNER JOIN orders ON orders.user_id = users.id WHERE orders.status IN ('pending', 'processing') ORDER BY orders.created_at DESC;",
+            '```',
+            ...collect(range(1, 18))
+                ->map(
+                    fn (int $section): string => "## Section {$section}\n\n".str_repeat(
+                        'Long body content. ',
+                        60,
+                    ),
+                )
+                ->all(),
+        ]),
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.posts.show', [
+        'namespace' => $namespace->id,
+        'post' => $post->slug,
+    ], absolute: false))->resize(1280, 720);
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="table-of-contents"][data-sticky="true"]')
+        ->wait(0.5);
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const toc = document.querySelector('[data-test="table-of-contents"][data-sticky="true"]');
+
+            if (! toc) {
+                return null;
+            }
+
+            const rect = toc.getBoundingClientRect();
+
+            return rect.right <= window.innerWidth && document.documentElement.scrollWidth <= window.innerWidth;
         })()
     JS))->toBeTrue();
 });


### PR DESCRIPTION
## Summary
- synchronize rendered markdown heading IDs with TOC IDs, including duplicate headings outside fenced code blocks
- adjust namespace and admin post layouts to avoid empty gutters and wide-markdown overflow
- align seeded syntax guide heading levels with the new TOC structure and add browser coverage for namespace/admin TOC behavior

## Testing
- vendor/bin/sail npm run build
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npx eslint resources/js/components/markdown-content.tsx resources/js/hooks/use-markdown-toc.tsx resources/js/lib/markdown-components.tsx resources/js/lib/markdown-heading-ids.ts resources/js/lib/markdown-headings.ts resources/js/pages/admin/posts/show.tsx resources/js/pages/posts/namespace.tsx
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail artisan test --compact tests/Feature/PostControllerTest.php tests/Feature/Admin/PostControllerTest.php