### PR TITLE
Unify canonical content and admin flows

### DIFF
--- a/CONTENT_URL_UNIFICATION_HANDOFF.md
+++ b/CONTENT_URL_UNIFICATION_HANDOFF.md
@@ -1,0 +1,326 @@
+# Content URL Unification Handoff
+
+## Summary
+
+This document captures the current status of the content URL unification work as of 2026-04-20.
+
+The product direction is still:
+
+- Treat `/{full_path}` as the canonical content URL.
+- Keep `/admin/...` for management dashboards and operational tooling.
+- Let authenticated users enter edit flows from canonical public pages.
+- Return users to canonical public pages after editing.
+
+That said, Phase 1 is now materially in place. Save redirects now recompute the latest canonical URL from updated model state, while cancel flows can still use a carried `return_to` query value.
+
+## Problem Statement
+
+The application still has two URL systems for the same content:
+
+- Public content:
+  - `/guides`
+  - `/guides/extended-syntax`
+- Admin content:
+  - `/admin/posts/1`
+  - `/admin/posts/1/extended-syntax`
+  - `/admin/posts/1/extended-syntax/edit`
+
+The desired rule is:
+
+- public canonical URLs are the primary read/edit surface
+- `/admin/...` remains a dashboard and management surface
+
+## Current Architecture
+
+### Public Routing
+
+Public content is resolved by wildcard path routing.
+
+- [routes/web.php](/opt/home-admin/thinkstream/routes/web.php:28)
+- [app/Http/Controllers/PostController.php](/opt/home-admin/thinkstream/app/Http/Controllers/PostController.php:51)
+
+Behavior:
+
+- `/{path}` resolves against `posts.full_path`
+- if a post matches, render `resources/js/pages/posts/show.tsx`
+- if a namespace matches, render `resources/js/pages/posts/namespace.tsx`
+
+### Admin Routing
+
+Admin content is resolved through explicit nested routes under `/admin/posts`.
+
+- [routes/admin.php](/opt/home-admin/thinkstream/routes/admin.php:12)
+- [app/Http/Controllers/Admin/PostController.php](/opt/home-admin/thinkstream/app/Http/Controllers/Admin/PostController.php:62)
+
+Behavior:
+
+- `/admin/posts` is the admin dashboard root
+- `/admin/posts/{namespace}` is namespace management
+- `/admin/posts/{namespace}/{post:slug}` is admin post detail
+- `/admin/posts/{namespace}/{post:slug}/edit` is post edit
+
+### Route Key Mismatch
+
+The URL systems still differ because namespace route binding uses `id`, while public content lookup uses `full_path`.
+
+- `PostNamespace` route key: [app/Models/PostNamespace.php](/opt/home-admin/thinkstream/app/Models/PostNamespace.php:52)
+- `Post` route key: [app/Models/Post.php](/opt/home-admin/thinkstream/app/Models/Post.php:29)
+
+Implication:
+
+- public URL uses `full_path`
+- admin URL uses `namespace id + post slug`
+
+This mismatch is still the underlying reason that Phase 3 would be useful later.
+
+## Current Status
+
+### Implemented in the current worktree
+
+#### 1. Canonical login return flow
+
+Users who click `Login` from a canonical public page are sent to `/login?intended=...` and then returned to that canonical page after successful authentication.
+
+Relevant files:
+
+- [app/Providers/FortifyServiceProvider.php](/opt/home-admin/thinkstream/app/Providers/FortifyServiceProvider.php:48)
+- [resources/js/pages/posts/index.tsx](/opt/home-admin/thinkstream/resources/js/pages/posts/index.tsx:31)
+- [resources/js/pages/posts/namespace.tsx](/opt/home-admin/thinkstream/resources/js/pages/posts/namespace.tsx:123)
+- [resources/js/pages/posts/show.tsx](/opt/home-admin/thinkstream/resources/js/pages/posts/show.tsx:292)
+
+Tests added:
+
+- [tests/Feature/Auth/AuthenticationTest.php](/opt/home-admin/thinkstream/tests/Feature/Auth/AuthenticationTest.php:36)
+
+#### 2. Public post page edit entry
+
+Authenticated users can now enter post editing directly from the canonical post page.
+
+Current public affordances:
+
+- `Edit Page`
+- heading-level section editing from the canonical post page
+
+Relevant file:
+
+- [resources/js/pages/posts/show.tsx](/opt/home-admin/thinkstream/resources/js/pages/posts/show.tsx:125)
+
+#### 3. Public namespace page edit entry
+
+Authenticated users can now enter namespace editing directly from the canonical namespace page.
+
+Current public affordances:
+
+- `Edit Section`
+
+Relevant file:
+
+- [resources/js/pages/posts/namespace.tsx](/opt/home-admin/thinkstream/resources/js/pages/posts/namespace.tsx:123)
+
+#### 4. Admin save redirects recompute canonical pages
+
+Admin edit pages now accept `return_to` for entry/cancel behavior, while save redirects recompute the latest canonical public URL from updated model state.
+
+Relevant files:
+
+- [app/Http/Controllers/Admin/PostController.php](/opt/home-admin/thinkstream/app/Http/Controllers/Admin/PostController.php:111)
+- [app/Http/Controllers/Admin/NamespaceController.php](/opt/home-admin/thinkstream/app/Http/Controllers/Admin/NamespaceController.php:82)
+- [resources/js/pages/admin/posts/edit.tsx](/opt/home-admin/thinkstream/resources/js/pages/admin/posts/edit.tsx:50)
+- [resources/js/pages/admin/namespaces/edit.tsx](/opt/home-admin/thinkstream/resources/js/pages/admin/namespaces/edit.tsx:20)
+
+#### 5. Admin has been de-emphasized in public headers
+
+Public pages now prefer:
+
+- `Login`
+- `Dashboard`
+- content-specific edit controls
+
+instead of treating `Admin` as the primary CTA.
+
+#### 6. Revision label cleanup
+
+The accidental Japanese `変更履歴` label has been normalized back to `Revision History`.
+
+Relevant files:
+
+- [resources/js/pages/admin/posts/edit.tsx](/opt/home-admin/thinkstream/resources/js/pages/admin/posts/edit.tsx:139)
+- [resources/js/pages/admin/posts/revisions.tsx](/opt/home-admin/thinkstream/resources/js/pages/admin/posts/revisions.tsx:116)
+
+### Verified so far
+
+The following were already run in Sail during this work:
+
+```bash
+vendor/bin/sail artisan test --compact tests/Feature/Auth/AuthenticationTest.php tests/Feature/PrivateModeTest.php
+vendor/bin/sail artisan test --compact tests/Feature/Admin/PostControllerTest.php tests/Feature/Admin/NamespaceControllerTest.php
+vendor/bin/sail bin pint --dirty --format agent
+```
+
+Playwright also confirmed:
+
+- `/guides -> Login -> authenticate -> /guides`
+- `/guides/index -> Login -> authenticate -> /guides/index`
+- authenticated canonical post page shows `Edit Page`
+
+## Redirect Correctness Status
+
+The stale-`return_to` save redirect problem has now been addressed.
+
+Current behavior:
+
+- `return_to` is still accepted as a signal that the user entered from a canonical page
+- after `$post->update($data)`, save redirects use the post's updated `full_path`
+- after `$namespace->update($data)`, save redirects use the namespace's updated `full_path`
+- `return_heading` is preserved only as a fragment/hash
+
+## Recommended Product Interpretation
+
+The current thinking is:
+
+- canonical URLs should be for view/edit
+- `/admin` should be for management/operations
+
+That means:
+
+### Canonical pages should contain
+
+- view content
+- edit the current item
+- optionally lightweight in-context actions directly related to the current item
+
+Examples:
+
+- post canonical: `Edit Page`, `Edit Section`
+- namespace canonical: `Edit Section`
+- maybe `New Post` later if it feels natural in-context
+
+### `/admin` should contain
+
+- namespace tree management
+- cross-namespace dashboards
+- sorting/reordering
+- list views
+- revision tooling
+- broader operational workflows
+
+This means we should avoid turning canonical namespace pages into a full admin control plane.
+
+## Recommended Phase Framing
+
+### Phase 1
+
+Goal:
+
+- unify the editor journey without changing route models
+
+Status:
+
+- partially done
+
+Done:
+
+1. canonical login return flow
+2. canonical post edit entry
+3. canonical namespace edit entry
+4. `Dashboard` is now more clearly secondary/admin utility
+
+Not done cleanly yet:
+
+1. namespace canonical management affordances still need product-level pruning/expansion
+2. public-page auth-state coverage is still thinner than ideal
+
+### Phase 2
+
+Goal:
+
+- reduce duplicate UI responsibilities between public detail pages and admin detail pages
+
+Still not started.
+
+Questions still valid:
+
+1. Is admin post show still necessary once public pages are the primary editing entry point?
+2. Which display blocks should be shared between public and admin views?
+3. Can admin detail responsibilities be reduced further?
+
+### Phase 3
+
+Goal:
+
+- move to path-based edit URLs
+
+Examples:
+
+- `/guides/edit`
+- `/guides/extended-syntax/edit`
+
+Still not started, and should not be started until Phase 1 redirect behavior is cleaned up.
+
+## Next Commit Recommendation
+
+The next commit should focus on the remaining product and coverage gaps, not redirect correctness.
+
+### Concrete next step
+
+1. Decide whether canonical namespace pages should keep only `Edit Section` or also expose `New Post`.
+2. Add broader auth-state coverage for canonical namespace/post page controls.
+3. Reduce duplication between canonical detail pages and admin detail pages where it still exists.
+
+Suggested files:
+
+- [app/Http/Controllers/Admin/PostController.php](/opt/home-admin/thinkstream/app/Http/Controllers/Admin/PostController.php:111)
+- [app/Http/Controllers/Admin/NamespaceController.php](/opt/home-admin/thinkstream/app/Http/Controllers/Admin/NamespaceController.php:82)
+- [tests/Feature/Admin/PostControllerTest.php](/opt/home-admin/thinkstream/tests/Feature/Admin/PostControllerTest.php:370)
+- [tests/Feature/Admin/NamespaceControllerTest.php](/opt/home-admin/thinkstream/tests/Feature/Admin/NamespaceControllerTest.php:249)
+
+## Secondary Follow-Up After That
+
+Once redirect correctness is fixed, the next product decision should be made explicitly for canonical namespace pages:
+
+- keep only `Edit Section`
+- or add `New Post`
+- but do not turn canonical namespace pages into a full admin dashboard by default
+
+That decision should be made before adding more namespace-level controls.
+
+## Test Plan Going Forward
+
+Required additional coverage:
+
+1. Updating a post with a changed slug redirects to the new canonical URL.
+2. Updating a namespace with a changed slug redirects to the new canonical URL.
+3. Public namespace page shows authenticated edit affordances.
+4. Public namespace page hides those affordances from guests.
+
+Suggested commands:
+
+```bash
+vendor/bin/sail artisan test --compact tests/Feature/Admin/PostControllerTest.php tests/Feature/Admin/NamespaceControllerTest.php
+vendor/bin/sail artisan test --compact tests/Feature/Auth/AuthenticationTest.php tests/Feature/PrivateModeTest.php
+vendor/bin/sail bin pint --dirty --format agent
+```
+
+## Risks and Constraints
+
+### Risk 1: stale carried paths
+
+If save redirects continue to trust a carried `return_to`, users may land on outdated URLs after slug changes.
+
+### Risk 2: public pages becoming pseudo-admin dashboards
+
+If too many management controls are added to canonical namespace pages, the public/admin separation will blur again.
+
+### Risk 3: future path collisions
+
+If Phase 3 introduces `/{path}/edit` or `/{path}/create`, reserved segment design must be handled deliberately.
+
+Relevant files:
+
+- [app/Support/ReservedContentPath.php](/opt/home-admin/thinkstream/app/Support/ReservedContentPath.php:1)
+- [routes/web.php](/opt/home-admin/thinkstream/routes/web.php:28)
+
+## Notes
+
+- Laravel Boost MCP tools were expected by project instructions, but the MCP server was not available in this session, so analysis and implementation were done from repository code directly.
+- The document was updated after partial Phase 1 implementation in the working tree on 2026-04-20.

--- a/CONTENT_URL_UNIFICATION_HANDOFF.md
+++ b/CONTENT_URL_UNIFICATION_HANDOFF.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This document captures the current status of the content URL unification work as of 2026-04-20.
+This document captures the current status of the content URL unification work as of 2026-04-21.
 
 The product direction is still:
 
@@ -11,7 +11,24 @@ The product direction is still:
 - Let authenticated users enter edit flows from canonical public pages.
 - Return users to canonical public pages after editing.
 
-That said, Phase 1 is now materially in place. Save redirects now recompute the latest canonical URL from updated model state, while cancel flows can still use a carried `return_to` query value.
+That said, Phase 1 is now functionally in place on this branch. The current branch commit now covers canonical preview/edit affordances, canonical-aware create and save redirects, recursive namespace deletion, and the admin UI reshaping needed to make canonical pages the primary content surface.
+
+## Current Evaluation
+
+Overall status is good: the branch now delivers the intended Phase 1 journey well enough to treat the canonical content URL as the primary read/edit surface without changing the route model yet.
+
+What is now in solid shape:
+
+- canonical post pages expose direct edit entry and heading-level edit jumps
+- canonical namespace pages expose inline section editing and in-context post creation
+- admin create/save flows now recompute redirects from current model state instead of stale entry URLs
+- namespace deletion now recursively deletes descendant namespaces and posts
+- affected feature tests, type-checking, and production build are green on this branch
+
+What still looks like follow-up rather than blocker work:
+
+- the admin namespace post table still renders its external-link icon from `post.full_path` instead of the new `canonical_url` field, so the UI contract is not fully aligned yet
+- admin detail screens still overlap with the new canonical authoring surface more than they should
 
 ## Problem Statement
 
@@ -75,7 +92,7 @@ This mismatch is still the underlying reason that Phase 3 would be useful later.
 
 ## Current Status
 
-### Implemented in the current worktree
+### Committed on this branch
 
 #### 1. Canonical login return flow
 
@@ -100,6 +117,7 @@ Current public affordances:
 
 - `Edit Page`
 - heading-level section editing from the canonical post page
+- `Manage` as the secondary admin/operations entry
 
 Relevant file:
 
@@ -107,38 +125,51 @@ Relevant file:
 
 #### 3. Public namespace page edit entry
 
-Authenticated users can now enter namespace editing directly from the canonical namespace page.
+Authenticated users can now edit namespace metadata directly from the canonical namespace page.
 
 Current public affordances:
 
-- `Edit Section`
+- inline `Edit Section` / `Done` toggle
+- `New Post`
+- `Manage` as the secondary admin/operations entry
 
 Relevant file:
 
 - [resources/js/pages/posts/namespace.tsx](/opt/home-admin/thinkstream/resources/js/pages/posts/namespace.tsx:123)
 
-#### 4. Admin save redirects recompute canonical pages
+#### 4. Admin create/edit redirects recompute canonical pages
 
-Admin edit pages now accept `return_to` for entry/cancel behavior, while save redirects recompute the latest canonical public URL from updated model state.
+Admin post and namespace edit pages now accept `return_to` for entry/cancel behavior, while save redirects recompute the latest canonical public URL from updated model state. Post creation also accepts `return_to`, so entering `New Post` from a canonical namespace page returns to the newly created canonical post page.
 
 Relevant files:
 
-- [app/Http/Controllers/Admin/PostController.php](/opt/home-admin/thinkstream/app/Http/Controllers/Admin/PostController.php:111)
+- [app/Http/Controllers/Admin/PostController.php](/opt/home-admin/thinkstream/app/Http/Controllers/Admin/PostController.php:77)
 - [app/Http/Controllers/Admin/NamespaceController.php](/opt/home-admin/thinkstream/app/Http/Controllers/Admin/NamespaceController.php:82)
+- [resources/js/pages/admin/posts/create.tsx](/opt/home-admin/thinkstream/resources/js/pages/admin/posts/create.tsx:36)
 - [resources/js/pages/admin/posts/edit.tsx](/opt/home-admin/thinkstream/resources/js/pages/admin/posts/edit.tsx:50)
 - [resources/js/pages/admin/namespaces/edit.tsx](/opt/home-admin/thinkstream/resources/js/pages/admin/namespaces/edit.tsx:20)
 
-#### 5. Admin has been de-emphasized in public headers
+#### 5. Public admin affordances have been reframed
 
 Public pages now prefer:
 
 - `Login`
-- `Dashboard`
+- `Manage`
 - content-specific edit controls
 
 instead of treating `Admin` as the primary CTA.
 
-#### 6. Revision label cleanup
+#### 6. Slug prefix UI has been aligned in post create/edit
+
+Admin post create and edit screens now consistently show the namespace path prefix in the slug field, including root namespaces.
+
+Relevant files:
+
+- [app/Http/Controllers/Admin/PostController.php](/opt/home-admin/thinkstream/app/Http/Controllers/Admin/PostController.php:72)
+- [resources/js/pages/admin/posts/create.tsx](/opt/home-admin/thinkstream/resources/js/pages/admin/posts/create.tsx:38)
+- [resources/js/pages/admin/posts/edit.tsx](/opt/home-admin/thinkstream/resources/js/pages/admin/posts/edit.tsx:34)
+
+#### 7. Revision label cleanup
 
 The accidental Japanese `変更履歴` label has been normalized back to `Revision History`.
 
@@ -154,7 +185,10 @@ The following were already run in Sail during this work:
 ```bash
 vendor/bin/sail artisan test --compact tests/Feature/Auth/AuthenticationTest.php tests/Feature/PrivateModeTest.php
 vendor/bin/sail artisan test --compact tests/Feature/Admin/PostControllerTest.php tests/Feature/Admin/NamespaceControllerTest.php
+vendor/bin/sail artisan test --compact tests/Feature/PostControllerTest.php
+vendor/bin/sail npm run types:check
 vendor/bin/sail bin pint --dirty --format agent
+vendor/bin/sail npm run build
 ```
 
 Playwright also confirmed:
@@ -162,6 +196,7 @@ Playwright also confirmed:
 - `/guides -> Login -> authenticate -> /guides`
 - `/guides/index -> Login -> authenticate -> /guides/index`
 - authenticated canonical post page shows `Edit Page`
+- authenticated canonical namespace page shows `Edit Section`
 
 ## Redirect Correctness Status
 
@@ -170,6 +205,7 @@ The stale-`return_to` save redirect problem has now been addressed.
 Current behavior:
 
 - `return_to` is still accepted as a signal that the user entered from a canonical page
+- after `$post = Post::create(...)`, create redirects can use the post's new `full_path`
 - after `$post->update($data)`, save redirects use the post's updated `full_path`
 - after `$namespace->update($data)`, save redirects use the namespace's updated `full_path`
 - `return_heading` is preserved only as a fragment/hash
@@ -192,8 +228,7 @@ That means:
 Examples:
 
 - post canonical: `Edit Page`, `Edit Section`
-- namespace canonical: `Edit Section`
-- maybe `New Post` later if it feels natural in-context
+- namespace canonical: inline `Edit Section`, `New Post`
 
 ### `/admin` should contain
 
@@ -216,19 +251,21 @@ Goal:
 
 Status:
 
-- partially done
+- materially done, with remaining cleanup/coverage work
 
 Done:
 
 1. canonical login return flow
 2. canonical post edit entry
-3. canonical namespace edit entry
-4. `Dashboard` is now more clearly secondary/admin utility
+3. canonical namespace inline edit entry
+4. canonical namespace `New Post` entry
+5. `Manage` is now the public secondary admin utility label
+6. admin create/edit redirects recompute canonical save destinations
 
 Not done cleanly yet:
 
-1. namespace canonical management affordances still need product-level pruning/expansion
-2. public-page auth-state coverage is still thinner than ideal
+1. namespace canonical management affordances may still need product-level pruning
+2. admin detail screens may still duplicate public detail screens more than necessary
 
 ### Phase 2
 
@@ -255,34 +292,33 @@ Examples:
 - `/guides/edit`
 - `/guides/extended-syntax/edit`
 
-Still not started, and should not be started until Phase 1 redirect behavior is cleaned up.
+Still not started, and should not be started until the remaining Phase 1 cleanup is explicitly considered complete.
 
-## Next Commit Recommendation
+## Next Work Recommendation
 
-The next commit should focus on the remaining product and coverage gaps, not redirect correctness.
+The next work should focus on the remaining UI contract gaps and product cleanup, not redirect correctness.
 
 ### Concrete next step
 
-1. Decide whether canonical namespace pages should keep only `Edit Section` or also expose `New Post`.
-2. Add broader auth-state coverage for canonical namespace/post page controls.
-3. Reduce duplication between canonical detail pages and admin detail pages where it still exists.
+1. Align the admin namespace post table with the controller contract by only showing a public external-link target when `canonical_url` exists.
+2. Reduce duplication between canonical detail pages and admin detail pages where it still exists.
+3. Decide whether admin post show remains necessary as canonical pages become the primary authoring surface.
 
 Suggested files:
 
-- [app/Http/Controllers/Admin/PostController.php](/opt/home-admin/thinkstream/app/Http/Controllers/Admin/PostController.php:111)
-- [app/Http/Controllers/Admin/NamespaceController.php](/opt/home-admin/thinkstream/app/Http/Controllers/Admin/NamespaceController.php:82)
-- [tests/Feature/Admin/PostControllerTest.php](/opt/home-admin/thinkstream/tests/Feature/Admin/PostControllerTest.php:370)
-- [tests/Feature/Admin/NamespaceControllerTest.php](/opt/home-admin/thinkstream/tests/Feature/Admin/NamespaceControllerTest.php:249)
+- [resources/js/pages/posts/show.tsx](/opt/home-admin/thinkstream/resources/js/pages/posts/show.tsx:292)
+- [resources/js/pages/posts/namespace.tsx](/opt/home-admin/thinkstream/resources/js/pages/posts/namespace.tsx:123)
+- [resources/js/pages/admin/posts/namespace.tsx](/opt/home-admin/thinkstream/resources/js/pages/admin/posts/namespace.tsx:199)
+- [resources/js/pages/admin/posts/show.tsx](/opt/home-admin/thinkstream/resources/js/pages/admin/posts/show.tsx:1)
+- [tests/Feature/PostControllerTest.php](/opt/home-admin/thinkstream/tests/Feature/PostControllerTest.php:90)
 
 ## Secondary Follow-Up After That
 
-Once redirect correctness is fixed, the next product decision should be made explicitly for canonical namespace pages:
+The next product decision should be made explicitly for canonical namespace pages:
 
-- keep only `Edit Section`
-- or add `New Post`
+- keep the current `Edit Section` + `New Post` surface
+- or prune it back if it starts to feel too close to admin
 - but do not turn canonical namespace pages into a full admin dashboard by default
-
-That decision should be made before adding more namespace-level controls.
 
 ## Test Plan Going Forward
 
@@ -290,28 +326,26 @@ Required additional coverage:
 
 1. Updating a post with a changed slug redirects to the new canonical URL.
 2. Updating a namespace with a changed slug redirects to the new canonical URL.
-3. Public namespace page shows authenticated edit affordances.
-4. Public namespace page hides those affordances from guests.
+3. Public canonical pages receive the expected auth state for their edit/manage controls.
+4. Any future namespace-level controls should add explicit auth/guest coverage when introduced.
 
 Suggested commands:
 
 ```bash
 vendor/bin/sail artisan test --compact tests/Feature/Admin/PostControllerTest.php tests/Feature/Admin/NamespaceControllerTest.php
 vendor/bin/sail artisan test --compact tests/Feature/Auth/AuthenticationTest.php tests/Feature/PrivateModeTest.php
+vendor/bin/sail artisan test --compact tests/Feature/PostControllerTest.php
 vendor/bin/sail bin pint --dirty --format agent
+vendor/bin/sail npm run build
 ```
 
 ## Risks and Constraints
 
-### Risk 1: stale carried paths
-
-If save redirects continue to trust a carried `return_to`, users may land on outdated URLs after slug changes.
-
-### Risk 2: public pages becoming pseudo-admin dashboards
+### Risk 1: public pages becoming pseudo-admin dashboards
 
 If too many management controls are added to canonical namespace pages, the public/admin separation will blur again.
 
-### Risk 3: future path collisions
+### Risk 2: future path collisions
 
 If Phase 3 introduces `/{path}/edit` or `/{path}/create`, reserved segment design must be handled deliberately.
 
@@ -323,4 +357,4 @@ Relevant files:
 ## Notes
 
 - Laravel Boost MCP tools were expected by project instructions, but the MCP server was not available in this session, so analysis and implementation were done from repository code directly.
-- The document was updated after partial Phase 1 implementation in the working tree on 2026-04-20.
+- The document was updated after commit `fb71e6c` on 2026-04-21.

--- a/app/Http/Controllers/Admin/NamespaceController.php
+++ b/app/Http/Controllers/Admin/NamespaceController.php
@@ -92,6 +92,12 @@ class NamespaceController extends Controller
 
         $namespace->update($data);
 
+        $returnTo = $this->safeReturnPath($request->string('return_to')->toString());
+
+        if ($returnTo !== null) {
+            return redirect()->to(route('posts.path', ['path' => $namespace->full_path], absolute: false));
+        }
+
         return to_route('admin.posts.index');
     }
 
@@ -104,5 +110,23 @@ class NamespaceController extends Controller
         $namespace->delete();
 
         return to_route('admin.posts.index');
+    }
+
+    private function safeReturnPath(string $path): ?string
+    {
+        if ($path === '') {
+            return null;
+        }
+
+        if (
+            ! str_starts_with($path, '/')
+            || str_starts_with($path, '//')
+            || parse_url($path, PHP_URL_SCHEME) !== null
+            || parse_url($path, PHP_URL_HOST) !== null
+        ) {
+            return null;
+        }
+
+        return $path;
     }
 }

--- a/app/Http/Controllers/Admin/NamespaceController.php
+++ b/app/Http/Controllers/Admin/NamespaceController.php
@@ -103,11 +103,7 @@ class NamespaceController extends Controller
 
     public function destroy(PostNamespace $namespace): RedirectResponse
     {
-        if ($namespace->cover_image) {
-            Storage::disk('public')->delete($namespace->cover_image);
-        }
-
-        $namespace->delete();
+        $namespace->deleteRecursively();
 
         return to_route('admin.posts.index');
     }

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -128,6 +128,11 @@ class PostController extends Controller
 
         $fragment = $request->string('return_heading')->toString();
         $hash = $fragment !== '' ? '#'.ltrim($fragment, '#') : '';
+        $returnTo = $this->safeReturnPath($request->string('return_to')->toString());
+
+        if ($returnTo !== null) {
+            return redirect()->to(route('posts.path', ['path' => $post->full_path], absolute: false).$hash);
+        }
 
         return redirect()->route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug])
             ->setTargetUrl(route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug]).$hash);
@@ -212,5 +217,23 @@ class PostController extends Controller
         Inertia::flash('toast', ['type' => 'success', 'message' => 'Post deleted.']);
 
         return to_route('admin.posts.namespace', $namespace);
+    }
+
+    private function safeReturnPath(string $path): ?string
+    {
+        if ($path === '') {
+            return null;
+        }
+
+        if (
+            ! str_starts_with($path, '/')
+            || str_starts_with($path, '//')
+            || parse_url($path, PHP_URL_SCHEME) !== null
+            || parse_url($path, PHP_URL_HOST) !== null
+        ) {
+            return null;
+        }
+
+        return $path;
     }
 }

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -61,11 +61,33 @@ class PostController extends Controller
 
     public function namespaceIndex(PostNamespace $namespace): Response
     {
+        $posts = $namespace->sortPosts($namespace->posts()->latest()->get([
+            'id',
+            'title',
+            'slug',
+            'full_path',
+            'is_draft',
+            'published_at',
+            'created_at',
+        ]))->map(fn (Post $post) => [
+            'id' => $post->id,
+            'title' => $post->title,
+            'slug' => $post->slug,
+            'full_path' => $post->full_path,
+            'is_draft' => $post->is_draft,
+            'published_at' => $post->published_at,
+            'created_at' => $post->created_at,
+            'canonical_url' => ! $post->is_draft && $post->published_at !== null && $post->published_at->isPast()
+                ? route('posts.path', ['path' => $post->full_path], absolute: false)
+                : null,
+            'admin_url' => route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug], absolute: false),
+        ]);
+
         return Inertia::render('admin/posts/namespace', [
             'namespace' => $namespace,
             'ancestors' => $namespace->ancestors()->map(fn (PostNamespace $ns) => ['id' => $ns->id, 'name' => $ns->name]),
             'children' => $namespace->sortNamespaces($namespace->children()->withCount('posts')->get()),
-            'posts' => $namespace->sortPosts($namespace->posts()->latest()->get(['id', 'title', 'slug', 'is_draft', 'published_at', 'created_at'])),
+            'posts' => $posts,
         ]);
     }
 
@@ -73,9 +95,7 @@ class PostController extends Controller
     {
         return Inertia::render('admin/posts/create', [
             'namespace' => $namespace,
-            'slugPrefix' => $namespace->full_path !== $namespace->slug
-                ? trim($namespace->full_path, '/').'/'
-                : null,
+            'slugPrefix' => trim($namespace->full_path, '/').'/',
         ]);
     }
 
@@ -88,6 +108,12 @@ class PostController extends Controller
         ]);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => 'Post created.']);
+
+        $returnTo = $this->safeReturnPath($request->string('return_to')->toString());
+
+        if ($returnTo !== null) {
+            return redirect()->to(route('posts.path', ['path' => $post->full_path], absolute: false));
+        }
 
         return to_route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug]);
     }
@@ -105,6 +131,7 @@ class PostController extends Controller
         return Inertia::render('admin/posts/edit', [
             'namespace' => $namespace,
             'post' => $post,
+            'slugPrefix' => trim($namespace->full_path, '/').'/',
         ]);
     }
 
@@ -124,8 +151,6 @@ class PostController extends Controller
 
         $post->update($data);
 
-        Inertia::flash('toast', ['type' => 'success', 'message' => 'Post saved.']);
-
         $fragment = $request->string('return_heading')->toString();
         $hash = $fragment !== '' ? '#'.ltrim($fragment, '#') : '';
         $returnTo = $this->safeReturnPath($request->string('return_to')->toString());
@@ -134,8 +159,8 @@ class PostController extends Controller
             return redirect()->to(route('posts.path', ['path' => $post->full_path], absolute: false).$hash);
         }
 
-        return redirect()->route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug])
-            ->setTargetUrl(route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug]).$hash);
+        return redirect()->route('admin.posts.edit', ['namespace' => $namespace, 'post' => $post->slug])
+            ->setTargetUrl(route('admin.posts.edit', ['namespace' => $namespace, 'post' => $post->slug]).$hash);
     }
 
     public function revisions(PostNamespace $namespace, Post $post): Response

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -12,6 +12,7 @@ use App\Models\PostNamespace;
 use App\Models\PostRevision;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -116,6 +117,44 @@ class PostController extends Controller
         }
 
         return to_route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug]);
+    }
+
+    public function reorderPosts(Request $request, PostNamespace $namespace): RedirectResponse
+    {
+        $postSlugs = $namespace->posts()->pluck('slug')->all();
+        $slugs = $request->validate([
+            'slugs' => ['required', 'array'],
+            'slugs.*' => ['string', 'distinct:strict', Rule::in($postSlugs)],
+        ])['slugs'];
+
+        $existingOrder = $namespace->post_order ?? [];
+        $childSlugs = $namespace->children()->pluck('slug')->all();
+        $namespaceSlugsInOrder = array_values(
+            array_filter($existingOrder, fn (string $slug) => in_array($slug, $childSlugs, true))
+        );
+
+        $namespace->update(['post_order' => [...$namespaceSlugsInOrder, ...$slugs]]);
+
+        return back();
+    }
+
+    public function reorderNamespaces(Request $request, PostNamespace $namespace): RedirectResponse
+    {
+        $childSlugs = $namespace->children()->pluck('slug')->all();
+        $slugs = $request->validate([
+            'slugs' => ['required', 'array'],
+            'slugs.*' => ['string', 'distinct:strict', Rule::in($childSlugs)],
+        ])['slugs'];
+
+        $existingOrder = $namespace->post_order ?? [];
+        $postSlugs = $namespace->posts()->pluck('slug')->all();
+        $postSlugsInOrder = array_values(
+            array_filter($existingOrder, fn (string $slug) => in_array($slug, $postSlugs, true))
+        );
+
+        $namespace->update(['post_order' => [...$slugs, ...$postSlugsInOrder]]);
+
+        return back();
     }
 
     public function show(PostNamespace $namespace, Post $post): Response

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -86,19 +86,35 @@ class PostController extends Controller
         $namespace = PostNamespace::query()
             ->where('full_path', $normalizedPath)
             ->where('is_published', true)
-            ->firstOrFail();
+            ->first();
 
-        $ancestors = $this->ancestorChain($namespace);
+        if ($namespace) {
+            $ancestors = $this->ancestorChain($namespace);
 
-        abort_unless($this->namespaceChainIsPublished($namespace, $ancestors), 404);
+            abort_unless($this->namespaceChainIsPublished($namespace, $ancestors), 404);
 
-        return $this->renderNamespace($namespace, $ancestors);
+            return $this->renderNamespace($namespace, $ancestors);
+        }
+
+        if (auth()->check()) {
+            $previewNamespace = PostNamespace::query()
+                ->where('full_path', $normalizedPath)
+                ->first();
+
+            if ($previewNamespace) {
+                $ancestors = $this->ancestorChain($previewNamespace);
+
+                return $this->renderNamespace($previewNamespace, $ancestors, preview: true);
+            }
+        }
+
+        abort(404);
     }
 
     /**
      * @param  Collection<int, PostNamespace>  $ancestors
      */
-    private function renderNamespace(PostNamespace $namespace, Collection $ancestors): Response
+    private function renderNamespace(PostNamespace $namespace, Collection $ancestors, bool $preview = false): Response
     {
         $rootNamespace = $this->rootNamespace($namespace, $ancestors);
         $children = $namespace->children()
@@ -118,6 +134,7 @@ class PostController extends Controller
             'navRoot' => $this->buildNavigationNode($rootNamespace),
             'namespace' => $namespace->only(['id', 'slug', 'full_path', 'name', 'description', 'cover_image_url', 'is_published']),
             'posts' => $namespace->sortPosts($posts),
+            'preview' => $preview,
         ]);
     }
 

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -70,6 +70,19 @@ class PostController extends Controller
             return $this->renderPost($post, $ancestors);
         }
 
+        if (auth()->check()) {
+            $previewPost = Post::query()
+                ->with('namespace:id,parent_id,slug,full_path,name,cover_image,is_published')
+                ->where('full_path', $normalizedPath)
+                ->first();
+
+            if ($previewPost) {
+                $ancestors = $this->ancestorChain($previewPost->namespace);
+
+                return $this->renderPost($previewPost, $ancestors, preview: true);
+            }
+        }
+
         $namespace = PostNamespace::query()
             ->where('full_path', $normalizedPath)
             ->where('is_published', true)
@@ -103,7 +116,7 @@ class PostController extends Controller
             'breadcrumbs' => $this->breadcrumbs($ancestors),
             'children' => $namespace->sortNamespaces($children),
             'navRoot' => $this->buildNavigationNode($rootNamespace),
-            'namespace' => $namespace->only(['id', 'slug', 'full_path', 'name', 'description', 'cover_image_url']),
+            'namespace' => $namespace->only(['id', 'slug', 'full_path', 'name', 'description', 'cover_image_url', 'is_published']),
             'posts' => $namespace->sortPosts($posts),
         ]);
     }
@@ -111,7 +124,7 @@ class PostController extends Controller
     /**
      * @param  Collection<int, PostNamespace>  $ancestors
      */
-    private function renderPost(Post $post, Collection $ancestors): Response
+    private function renderPost(Post $post, Collection $ancestors, bool $preview = false): Response
     {
         $namespace = $post->namespace;
         $rootNamespace = $this->rootNamespace($namespace, $ancestors);
@@ -129,6 +142,10 @@ class PostController extends Controller
             'postUrl' => route('posts.path', ['path' => $post->full_path]),
             'post' => $post->only(['id', 'slug', 'full_path', 'title', 'content', 'published_at', 'updated_at']),
             'posts' => $namespace->sortPosts($posts),
+            'preview' => $preview ? [
+                'status' => $post->is_draft ? 'draft' : 'scheduled',
+                'published_at' => $post->published_at?->toISOString(),
+            ] : null,
         ]);
     }
 

--- a/app/Http/Requests/Admin/StoreNamespaceRequest.php
+++ b/app/Http/Requests/Admin/StoreNamespaceRequest.php
@@ -54,7 +54,7 @@ class StoreNamespaceRequest extends FormRequest
                 'string',
                 'max:255',
                 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/',
-                Rule::notIn(ReservedContentPath::rootSegments()),
+                ...($this->parentId() === null ? [Rule::notIn(ReservedContentPath::rootSegments())] : []),
                 Rule::unique('namespaces', 'slug')->where(function ($query) {
                     return $this->parentId() === null
                         ? $query->whereNull('parent_id')

--- a/app/Http/Requests/Admin/UpdateNamespaceRequest.php
+++ b/app/Http/Requests/Admin/UpdateNamespaceRequest.php
@@ -88,7 +88,7 @@ class UpdateNamespaceRequest extends FormRequest
                 'string',
                 'max:255',
                 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/',
-                Rule::notIn(ReservedContentPath::rootSegments()),
+                ...($this->parentId() === null ? [Rule::notIn(ReservedContentPath::rootSegments())] : []),
                 Rule::unique('namespaces', 'slug')
                     ->where(function ($query) {
                         return $this->parentId() === null

--- a/app/Models/PostNamespace.php
+++ b/app/Models/PostNamespace.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
 class PostNamespace extends Model
@@ -109,6 +110,23 @@ class PostNamespace extends Model
     public function posts(): HasMany
     {
         return $this->hasMany(Post::class, 'namespace_id');
+    }
+
+    public function deleteRecursively(): void
+    {
+        DB::transaction(function (): void {
+            foreach ($this->children()->get() as $child) {
+                $child->deleteRecursively();
+            }
+
+            $this->posts()->delete();
+
+            if ($this->cover_image) {
+                Storage::disk('public')->delete($this->cover_image);
+            }
+
+            $this->delete();
+        });
     }
 
     /**

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -47,11 +47,15 @@ class FortifyServiceProvider extends ServiceProvider
      */
     private function configureViews(): void
     {
-        Fortify::loginView(fn (Request $request) => Inertia::render('auth/login', [
-            'canResetPassword' => Features::enabled(Features::resetPasswords()),
-            'canRegister' => Features::enabled(Features::registration()),
-            'status' => $request->session()->get('status'),
-        ]));
+        Fortify::loginView(function (Request $request) {
+            $this->storeIntendedPath($request);
+
+            return Inertia::render('auth/login', [
+                'canResetPassword' => Features::enabled(Features::resetPasswords()),
+                'canRegister' => Features::enabled(Features::registration()),
+                'status' => $request->session()->get('status'),
+            ]);
+        });
 
         Fortify::resetPasswordView(fn (Request $request) => Inertia::render('auth/reset-password', [
             'email' => $request->email,
@@ -87,5 +91,26 @@ class FortifyServiceProvider extends ServiceProvider
 
             return Limit::perMinute(5)->by($throttleKey);
         });
+    }
+
+    private function storeIntendedPath(Request $request): ?string
+    {
+        $intended = $request->query('intended');
+
+        if (! is_string($intended) || ! $this->isSafeRelativePath($intended)) {
+            return null;
+        }
+
+        $request->session()->put('url.intended', $intended);
+
+        return $intended;
+    }
+
+    private function isSafeRelativePath(string $path): bool
+    {
+        return str_starts_with($path, '/')
+            && ! str_starts_with($path, '//')
+            && parse_url($path, PHP_URL_SCHEME) === null
+            && parse_url($path, PHP_URL_HOST) === null;
     }
 }

--- a/database/seeders/SyntaxSeeder.php
+++ b/database/seeders/SyntaxSeeder.php
@@ -1515,5 +1515,344 @@ Initial launch of Thinkstream with support for Markdown, GFM, Zenn syntax, and c
 MD),
                 'published_at' => now(),
             ]);
+
+        $metaNamespace = PostNamespace::updateOrCreate(
+            ['slug' => 'meta'],
+            [
+                'name' => 'Meta',
+                'description' => 'ThinkStream の設計判断、実装状況、運用メモを置く namespace。',
+                'post_order' => ['content-url-unification-handoff'],
+            ],
+        );
+
+        Post::updateOrCreate(
+            ['namespace_id' => $metaNamespace->id, 'slug' => 'content-url-unification-handoff'],
+            [
+                'user_id' => $user->id,
+                'title' => 'Content URL 統一ハンドオフ',
+                'content' => trim(<<<'MD'
+# Content URL 統一ハンドオフ
+
+## 概要
+
+この文書は、2026-04-21 時点の ThinkStream における content URL 統一作業の現状を、日本語で引き継げる形に整理したものです。
+
+いまのプロダクト方針は次のとおりです。
+
+- `/{full_path}` を canonical なコンテンツ URL として扱う
+- `/admin/...` は管理ダッシュボードと運用導線として残す
+- 認証済みユーザーは canonical 公開ページから編集導線へ入れるようにする
+- 編集後は canonical 公開ページへ戻す
+
+Phase 1 は、現在のコードベース上では実用レベルまで進んでいます。canonical preview / edit 導線、create / save 後の canonical redirect、namespace の再帰削除、管理 UI の整理まで含めて、主導線はかなり揃っています。
+
+## 現在の評価
+
+全体としては良い状態です。route model 自体はまだ変えていないものの、canonical content URL を主たる read / edit surface とみなせるだけの挙動は、すでに実装できています。
+
+現在しっかりしている点:
+
+- canonical post page から直接 edit に入れる
+- heading 単位の編集ジャンプが canonical post page から使える
+- canonical namespace page から inline 編集と `New Post` が使える
+- admin create / save flow が stale な entry URL ではなく、更新後の model state から canonical redirect を再計算する
+- namespace 削除は子孫 namespace / post まで再帰削除される
+- `admin/posts` の namespace 削除は namespace 名の手入力が必須になっている
+- post slug / namespace slug を変えたときの canonical redirect は Feature test で押さえられている
+
+現状まだ follow-up 扱いの点:
+
+- admin namespace post table は controller が `canonical_url` を返しているのに、UI はまだ `post.full_path` から公開リンクを組み立てている
+- admin detail screen と canonical detail screen の責務がまだ少し重なっている
+
+## 問題設定
+
+いまの主問題は、「同じコンテンツに URL が 2 つあること」そのものではありません。現在の ThinkStream では、コンテキストが違うなら URL が分かれていること自体は自然です。
+
+重要なのは、その 2 つのコンテキストの責務境界が曖昧にならないことです。
+
+現在の canonical 公開 URL:
+
+- `/guides`
+- `/guides/extended-syntax`
+
+現在の admin 管理 URL:
+
+- `/admin/posts`
+- `/admin/posts/{namespace}`
+- `/admin/posts/{namespace}/{post:slug}`
+- `/admin/posts/{namespace}/{post:slug}/edit`
+
+目標ルールは次です。
+
+- 公開 canonical URL は主要な閲覧・共有面として維持する
+- 公開 canonical URL には、その item に近い軽量な edit entry だけを載せる
+- `/admin/...` は管理・運用面として残す
+
+つまり実務上の論点は、二重 URL の存在そのものではなく、canonical page と admin page の責務のずれを防ぐことです。
+
+## 現在のアーキテクチャ
+
+### 公開側ルーティング
+
+公開コンテンツは wildcard path routing で解決しています。
+
+- `/{path}` を `posts.full_path` / `namespaces.full_path` に対して引く
+- post に一致すれば `resources/js/pages/posts/show.tsx` を描画する
+- namespace に一致すれば `resources/js/pages/posts/namespace.tsx` を描画する
+
+関連ファイル:
+
+- `routes/web.php`
+- `app/Http/Controllers/PostController.php`
+
+### 管理側ルーティング
+
+管理画面は `/admin/posts` 以下の明示的な nested route で解決しています。
+
+- `/admin/posts` は dashboard root
+- `/admin/posts/{namespace}` は namespace 管理
+- `/admin/posts/{namespace}/{post:slug}` は admin post detail
+- `/admin/posts/{namespace}/{post:slug}/edit` は post edit
+
+関連ファイル:
+
+- `routes/admin.php`
+- `app/Http/Controllers/Admin/PostController.php`
+
+### Route key のズレ
+
+URL が二系統に見える根本理由は、namespace の admin route binding が `id` ベースで、公開側は `full_path` ベースだからです。
+
+- 公開 URL は `full_path`
+- admin URL は `namespace id + post slug`
+
+このズレはまだ残っています。ただし現時点では、これ自体が最優先の問題ではありません。将来的に path-based edit URL を考える理由にはなりますが、当面のボトルネックは責務整理の方です。
+
+## 現在入っている実装
+
+### 1. canonical login return flow
+
+canonical 公開ページから `Login` を押すと、`/login?intended=...` に入り、認証後に元の canonical page へ戻ります。
+
+関連:
+
+- `app/Providers/FortifyServiceProvider.php`
+- `resources/js/pages/posts/index.tsx`
+- `resources/js/pages/posts/namespace.tsx`
+- `resources/js/pages/posts/show.tsx`
+- `tests/Feature/Auth/AuthenticationTest.php`
+
+### 2. canonical post page からの編集導線
+
+認証済みユーザーは canonical post page から直接編集に入れます。
+
+公開側 affordance:
+
+- `Edit Page`
+- heading 単位の編集導線
+- 補助導線としての `Manage`
+
+### 3. canonical namespace page からの編集導線
+
+認証済みユーザーは canonical namespace page から namespace metadata をその場で編集できます。
+
+公開側 affordance:
+
+- inline `Edit Section` / `Done`
+- `New Post`
+- 補助導線としての `Manage`
+
+### 4. admin create / edit redirect の canonical 化
+
+admin post / namespace edit page は `return_to` を受け取り、save 後の redirect は更新後の model state を使って canonical URL を再計算します。
+
+つまり:
+
+- post create 後は新しい `full_path` に戻せる
+- post update 後は更新後の `full_path` に戻せる
+- namespace update 後は更新後の `full_path` に戻せる
+- `return_heading` は hash fragment としてだけ保持する
+
+### 5. public admin affordance の言い換え
+
+公開ページでは `Admin` を前面に出すのではなく、現在は次を優先しています。
+
+- `Login`
+- `Manage`
+- そのコンテンツに直接関係する edit control
+
+### 6. admin の destructive action 強化
+
+`admin/posts` の namespace 削除は、namespace 名を手入力しないと `Delete` が押せないようになっています。top-level row と child row の両方に適用されています。
+
+関連:
+
+- `resources/js/pages/admin/posts/index.tsx`
+- `resources/js/lib/delete-confirmation.ts`
+- `tests-node/markdown/delete-confirmation.test.ts`
+
+### 7. slug prefix UI の整合
+
+admin post create / edit 画面では、slug input の前に namespace path prefix が一貫して表示されます。root namespace でも nested namespace でも同じ考え方です。
+
+## 検証状況
+
+この系統の作業では、次の検証がすでに入っています。
+
+Sail で回したもの:
+
+```bash
+vendor/bin/sail artisan test --compact tests/Feature/Auth/AuthenticationTest.php tests/Feature/PrivateModeTest.php
+vendor/bin/sail artisan test --compact tests/Feature/Admin/PostControllerTest.php tests/Feature/Admin/NamespaceControllerTest.php
+vendor/bin/sail artisan test --compact tests/Feature/PostControllerTest.php
+vendor/bin/sail npm run types:check
+vendor/bin/sail bin pint --dirty --format agent
+vendor/bin/sail npm run build
+```
+
+Playwright で確認済みの動線:
+
+- `/guides -> Login -> authenticate -> /guides`
+- `/guides/index -> Login -> authenticate -> /guides/index`
+- canonical post page に `Edit Page` が出る
+- canonical namespace page に `Edit Section` が出る
+
+ローカル追加確認:
+
+```bash
+npm run types:check
+./node_modules/.bin/eslint resources/js/pages/admin/posts/index.tsx
+./node_modules/.bin/tsc --project tsconfig.markdown-tests.json
+node --test .tmp/markdown-tests/tests-node/markdown/delete-confirmation.test.js
+```
+
+## Product interpretation
+
+いまの解釈は明確です。
+
+- canonical URL は view / edit の面
+- `/admin` は management / operations の面
+
+つまり canonical page に載せるべきものは次に限るべきです。
+
+- コンテンツ閲覧
+- 現在の item の編集
+- その item に近い軽量な in-context action
+
+例:
+
+- post canonical: `Edit Page`, `Edit Section`
+- namespace canonical: inline `Edit Section`, `New Post`
+
+逆に `/admin` が持つべき責務は次です。
+
+- namespace tree 管理
+- cross-namespace dashboard
+- sort / reorder
+- list view
+- revision tooling
+- 広めの運用 workflow
+
+canonical namespace page を full admin control plane にしてしまうのは避けるべきです。
+
+## Phase framing
+
+### Phase 1
+
+目標:
+
+- route model を変えずに editor journey を統一する
+
+現状:
+
+- 概ね完了。残りは cleanup と product-level pruning
+
+完了済み:
+
+1. canonical login return flow
+2. canonical post edit entry
+3. canonical namespace inline edit entry
+4. canonical namespace `New Post` entry
+5. `Manage` を secondary admin utility label に統一
+6. create / edit 後の canonical save destination 再計算
+7. recursive namespace deletion と typed destructive confirmation
+
+まだ整理が甘い点:
+
+1. canonical namespace page 上の管理 affordance は product 的にもう少し絞る余地がある
+2. admin detail page と canonical detail page の責務分担はまだ改善余地がある
+
+### Phase 2
+
+目標:
+
+- public detail page と admin detail page の重複責務を減らす
+
+まだ未着手です。
+
+有効な問い:
+
+1. canonical page が primary authoring surface になった後も admin post show は必要か
+2. public view と admin view で共有すべき display block は何か
+3. admin detail の責務はさらに削れるか
+
+### Phase 3
+
+目標:
+
+- path-based edit URL へ進める
+
+例:
+
+- `/guides/edit`
+- `/guides/extended-syntax/edit`
+
+これはまだ未着手です。いまは「将来的な単純化の候補」であって、急いで進めるべき必須課題ではありません。
+
+## 次の作業候補
+
+redirect correctness や URL の一本化そのものではなく、残っている UI contract gap と product cleanup に集中するのが次の一手です。
+
+具体候補:
+
+1. admin namespace post table が `canonical_url` を尊重するように揃える
+2. draft / scheduled state のときに公開リンクをどう扱うかを、`full_path` 直組みではなく controller contract ベースで決める
+3. canonical detail page と admin detail page の重複を減らす
+4. canonical page が主導線になったあとも admin post show を残すかを判断する
+
+## 今後のテスト方針
+
+追加で気にすべき coverage:
+
+1. canonical page の auth-state に応じた edit / manage control の出し分け
+2. admin namespace table の `canonical_url` 契約を変えるときの明示テスト
+3. typed namespace-delete confirmation が複雑化したら browser-level coverage を追加
+4. 今後 namespace level control を増やす場合は guest / auth coverage を必ず足す
+
+## リスクと制約
+
+### リスク 1: canonical page が pseudo-admin dashboard になる
+
+canonical namespace page に管理操作を盛りすぎると、public / admin の境界がまた曖昧になります。
+
+### リスク 2: 将来の path collision
+
+Phase 3 で `/{path}/edit` や `/{path}/create` を導入する場合、reserved segment 設計は慎重に扱う必要があります。
+
+関連:
+
+- `app/Support/ReservedContentPath.php`
+- `routes/web.php`
+
+## 補足
+
+- このセッションでは Laravel Boost MCP server が見えていなかったため、分析と実装は repository code の直接確認で進めています
+- admin namespace controller はまだ `canonical_url` を返していますが、namespace post table UI はその契約をまだ使い切っていません
+- この文書は単一 commit のスナップショットというより、現在の repository state を説明する meta article として読むのがよいです
+MD),
+                'published_at' => now(),
+            ],
+        );
     }
 }

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { initializeTheme } from '@/hooks/use-appearance';
 import AppLayout from '@/layouts/app-layout';
 import AuthLayout from '@/layouts/auth-layout';
+import AuthenticatedPublicLayout from '@/layouts/authenticated-public-layout';
 import SettingsLayout from '@/layouts/settings/layout';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
@@ -13,8 +14,9 @@ createInertiaApp({
     layout: (name) => {
         switch (true) {
             case name === 'welcome':
-            case name.startsWith('posts/'):
                 return null;
+            case name.startsWith('posts/'):
+                return AuthenticatedPublicLayout;
             case name.startsWith('auth/'):
                 return AuthLayout;
             case name.startsWith('settings/'):

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -1,5 +1,6 @@
 import { Link, usePage } from '@inertiajs/react';
-import { LayoutGrid, Menu, NotebookPen, Search } from 'lucide-react';
+import { Globe, LayoutGrid, Menu, NotebookPen, Search } from 'lucide-react';
+import { index as adminPostsIndex } from '@/actions/App/Http/Controllers/Admin/PostController';
 import AppLogo from '@/components/app-logo';
 import AppLogoIcon from '@/components/app-logo-icon';
 import { Breadcrumbs } from '@/components/breadcrumbs';
@@ -32,8 +33,7 @@ import { UserMenuContent } from '@/components/user-menu-content';
 import { useCurrentUrl } from '@/hooks/use-current-url';
 import { useInitials } from '@/hooks/use-initials';
 import { cn, toUrl } from '@/lib/utils';
-import { index as adminPostsIndex } from '@/actions/App/Http/Controllers/Admin/PostController';
-import { dashboard } from '@/routes';
+import { dashboard, home } from '@/routes';
 import type { BreadcrumbItem, NavItem } from '@/types';
 
 type Props = {
@@ -51,6 +51,11 @@ const mainNavItems: NavItem[] = [
         href: adminPostsIndex.url(),
         icon: NotebookPen,
     },
+    {
+        title: 'Site',
+        href: home(),
+        icon: Globe,
+    },
 ];
 
 const rightNavItems: NavItem[] = [];
@@ -62,7 +67,15 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
     const page = usePage();
     const { auth } = page.props;
     const getInitials = useInitials();
-    const { isCurrentUrl, whenCurrentUrl } = useCurrentUrl();
+    const { currentUrl, isCurrentUrl, whenCurrentUrl } = useCurrentUrl();
+    const postsIndexUrl = adminPostsIndex.url();
+    const isPostsActive =
+        currentUrl === postsIndexUrl ||
+        currentUrl.startsWith(`${postsIndexUrl}/`);
+    const resolvedMainNavItems = mainNavItems.map((item) => ({
+        ...item,
+        isActive: item.href === postsIndexUrl ? isPostsActive : item.isActive,
+    }));
 
     return (
         <>
@@ -93,18 +106,26 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
                                 <div className="flex h-full flex-1 flex-col space-y-4 p-4">
                                     <div className="flex h-full flex-col justify-between text-sm">
                                         <div className="flex flex-col space-y-4">
-                                            {mainNavItems.map((item) => (
-                                                <Link
-                                                    key={item.title}
-                                                    href={item.href}
-                                                    className="flex items-center space-x-2 font-medium"
-                                                >
-                                                    {item.icon && (
-                                                        <item.icon className="h-5 w-5" />
-                                                    )}
-                                                    <span>{item.title}</span>
-                                                </Link>
-                                            ))}
+                                            {resolvedMainNavItems.map(
+                                                (item) => (
+                                                    <Link
+                                                        key={item.title}
+                                                        href={item.href}
+                                                        className={cn(
+                                                            'flex items-center space-x-2 font-medium',
+                                                            item.isActive &&
+                                                                activeItemStyles,
+                                                        )}
+                                                    >
+                                                        {item.icon && (
+                                                            <item.icon className="h-5 w-5" />
+                                                        )}
+                                                        <span>
+                                                            {item.title}
+                                                        </span>
+                                                    </Link>
+                                                ),
+                                            )}
                                         </div>
 
                                         <div className="flex flex-col space-y-4">
@@ -141,7 +162,7 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
                     <div className="ml-6 hidden h-full items-center space-x-6 lg:flex">
                         <NavigationMenu className="flex h-full items-stretch">
                             <NavigationMenuList className="flex h-full items-stretch space-x-2">
-                                {mainNavItems.map((item, index) => (
+                                {resolvedMainNavItems.map((item, index) => (
                                     <NavigationMenuItem
                                         key={index}
                                         className="relative flex h-full items-center"
@@ -150,10 +171,12 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
                                             href={item.href}
                                             className={cn(
                                                 navigationMenuTriggerStyle(),
-                                                whenCurrentUrl(
-                                                    item.href,
-                                                    activeItemStyles,
-                                                ),
+                                                item.isActive
+                                                    ? activeItemStyles
+                                                    : whenCurrentUrl(
+                                                          item.href,
+                                                          activeItemStyles,
+                                                      ),
                                                 'h-9 cursor-pointer px-3',
                                             )}
                                         >
@@ -162,7 +185,8 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
                                             )}
                                             {item.title}
                                         </Link>
-                                        {isCurrentUrl(item.href) && (
+                                        {(item.isActive ??
+                                            isCurrentUrl(item.href)) && (
                                             <div className="absolute bottom-0 left-0 h-0.5 w-full translate-y-px bg-black dark:bg-white"></div>
                                         )}
                                     </NavigationMenuItem>

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@inertiajs/react';
-import { LayoutGrid, NotebookPen } from 'lucide-react';
+import { Globe, LayoutGrid, NotebookPen } from 'lucide-react';
+import { index as adminPostsIndex } from '@/actions/App/Http/Controllers/Admin/PostController';
 import AppLogo from '@/components/app-logo';
 import { NavFooter } from '@/components/nav-footer';
 import { NavMain } from '@/components/nav-main';
@@ -13,8 +14,8 @@ import {
     SidebarMenuButton,
     SidebarMenuItem,
 } from '@/components/ui/sidebar';
-import { index as adminPostsIndex } from '@/actions/App/Http/Controllers/Admin/PostController';
-import { dashboard } from '@/routes';
+import { useCurrentUrl } from '@/hooks/use-current-url';
+import { dashboard, home } from '@/routes';
 import type { NavItem } from '@/types';
 
 const mainNavItems: NavItem[] = [
@@ -28,11 +29,26 @@ const mainNavItems: NavItem[] = [
         href: adminPostsIndex.url(),
         icon: NotebookPen,
     },
+    {
+        title: 'Site',
+        href: home(),
+        icon: Globe,
+    },
 ];
 
 const footerNavItems: NavItem[] = [];
 
 export function AppSidebar() {
+    const { currentUrl } = useCurrentUrl();
+    const postsIndexUrl = adminPostsIndex.url();
+    const isPostsActive =
+        currentUrl === postsIndexUrl ||
+        currentUrl.startsWith(`${postsIndexUrl}/`);
+    const resolvedMainNavItems = mainNavItems.map((item) => ({
+        ...item,
+        isActive: item.href === postsIndexUrl ? isPostsActive : item.isActive,
+    }));
+
     return (
         <Sidebar collapsible="icon" variant="inset">
             <SidebarHeader>
@@ -48,7 +64,7 @@ export function AppSidebar() {
             </SidebarHeader>
 
             <SidebarContent>
-                <NavMain items={mainNavItems} />
+                <NavMain items={resolvedMainNavItems} />
             </SidebarContent>
 
             <SidebarFooter>

--- a/resources/js/components/delete-user.tsx
+++ b/resources/js/components/delete-user.tsx
@@ -55,7 +55,7 @@ export default function DeleteUser() {
                         </DialogDescription>
 
                         <Form
-                            {...ProfileController.destroy.form()}
+                            action={ProfileController.destroy()}
                             options={{
                                 preserveScroll: true,
                             }}

--- a/resources/js/components/namespace-header.tsx
+++ b/resources/js/components/namespace-header.tsx
@@ -1,0 +1,105 @@
+import { Link } from '@inertiajs/react';
+import {
+    ArrowRightLeft,
+    CheckCircle2,
+    FilePen,
+    FolderOpen,
+    FolderPlus,
+    Pencil,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import ViewContextBadge from '@/components/view-context-badge';
+import { useCurrentUrl } from '@/hooks/use-current-url';
+import {
+    create as namespaceCreate,
+    edit as editNamespace,
+} from '@/routes/admin/namespaces';
+import { namespace as namespaceRoute } from '@/routes/admin/posts';
+
+type Namespace = {
+    id: number;
+    slug: string;
+    full_path: string;
+    name: string;
+    is_published: boolean;
+};
+
+export default function NamespaceHeader({
+    namespace,
+}: {
+    namespace: Namespace;
+}) {
+    const { currentUrl } = useCurrentUrl();
+    const childNamespaceCreateUrl = `${namespaceCreate.url()}?${new URLSearchParams({ parent: String(namespace.id) }).toString()}`;
+    const siteUrl = `/${namespace.full_path}`;
+
+    return (
+        <div className="rounded-xl border border-amber-200/80 bg-amber-50/70 p-5 dark:border-amber-900/80 dark:bg-amber-950/20">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                    <p className="text-xs font-semibold tracking-wider text-amber-700 uppercase dark:text-amber-300">
+                        Manage Namespace
+                    </p>
+                    <div className="mt-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                        <h1 className="flex items-center gap-2 text-2xl font-semibold">
+                            <FolderOpen className="size-5 shrink-0 text-amber-700 dark:text-amber-300" />
+                            <Link
+                                href={namespaceRoute.url(namespace.id)}
+                                className="hover:underline"
+                            >
+                                {namespace.name}
+                            </Link>
+                        </h1>
+                        <div className="flex items-center gap-2">
+                            <p className="text-sm text-amber-800/70 dark:text-amber-200/70">
+                                /{namespace.full_path}
+                            </p>
+                        </div>
+                    </div>
+                    <div className="mt-2">
+                        {namespace.is_published ? (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                                <CheckCircle2 className="size-3" />
+                                Published
+                            </span>
+                        ) : (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                                <FilePen className="size-3" />
+                                Draft
+                            </span>
+                        )}
+                    </div>
+                </div>
+                <div className="flex flex-col items-start gap-2 sm:items-end">
+                    <div className="flex flex-wrap items-center gap-2">
+                        <Button variant="outline" asChild>
+                            <Link href={siteUrl}>
+                                <ArrowRightLeft className="size-4" />
+                                View Site
+                            </Link>
+                        </Button>
+                        <ViewContextBadge label="Admin View" variant="admin" />
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                        <Button variant="outline" asChild>
+                            <Link
+                                href={editNamespace.url(namespace.id, {
+                                    query: { return_to: currentUrl },
+                                })}
+                            >
+                                <Pencil className="size-4" />
+                                Edit
+                            </Link>
+                        </Button>
+                        <Button variant="outline" asChild>
+                            <Link href={childNamespaceCreateUrl}>
+                                <FolderPlus className="size-4" />
+                                New Child Namespace
+                            </Link>
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/nav-main.tsx
+++ b/resources/js/components/nav-main.tsx
@@ -20,7 +20,7 @@ export function NavMain({ items = [] }: { items: NavItem[] }) {
                     <SidebarMenuItem key={item.title}>
                         <SidebarMenuButton
                             asChild
-                            isActive={isCurrentUrl(item.href)}
+                            isActive={item.isActive ?? isCurrentUrl(item.href)}
                             tooltip={{ children: item.title }}
                         >
                             <Link href={item.href} prefetch>

--- a/resources/js/components/post-header.tsx
+++ b/resources/js/components/post-header.tsx
@@ -1,8 +1,9 @@
 import { Form, Link } from '@inertiajs/react';
 import {
+    ArrowRightLeft,
     CheckCircle2,
     Clock,
-    ExternalLink,
+    FileText,
     FilePen,
     History,
     ArrowLeft,
@@ -19,6 +20,7 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
+import ViewContextBadge from '@/components/view-context-badge';
 import { destroy, edit, revisions, show } from '@/routes/admin/posts';
 
 type Namespace = {
@@ -65,22 +67,18 @@ export default function PostHeader({
     post: Post;
     mode?: 'show' | 'edit';
 }) {
-    const canonicalUrl =
-        !post.is_draft &&
-        post.published_at &&
-        new Date(post.published_at) <= new Date()
-            ? `/${post.full_path}`
-            : null;
+    const siteUrl = `/${post.full_path}`;
 
     return (
-        <div className="rounded-xl border bg-card p-5">
+        <div className="rounded-xl border border-sky-200/80 bg-sky-50/70 p-5 dark:border-sky-900/80 dark:bg-sky-950/20">
             <div className="flex flex-wrap items-start justify-between gap-4">
                 <div>
-                    <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                    <p className="text-xs font-semibold tracking-wider text-sky-700 uppercase dark:text-sky-300">
                         Manage Post
                     </p>
                     <div className="mt-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
-                        <h1 className="text-2xl font-semibold">
+                        <h1 className="flex items-center gap-2 text-2xl font-semibold">
+                            <FileText className="size-5 shrink-0 text-sky-700 dark:text-sky-300" />
                             <Link
                                 href={show.url({
                                     namespace: namespace.id,
@@ -92,25 +90,15 @@ export default function PostHeader({
                             </Link>
                         </h1>
                         <div className="flex items-center gap-2">
-                            <p className="text-sm text-muted-foreground">
+                            <p className="text-sm text-sky-800/70 dark:text-sky-200/70">
                                 /{post.full_path}
                             </p>
-                            {canonicalUrl && (
-                                <a
-                                    href={canonicalUrl}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    className="text-muted-foreground transition-colors hover:text-foreground"
-                                >
-                                    <ExternalLink className="size-3.5" />
-                                </a>
-                            )}
                             <Link
                                 href={revisions.url({
                                     namespace: namespace.id,
                                     post: post.slug,
                                 })}
-                                className="text-muted-foreground transition-colors hover:text-foreground"
+                                className="text-sky-700/70 transition-colors hover:text-sky-900 dark:text-sky-300/70 dark:hover:text-sky-100"
                             >
                                 <History className="size-3.5" />
                             </Link>
@@ -190,32 +178,43 @@ export default function PostHeader({
                         )}
                     </div>
                 </div>
-                <div className="flex flex-wrap items-center gap-2">
-                    {mode === 'show' ? (
+                <div className="flex flex-col items-start gap-2 sm:items-end">
+                    <div className="flex flex-wrap items-center gap-2">
                         <Button variant="outline" asChild>
-                            <Link
-                                href={edit.url({
-                                    namespace: namespace.id,
-                                    post: post.slug,
-                                })}
-                            >
-                                <Pencil className="size-4" />
-                                Edit
+                            <Link href={siteUrl}>
+                                <ArrowRightLeft className="size-4" />
+                                View Site
                             </Link>
                         </Button>
-                    ) : (
-                        <Button variant="outline" asChild>
-                            <Link
-                                href={show.url({
-                                    namespace: namespace.id,
-                                    post: post.slug,
-                                })}
-                            >
-                                <ArrowLeft className="size-4" />
-                                Back
-                            </Link>
-                        </Button>
-                    )}
+                        <ViewContextBadge label="Admin View" variant="admin" />
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                        {mode === 'show' ? (
+                            <Button variant="outline" asChild>
+                                <Link
+                                    href={edit.url({
+                                        namespace: namespace.id,
+                                        post: post.slug,
+                                    })}
+                                >
+                                    <Pencil className="size-4" />
+                                    Edit
+                                </Link>
+                            </Button>
+                        ) : (
+                            <Button variant="outline" asChild>
+                                <Link
+                                    href={show.url({
+                                        namespace: namespace.id,
+                                        post: post.slug,
+                                    })}
+                                >
+                                    <ArrowLeft className="size-4" />
+                                    View Post
+                                </Link>
+                            </Button>
+                        )}
+                    </div>
                 </div>
             </div>
         </div>

--- a/resources/js/components/post-header.tsx
+++ b/resources/js/components/post-header.tsx
@@ -1,0 +1,223 @@
+import { Form, Link } from '@inertiajs/react';
+import {
+    CheckCircle2,
+    Clock,
+    ExternalLink,
+    FilePen,
+    History,
+    ArrowLeft,
+    Pencil,
+    Trash2,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { destroy, edit, revisions, show } from '@/routes/admin/posts';
+
+type Namespace = {
+    id: number;
+    name: string;
+    slug: string;
+    full_path: string;
+};
+
+type Post = {
+    id: number;
+    title: string;
+    slug: string;
+    full_path: string;
+    is_draft: boolean;
+    published_at: string | null;
+};
+
+function scheduledHint(publishedAt: string): string {
+    const diff = new Date(publishedAt).getTime() - Date.now();
+    const minutes = Math.round(diff / 60000);
+
+    if (minutes < 60) {
+        return `in ${minutes} minute${minutes !== 1 ? 's' : ''}`;
+    }
+
+    const hours = Math.round(diff / 3600000);
+
+    if (hours < 24) {
+        return `in ${hours} hour${hours !== 1 ? 's' : ''}`;
+    }
+
+    const days = Math.round(diff / 86400000);
+
+    return `in ${days} day${days !== 1 ? 's' : ''}`;
+}
+
+export default function PostHeader({
+    namespace,
+    post,
+    mode = 'show',
+}: {
+    namespace: Namespace;
+    post: Post;
+    mode?: 'show' | 'edit';
+}) {
+    const canonicalUrl =
+        !post.is_draft &&
+        post.published_at &&
+        new Date(post.published_at) <= new Date()
+            ? `/${post.full_path}`
+            : null;
+
+    return (
+        <div className="rounded-xl border bg-card p-5">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                    <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                        Manage Post
+                    </p>
+                    <div className="mt-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                        <h1 className="text-2xl font-semibold">
+                            <Link
+                                href={show.url({
+                                    namespace: namespace.id,
+                                    post: post.slug,
+                                })}
+                                className="hover:underline"
+                            >
+                                {post.title}
+                            </Link>
+                        </h1>
+                        <div className="flex items-center gap-2">
+                            <p className="text-sm text-muted-foreground">
+                                /{post.full_path}
+                            </p>
+                            {canonicalUrl && (
+                                <a
+                                    href={canonicalUrl}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="text-muted-foreground transition-colors hover:text-foreground"
+                                >
+                                    <ExternalLink className="size-3.5" />
+                                </a>
+                            )}
+                            <Link
+                                href={revisions.url({
+                                    namespace: namespace.id,
+                                    post: post.slug,
+                                })}
+                                className="text-muted-foreground transition-colors hover:text-foreground"
+                            >
+                                <History className="size-3.5" />
+                            </Link>
+                            <Dialog>
+                                <DialogTrigger className="text-destructive/60 transition-colors hover:text-destructive">
+                                    <Trash2 className="size-3.5" />
+                                </DialogTrigger>
+                                <DialogContent>
+                                    <DialogTitle>
+                                        Delete &ldquo;{post.title}&rdquo;?
+                                    </DialogTitle>
+                                    <DialogDescription>
+                                        This action cannot be undone. The post
+                                        and all its revisions will be
+                                        permanently deleted.
+                                    </DialogDescription>
+                                    <Form
+                                        {...destroy.form({
+                                            namespace: namespace.id,
+                                            post: post.slug,
+                                        })}
+                                    >
+                                        {({ processing }) => (
+                                            <DialogFooter className="gap-2">
+                                                <DialogClose asChild>
+                                                    <Button variant="secondary">
+                                                        Cancel
+                                                    </Button>
+                                                </DialogClose>
+                                                <Button
+                                                    variant="destructive"
+                                                    disabled={processing}
+                                                    asChild
+                                                >
+                                                    <button type="submit">
+                                                        Delete
+                                                    </button>
+                                                </Button>
+                                            </DialogFooter>
+                                        )}
+                                    </Form>
+                                </DialogContent>
+                            </Dialog>
+                        </div>
+                    </div>
+                    <div className="mt-2">
+                        {post.is_draft ? (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                                <FilePen className="size-3" />
+                                Draft
+                            </span>
+                        ) : !post.published_at ||
+                          new Date(post.published_at) > new Date() ? (
+                            <div className="flex flex-wrap items-center gap-2">
+                                <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                                    <Clock className="size-3" />
+                                    Scheduled
+                                </span>
+                                {post.published_at && (
+                                    <span className="text-xs text-muted-foreground">
+                                        {new Date(
+                                            post.published_at,
+                                        ).toLocaleString(undefined, {
+                                            dateStyle: 'medium',
+                                            timeStyle: 'short',
+                                        })}
+                                        {' · '}
+                                        {scheduledHint(post.published_at)}
+                                    </span>
+                                )}
+                            </div>
+                        ) : (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                                <CheckCircle2 className="size-3" />
+                                Published
+                            </span>
+                        )}
+                    </div>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                    {mode === 'show' ? (
+                        <Button variant="outline" asChild>
+                            <Link
+                                href={edit.url({
+                                    namespace: namespace.id,
+                                    post: post.slug,
+                                })}
+                            >
+                                <Pencil className="size-4" />
+                                Edit
+                            </Link>
+                        </Button>
+                    ) : (
+                        <Button variant="outline" asChild>
+                            <Link
+                                href={show.url({
+                                    namespace: namespace.id,
+                                    post: post.slug,
+                                })}
+                            >
+                                <ArrowLeft className="size-4" />
+                                Back
+                            </Link>
+                        </Button>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/view-context-badge.tsx
+++ b/resources/js/components/view-context-badge.tsx
@@ -1,0 +1,28 @@
+import { cn } from '@/lib/utils';
+
+const variants = {
+    admin: 'border-slate-300/80 bg-slate-100 text-slate-700 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200',
+    site: 'border-emerald-300/80 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300',
+} as const;
+
+export default function ViewContextBadge({
+    label,
+    variant,
+    className,
+}: {
+    label: string;
+    variant: keyof typeof variants;
+    className?: string;
+}) {
+    return (
+        <span
+            className={cn(
+                'inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold tracking-wide uppercase',
+                variants[variant],
+                className,
+            )}
+        >
+            {label}
+        </span>
+    );
+}

--- a/resources/js/layouts/authenticated-public-layout.tsx
+++ b/resources/js/layouts/authenticated-public-layout.tsx
@@ -1,0 +1,18 @@
+import { usePage } from '@inertiajs/react';
+import AppLayout from '@/layouts/app-layout';
+
+export default function AuthenticatedPublicLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    const { auth } = usePage<{
+        auth: { user: { id: number; name: string } | null };
+    }>().props;
+
+    if (!auth.user) {
+        return <>{children}</>;
+    }
+
+    return <AppLayout>{children}</AppLayout>;
+}

--- a/resources/js/lib/delete-confirmation.ts
+++ b/resources/js/lib/delete-confirmation.ts
@@ -1,0 +1,6 @@
+export function matchesDeleteConfirmation(
+    value: string,
+    expected: string,
+): boolean {
+    return value.trim() === expected.trim();
+}

--- a/resources/js/lib/time.ts
+++ b/resources/js/lib/time.ts
@@ -1,0 +1,18 @@
+const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+
+export function timeAgo(dateStr: string): string {
+    const diff = new Date(dateStr).getTime() - Date.now();
+    const seconds = Math.round(diff / 1000);
+    const minutes = Math.round(diff / 60000);
+    const hours = Math.round(diff / 3600000);
+    const days = Math.round(diff / 86400000);
+    const months = Math.round(diff / 2592000000);
+    const years = Math.round(diff / 31536000000);
+
+    if (Math.abs(seconds) < 60) return rtf.format(seconds, 'second');
+    if (Math.abs(minutes) < 60) return rtf.format(minutes, 'minute');
+    if (Math.abs(hours) < 24) return rtf.format(hours, 'hour');
+    if (Math.abs(days) < 30) return rtf.format(days, 'day');
+    if (Math.abs(months) < 12) return rtf.format(months, 'month');
+    return rtf.format(years, 'year');
+}

--- a/resources/js/pages/admin/namespaces/edit.tsx
+++ b/resources/js/pages/admin/namespaces/edit.tsx
@@ -1,4 +1,5 @@
 import { Head, setLayoutProps, useForm } from '@inertiajs/react';
+import { useMemo } from 'react';
 import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import CoverImageDropzone from '@/components/cover-image-dropzone';
 import InputError from '@/components/input-error';
@@ -19,6 +20,14 @@ type Namespace = {
 };
 
 export default function Edit({ namespace }: { namespace: Namespace }) {
+    const returnTo = useMemo(() => {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
+        return new URLSearchParams(window.location.search).get('return_to');
+    }, []);
+
     setLayoutProps({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
@@ -34,6 +43,7 @@ export default function Edit({ namespace }: { namespace: Namespace }) {
         description: string;
         is_published: boolean;
         cover_image: File | null;
+        return_to: string;
     }>({
         _method: 'put',
         name: namespace.name,
@@ -41,6 +51,7 @@ export default function Edit({ namespace }: { namespace: Namespace }) {
         description: namespace.description ?? '',
         is_published: namespace.is_published,
         cover_image: null,
+        return_to: returnTo ?? '',
     });
 
     function submit(e: React.FormEvent) {
@@ -135,7 +146,7 @@ export default function Edit({ namespace }: { namespace: Namespace }) {
                             Save Changes
                         </Button>
                         <Button type="button" variant="outline" asChild>
-                            <a href={postsIndex.url()}>Cancel</a>
+                            <a href={returnTo ?? postsIndex.url()}>Cancel</a>
                         </Button>
                     </div>
                 </form>

--- a/resources/js/pages/admin/namespaces/index.tsx
+++ b/resources/js/pages/admin/namespaces/index.tsx
@@ -1,5 +1,6 @@
 import { Head, Link } from '@inertiajs/react';
 import { Form } from '@inertiajs/react';
+import { FolderPlus } from 'lucide-react';
 import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import { Button } from '@/components/ui/button';
 import { dashboard } from '@/routes';
@@ -27,7 +28,10 @@ export default function Index({ namespaces }: { namespaces: Namespace[] }) {
                         </p>
                     </div>
                     <Button asChild>
-                        <Link href={create.url()}>New Namespace</Link>
+                        <Link href={create.url()}>
+                            <FolderPlus className="size-4" />
+                            New Namespace
+                        </Link>
                     </Button>
                 </div>
 
@@ -38,6 +42,7 @@ export default function Index({ namespaces }: { namespaces: Namespace[] }) {
                         </p>
                         <Button asChild className="mt-4">
                             <Link href={create.url()}>
+                                <FolderPlus className="size-4" />
                                 Create your first namespace
                             </Link>
                         </Button>

--- a/resources/js/pages/admin/posts/create.tsx
+++ b/resources/js/pages/admin/posts/create.tsx
@@ -40,6 +40,11 @@ export default function Create({
     namespace: Namespace;
     slugPrefix?: string | null;
 }) {
+    const returnTo =
+        typeof window !== 'undefined'
+            ? new URLSearchParams(window.location.search).get('return_to')
+            : null;
+
     setLayoutProps({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
@@ -254,8 +259,20 @@ export default function Create({
                                 <Button type="submit" disabled={processing}>
                                     {isDraft ? 'Save Draft' : 'Create Post'}
                                 </Button>
+                                {returnTo && (
+                                    <input
+                                        type="hidden"
+                                        name="return_to"
+                                        value={returnTo}
+                                    />
+                                )}
                                 <Button type="button" variant="outline" asChild>
-                                    <a href={namespaceRoute.url(namespace.id)}>
+                                    <a
+                                        href={
+                                            returnTo ??
+                                            namespaceRoute.url(namespace.id)
+                                        }
+                                    >
                                         Cancel
                                     </a>
                                 </Button>

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -1,18 +1,19 @@
 import { Form, Head, Link, setLayoutProps } from '@inertiajs/react';
-import { ExternalLink } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { Check, Save } from 'lucide-react';
+import { useMemo, useRef, useState } from 'react';
 import InputError from '@/components/input-error';
 import MarkdownEditor from '@/components/markdown-editor';
+import PostHeader from '@/components/post-header';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
+import { cn } from '@/lib/utils';
 import { dashboard } from '@/routes';
 import {
     index,
     namespace as namespaceRoute,
-    revisions,
     show,
     update,
     uploadImage,
@@ -38,9 +39,11 @@ type Post = {
 export default function Edit({
     namespace,
     post,
+    slugPrefix,
 }: {
     namespace: Namespace;
     post: Post;
+    slugPrefix: string;
 }) {
     const initialPublishedAt = post.published_at
         ? new Date(post.published_at).toISOString().slice(0, 16)
@@ -65,6 +68,9 @@ export default function Edit({
             returnTo: params.get('return_to'),
         };
     }, []);
+
+    const [saved, setSaved] = useState(false);
+    const savedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const [isDraft, setIsDraft] = useState(post.is_draft);
     const [scheduleEnabled, setScheduleEnabled] = useState(isFutureDate);
@@ -121,46 +127,23 @@ export default function Edit({
             <Head title={`Edit: ${post.title}`} />
 
             <div className="space-y-6 p-4">
-                <div className="flex items-start justify-between">
-                    <div>
-                        <h1 className="text-2xl font-semibold">Edit Post</h1>
-                        <p className="text-sm text-muted-foreground">
-                            {namespace.slug}/{post.slug}
-                        </p>
-                    </div>
-                    <div className="flex items-center gap-2">
-                        <Button variant="ghost" size="sm" asChild>
-                            <Link
-                                href={revisions.url({
-                                    namespace: namespace.id,
-                                    post: post.slug,
-                                })}
-                            >
-                                Revision History
-                            </Link>
-                        </Button>
-                        {!post.is_draft &&
-                            post.published_at &&
-                            new Date(post.published_at) <= new Date() && (
-                                <Button variant="outline" size="sm" asChild>
-                                    <a
-                                        href={`/${post.full_path}`}
-                                        target="_blank"
-                                        rel="noreferrer"
-                                    >
-                                        <ExternalLink className="size-4" />
-                                        View Live
-                                    </a>
-                                </Button>
-                            )}
-                    </div>
-                </div>
+                <PostHeader namespace={namespace} post={post} mode="edit" />
 
                 <Form
                     {...update.form({
                         namespace: namespace.id,
                         post: post.slug,
                     })}
+                    options={{ preserveScroll: true }}
+                    onSuccess={() => {
+                        setSaved(true);
+                        if (savedTimer.current)
+                            clearTimeout(savedTimer.current);
+                        savedTimer.current = setTimeout(
+                            () => setSaved(false),
+                            2500,
+                        );
+                    }}
                     className="space-y-6"
                 >
                     {({ processing, errors }) => (
@@ -193,13 +176,21 @@ export default function Edit({
 
                             <div className="grid gap-2">
                                 <Label htmlFor="slug">Slug</Label>
-                                <Input
-                                    id="slug"
-                                    name="slug"
-                                    defaultValue={post.slug}
-                                    placeholder="my-post-slug"
-                                    required
-                                />
+                                <div className="flex rounded-md border border-input bg-transparent shadow-xs transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50">
+                                    <span className="inline-flex items-center border-r border-input bg-muted/30 px-3 text-sm whitespace-nowrap text-muted-foreground">
+                                        {slugPrefix}
+                                    </span>
+                                    <Input
+                                        id="slug"
+                                        name="slug"
+                                        defaultValue={post.slug}
+                                        placeholder="my-post-slug"
+                                        className={cn(
+                                            'rounded-l-none border-0 shadow-none focus-visible:border-0 focus-visible:ring-0',
+                                        )}
+                                        required
+                                    />
+                                </div>
                                 <p className="text-xs text-muted-foreground">
                                     Lowercase letters, numbers, and hyphens
                                     only.
@@ -207,6 +198,10 @@ export default function Edit({
                                 <p className="text-xs text-muted-foreground">
                                     Must be unique among pages and child
                                     namespaces under /{namespace.full_path}.
+                                </p>
+                                <p className="text-xs text-muted-foreground">
+                                    Path preview: /{slugPrefix}
+                                    {post.slug}
                                 </p>
                                 <InputError message={errors.slug} />
                             </div>
@@ -302,22 +297,24 @@ export default function Edit({
                                 <InputError message={errors.published_at} />
                             </div>
 
-                            <div className="flex gap-3">
-                                <Button type="submit" disabled={processing}>
-                                    Save Changes
-                                </Button>
-                                <Button type="button" variant="outline" asChild>
-                                    <Link
-                                        href={
-                                            returnTo ??
-                                            show.url({
-                                                namespace: namespace.id,
-                                                post: post.slug,
-                                            })
-                                        }
-                                    >
-                                        Cancel
-                                    </Link>
+                            <div className="fixed right-6 bottom-6 z-50">
+                                <Button
+                                    type="submit"
+                                    disabled={processing}
+                                    size="lg"
+                                    className={`gap-2.5 rounded-full px-6 shadow-xl transition-all hover:scale-105 active:scale-95 disabled:shadow-none ${saved ? 'bg-green-600 shadow-green-600/30 hover:bg-green-600' : 'shadow-primary/30'}`}
+                                >
+                                    {saved ? (
+                                        <>
+                                            <Check className="size-4.5" />
+                                            Saved
+                                        </>
+                                    ) : (
+                                        <>
+                                            <Save className="size-4.5" />
+                                            Save Changes
+                                        </>
+                                    )}
                                 </Button>
                             </div>
                         </>

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -1,4 +1,4 @@
-import { Form, Head, Link, setLayoutProps } from '@inertiajs/react';
+import { Form, Head, setLayoutProps } from '@inertiajs/react';
 import { Check, Save } from 'lucide-react';
 import { useMemo, useRef, useState } from 'react';
 import InputError from '@/components/input-error';
@@ -137,8 +137,11 @@ export default function Edit({
                     options={{ preserveScroll: true }}
                     onSuccess={() => {
                         setSaved(true);
-                        if (savedTimer.current)
+
+                        if (savedTimer.current) {
                             clearTimeout(savedTimer.current);
+                        }
+
                         savedTimer.current = setTimeout(
                             () => setSaved(false),
                             2500,

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -50,9 +50,9 @@ export default function Edit({
         ? new Date(post.published_at) > new Date()
         : false;
 
-    const { jumpTo, returnHeading } = useMemo(() => {
+    const { jumpTo, returnHeading, returnTo } = useMemo(() => {
         if (typeof window === 'undefined') {
-            return { jumpTo: undefined, returnHeading: null };
+            return { jumpTo: undefined, returnHeading: null, returnTo: null };
         }
 
         const params = new URLSearchParams(window.location.search);
@@ -62,6 +62,7 @@ export default function Edit({
         return {
             jumpTo: Number.isFinite(n) && jumpParam !== null ? n : undefined,
             returnHeading: params.get('return_heading'),
+            returnTo: params.get('return_to'),
         };
     }, []);
 
@@ -135,7 +136,7 @@ export default function Edit({
                                     post: post.slug,
                                 })}
                             >
-                                変更履歴
+                                Revision History
                             </Link>
                         </Button>
                         {!post.is_draft &&
@@ -169,6 +170,13 @@ export default function Edit({
                                     type="hidden"
                                     name="return_heading"
                                     value={returnHeading}
+                                />
+                            )}
+                            {returnTo && (
+                                <input
+                                    type="hidden"
+                                    name="return_to"
+                                    value={returnTo}
                                 />
                             )}
                             <div className="grid gap-2">
@@ -300,10 +308,13 @@ export default function Edit({
                                 </Button>
                                 <Button type="button" variant="outline" asChild>
                                     <Link
-                                        href={show.url({
-                                            namespace: namespace.id,
-                                            post: post.slug,
-                                        })}
+                                        href={
+                                            returnTo ??
+                                            show.url({
+                                                namespace: namespace.id,
+                                                post: post.slug,
+                                            })
+                                        }
                                     >
                                         Cancel
                                     </Link>

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -27,7 +27,18 @@ import {
     FilePen,
     Folder,
     GripVertical,
+    Pencil,
+    Trash2,
 } from 'lucide-react';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
 import { useEffect, useState } from 'react';
 import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import { Button } from '@/components/ui/button';
@@ -186,21 +197,52 @@ function SortableRow({
                     )}
                     <Button variant="outline" size="sm" asChild>
                         <Link href={NamespaceController.edit.url(namespace.id)}>
+                            <Pencil className="size-4" />
                             Edit
                         </Link>
                     </Button>
-                    <Form {...NamespaceController.destroy.form(namespace.id)}>
-                        {({ processing }) => (
-                            <Button
-                                type="submit"
-                                variant="destructive"
-                                size="sm"
-                                disabled={processing}
-                            >
+                    <Dialog>
+                        <DialogTrigger asChild>
+                            <Button variant="destructive" size="sm">
+                                <Trash2 className="size-4" />
                                 Delete
                             </Button>
-                        )}
-                    </Form>
+                        </DialogTrigger>
+                        <DialogContent>
+                            <DialogTitle>
+                                Delete &ldquo;{namespace.name}&rdquo;?
+                            </DialogTitle>
+                            <DialogDescription>
+                                This will permanently delete the namespace, all
+                                child namespaces, and all their posts. This
+                                action cannot be undone.
+                            </DialogDescription>
+                            <Form
+                                {...NamespaceController.destroy.form(
+                                    namespace.id,
+                                )}
+                            >
+                                {({ processing }) => (
+                                    <DialogFooter className="gap-2">
+                                        <DialogClose asChild>
+                                            <Button variant="secondary">
+                                                Cancel
+                                            </Button>
+                                        </DialogClose>
+                                        <Button
+                                            variant="destructive"
+                                            disabled={processing}
+                                            asChild
+                                        >
+                                            <button type="submit">
+                                                Delete
+                                            </button>
+                                        </Button>
+                                    </DialogFooter>
+                                )}
+                            </Form>
+                        </DialogContent>
+                    </Dialog>
                 </div>
             </td>
         </tr>
@@ -291,23 +333,52 @@ function ChildRow({
                                     namespace.id,
                                 )}
                             >
+                                <Pencil className="size-4" />
                                 Edit
                             </Link>
                         </Button>
-                        <Form
-                            {...NamespaceController.destroy.form(namespace.id)}
-                        >
-                            {({ processing }) => (
-                                <Button
-                                    type="submit"
-                                    variant="destructive"
-                                    size="sm"
-                                    disabled={processing}
-                                >
+                        <Dialog>
+                            <DialogTrigger asChild>
+                                <Button variant="destructive" size="sm">
+                                    <Trash2 className="size-4" />
                                     Delete
                                 </Button>
-                            )}
-                        </Form>
+                            </DialogTrigger>
+                            <DialogContent>
+                                <DialogTitle>
+                                    Delete &ldquo;{namespace.name}&rdquo;?
+                                </DialogTitle>
+                                <DialogDescription>
+                                    This will permanently delete the namespace,
+                                    all child namespaces, and all their posts.
+                                    This action cannot be undone.
+                                </DialogDescription>
+                                <Form
+                                    {...NamespaceController.destroy.form(
+                                        namespace.id,
+                                    )}
+                                >
+                                    {({ processing }) => (
+                                        <DialogFooter className="gap-2">
+                                            <DialogClose asChild>
+                                                <Button variant="secondary">
+                                                    Cancel
+                                                </Button>
+                                            </DialogClose>
+                                            <Button
+                                                variant="destructive"
+                                                disabled={processing}
+                                                asChild
+                                            >
+                                                <button type="submit">
+                                                    Delete
+                                                </button>
+                                            </Button>
+                                        </DialogFooter>
+                                    )}
+                                </Form>
+                            </DialogContent>
+                        </Dialog>
                     </div>
                 </td>
             </tr>

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -18,6 +18,8 @@ import { CSS } from '@dnd-kit/utilities';
 import { Form } from '@inertiajs/react';
 import { Head, Link, router } from '@inertiajs/react';
 import {
+    ArrowUpDown,
+    Check,
     CheckCircle2,
     ChevronDown,
     ChevronRight,
@@ -26,10 +28,14 @@ import {
     ExternalLink,
     FilePen,
     Folder,
+    FolderPlus,
     GripVertical,
     Pencil,
     Trash2,
 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
+import { Button } from '@/components/ui/button';
 import {
     Dialog,
     DialogClose,
@@ -39,9 +45,8 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
-import { useEffect, useState } from 'react';
-import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
-import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { matchesDeleteConfirmation } from '@/lib/delete-confirmation';
 import { dashboard } from '@/routes';
 import { create as namespaceCreate } from '@/routes/admin/namespaces';
 import { index, namespace as namespaceRoute } from '@/routes/admin/posts';
@@ -60,6 +65,71 @@ type Sort = {
     column: string;
     direction: 'asc' | 'desc';
 };
+
+function DeleteNamespaceDialog({ namespace }: { namespace: Namespace }) {
+    const [confirmation, setConfirmation] = useState('');
+    const matches = matchesDeleteConfirmation(confirmation, namespace.name);
+
+    return (
+        <Dialog>
+            <DialogTrigger asChild>
+                <Button variant="destructive" size="sm">
+                    <Trash2 className="size-4" />
+                    Delete
+                </Button>
+            </DialogTrigger>
+            <DialogContent>
+                <DialogTitle>
+                    Delete &ldquo;{namespace.name}&rdquo;?
+                </DialogTitle>
+                <DialogDescription className="space-y-3">
+                    <p>
+                        This will permanently delete the namespace, all child
+                        namespaces, and all their posts. This action cannot be
+                        undone.
+                    </p>
+                    <p>
+                        Type{' '}
+                        <span className="font-semibold">{namespace.name}</span>{' '}
+                        to confirm.
+                    </p>
+                </DialogDescription>
+                <Form action={NamespaceController.destroy(namespace.id)}>
+                    {({ processing }) => (
+                        <div className="space-y-4">
+                            <Input
+                                name="confirmation"
+                                value={confirmation}
+                                onChange={(event) =>
+                                    setConfirmation(event.target.value)
+                                }
+                                autoComplete="off"
+                                placeholder={namespace.name}
+                            />
+                            <DialogFooter className="gap-2">
+                                <DialogClose asChild>
+                                    <Button
+                                        variant="secondary"
+                                        onClick={() => setConfirmation('')}
+                                    >
+                                        Cancel
+                                    </Button>
+                                </DialogClose>
+                                <Button
+                                    variant="destructive"
+                                    disabled={processing || !matches}
+                                    asChild
+                                >
+                                    <button type="submit">Delete</button>
+                                </Button>
+                            </DialogFooter>
+                        </div>
+                    )}
+                </Form>
+            </DialogContent>
+        </Dialog>
+    );
+}
 
 function SortIcon({ column, sort }: { column: string; sort: Sort }) {
     if (sort.column !== column) {
@@ -155,12 +225,15 @@ function SortableRow({
                 ) : null}
             </td>
             <td className="px-4 py-3 font-medium">
-                <Link
-                    href={namespaceRoute.url(namespace.id)}
-                    className="text-primary hover:underline"
-                >
-                    {namespace.name}
-                </Link>
+                <div className="flex items-center gap-1.5">
+                    <Folder className="size-3.5 shrink-0 text-muted-foreground" />
+                    <Link
+                        href={namespaceRoute.url(namespace.id)}
+                        className="text-primary hover:underline"
+                    >
+                        {namespace.name}
+                    </Link>
+                </div>
             </td>
             <td className="px-4 py-3 text-muted-foreground">
                 /{namespace.slug}
@@ -183,66 +256,23 @@ function SortableRow({
             </td>
             <td className="px-4 py-3 text-right">
                 <div className="flex items-center justify-end gap-2">
-                    {namespace.is_published && (
-                        <Button variant="outline" size="sm" asChild>
-                            <a
-                                href={`/${namespace.full_path}`}
-                                target="_blank"
-                                rel="noreferrer"
-                            >
-                                <ExternalLink className="size-4" />
-                                View
-                            </a>
-                        </Button>
-                    )}
+                    <Button variant="outline" size="sm" asChild>
+                        <a
+                            href={`/${namespace.full_path}`}
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            <ExternalLink className="size-4" />
+                            View
+                        </a>
+                    </Button>
                     <Button variant="outline" size="sm" asChild>
                         <Link href={NamespaceController.edit.url(namespace.id)}>
                             <Pencil className="size-4" />
                             Edit
                         </Link>
                     </Button>
-                    <Dialog>
-                        <DialogTrigger asChild>
-                            <Button variant="destructive" size="sm">
-                                <Trash2 className="size-4" />
-                                Delete
-                            </Button>
-                        </DialogTrigger>
-                        <DialogContent>
-                            <DialogTitle>
-                                Delete &ldquo;{namespace.name}&rdquo;?
-                            </DialogTitle>
-                            <DialogDescription>
-                                This will permanently delete the namespace, all
-                                child namespaces, and all their posts. This
-                                action cannot be undone.
-                            </DialogDescription>
-                            <Form
-                                {...NamespaceController.destroy.form(
-                                    namespace.id,
-                                )}
-                            >
-                                {({ processing }) => (
-                                    <DialogFooter className="gap-2">
-                                        <DialogClose asChild>
-                                            <Button variant="secondary">
-                                                Cancel
-                                            </Button>
-                                        </DialogClose>
-                                        <Button
-                                            variant="destructive"
-                                            disabled={processing}
-                                            asChild
-                                        >
-                                            <button type="submit">
-                                                Delete
-                                            </button>
-                                        </Button>
-                                    </DialogFooter>
-                                )}
-                            </Form>
-                        </DialogContent>
-                    </Dialog>
+                    <DeleteNamespaceDialog namespace={namespace} />
                 </div>
             </td>
         </tr>
@@ -337,48 +367,7 @@ function ChildRow({
                                 Edit
                             </Link>
                         </Button>
-                        <Dialog>
-                            <DialogTrigger asChild>
-                                <Button variant="destructive" size="sm">
-                                    <Trash2 className="size-4" />
-                                    Delete
-                                </Button>
-                            </DialogTrigger>
-                            <DialogContent>
-                                <DialogTitle>
-                                    Delete &ldquo;{namespace.name}&rdquo;?
-                                </DialogTitle>
-                                <DialogDescription>
-                                    This will permanently delete the namespace,
-                                    all child namespaces, and all their posts.
-                                    This action cannot be undone.
-                                </DialogDescription>
-                                <Form
-                                    {...NamespaceController.destroy.form(
-                                        namespace.id,
-                                    )}
-                                >
-                                    {({ processing }) => (
-                                        <DialogFooter className="gap-2">
-                                            <DialogClose asChild>
-                                                <Button variant="secondary">
-                                                    Cancel
-                                                </Button>
-                                            </DialogClose>
-                                            <Button
-                                                variant="destructive"
-                                                disabled={processing}
-                                                asChild
-                                            >
-                                                <button type="submit">
-                                                    Delete
-                                                </button>
-                                            </Button>
-                                        </DialogFooter>
-                                    )}
-                                </Form>
-                            </DialogContent>
-                        </Dialog>
+                        <DeleteNamespaceDialog namespace={namespace} />
                     </div>
                 </td>
             </tr>
@@ -488,10 +477,21 @@ export default function Index({
                             variant={reorderMode ? 'secondary' : 'outline'}
                             onClick={handleReorderToggle}
                         >
-                            {reorderMode ? 'Done' : 'Reorder'}
+                            {reorderMode ? (
+                                <>
+                                    <Check className="size-4" />
+                                    Done
+                                </>
+                            ) : (
+                                <>
+                                    <ArrowUpDown className="size-4" />
+                                    Reorder
+                                </>
+                            )}
                         </Button>
                         <Button asChild>
                             <Link href={namespaceCreate.url()}>
+                                <FolderPlus className="size-4" />
                                 New Namespace
                             </Link>
                         </Button>
@@ -508,6 +508,7 @@ export default function Index({
                         </p>
                         <Button asChild className="mt-4">
                             <Link href={namespaceCreate.url()}>
+                                <FolderPlus className="size-4" />
                                 Create your first namespace
                             </Link>
                         </Button>

--- a/resources/js/pages/admin/posts/namespace.tsx
+++ b/resources/js/pages/admin/posts/namespace.tsx
@@ -1,19 +1,46 @@
-import { Head, Link, setLayoutProps } from '@inertiajs/react';
+import type { DragEndEvent } from '@dnd-kit/core';
 import {
+    DndContext,
+    KeyboardSensor,
+    PointerSensor,
+    closestCenter,
+    useSensor,
+    useSensors,
+} from '@dnd-kit/core';
+import {
+    SortableContext,
+    arrayMove,
+    sortableKeyboardCoordinates,
+    useSortable,
+    verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Head, Link, router, setLayoutProps } from '@inertiajs/react';
+import {
+    ArrowUpDown,
+    Check,
     CheckCircle2,
     Clock,
     ExternalLink,
+    FilePlus2,
     FilePen,
+    FileText,
+    FolderPlus,
     FolderOpen,
+    GripVertical,
 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import NamespaceHeader from '@/components/namespace-header';
 import { Button } from '@/components/ui/button';
 import { timeAgo } from '@/lib/time';
 import { dashboard } from '@/routes';
 import { create as namespaceCreate } from '@/routes/admin/namespaces';
 import {
+    create,
     index,
     namespace as namespaceRoute,
-    create,
+    reorderNamespaces,
+    reorderPosts,
 } from '@/routes/admin/posts';
 
 type Namespace = {
@@ -21,6 +48,7 @@ type Namespace = {
     slug: string;
     full_path: string;
     name: string;
+    is_published: boolean;
 };
 
 type ChildNamespace = {
@@ -49,18 +77,237 @@ type Ancestor = {
     name: string;
 };
 
+function SortableChildRow({
+    child,
+    reorderMode,
+}: {
+    child: ChildNamespace;
+    reorderMode: boolean;
+}) {
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id: child.id });
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+    };
+
+    return (
+        <tr ref={setNodeRef} style={style} className="border-b last:border-0">
+            <td className="w-8 px-2 py-3">
+                {reorderMode && (
+                    <button
+                        {...attributes}
+                        {...listeners}
+                        className="cursor-grab touch-none text-muted-foreground hover:text-foreground active:cursor-grabbing"
+                    >
+                        <GripVertical className="size-4" />
+                    </button>
+                )}
+            </td>
+            <td className="px-4 py-3">
+                <div className="flex items-center gap-2">
+                    <FolderOpen className="size-4 text-muted-foreground" />
+                    <Link
+                        href={namespaceRoute.url(child.id)}
+                        className="font-medium text-primary hover:underline"
+                    >
+                        {child.name}
+                    </Link>
+                </div>
+            </td>
+            <td className="px-4 py-3 text-muted-foreground">
+                /{child.full_path}
+            </td>
+            <td className="px-4 py-3">
+                {child.is_published ? (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
+                        <CheckCircle2 className="size-3" />
+                        Published
+                    </span>
+                ) : (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                        <FilePen className="size-3" />
+                        Draft
+                    </span>
+                )}
+            </td>
+            <td className="px-4 py-3 text-muted-foreground">
+                {child.posts_count} {child.posts_count === 1 ? 'post' : 'posts'}
+            </td>
+        </tr>
+    );
+}
+
+function SortablePostRow({
+    post,
+    namespaceFullPath,
+    reorderMode,
+}: {
+    post: Post;
+    namespaceFullPath: string;
+    reorderMode: boolean;
+}) {
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id: post.id });
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+    };
+
+    return (
+        <tr ref={setNodeRef} style={style} className="border-b last:border-0">
+            <td className="w-8 px-2 py-3">
+                {reorderMode && (
+                    <button
+                        {...attributes}
+                        {...listeners}
+                        className="cursor-grab touch-none text-muted-foreground hover:text-foreground active:cursor-grabbing"
+                    >
+                        <GripVertical className="size-4" />
+                    </button>
+                )}
+            </td>
+            <td className="px-4 py-3 font-medium">
+                <div className="flex items-center gap-2">
+                    <FileText className="size-4 text-muted-foreground" />
+                    <Link href={post.admin_url} className="hover:underline">
+                        {post.title}
+                    </Link>
+                </div>
+            </td>
+            <td className="px-4 py-3 text-muted-foreground">
+                <div className="flex items-center gap-2">
+                    <span>
+                        /{namespaceFullPath}/{post.slug}
+                    </span>
+                    <a
+                        href={`/${post.full_path}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-muted-foreground transition-colors hover:text-foreground"
+                    >
+                        <ExternalLink className="size-3.5" />
+                    </a>
+                </div>
+            </td>
+            <td className="px-4 py-3">
+                {post.is_draft ? (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                        <FilePen className="size-3" />
+                        Draft
+                    </span>
+                ) : !post.published_at ||
+                  new Date(post.published_at) > new Date() ? (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                        <Clock className="size-3" />
+                        Scheduled
+                    </span>
+                ) : (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                        <CheckCircle2 className="size-3" />
+                        Published
+                    </span>
+                )}
+            </td>
+            <td
+                className="px-4 py-3 text-muted-foreground"
+                suppressHydrationWarning
+            >
+                {new Date(post.created_at).toLocaleString(undefined, {
+                    dateStyle: 'medium',
+                    timeStyle: 'short',
+                })}
+                <span className="ml-1.5 text-xs opacity-60">
+                    ({timeAgo(post.created_at)})
+                </span>
+            </td>
+        </tr>
+    );
+}
+
 export default function Namespace({
     namespace,
     ancestors,
-    children,
-    posts,
+    children: initialChildren,
+    posts: initialPosts,
 }: {
     namespace: Namespace;
     ancestors: Ancestor[];
     children: ChildNamespace[];
     posts: Post[];
 }) {
+    const [children, setChildren] = useState(initialChildren);
+    const [posts, setPosts] = useState(initialPosts);
+    const [namespacesReorderMode, setNamespacesReorderMode] = useState(false);
+    const [postsReorderMode, setPostsReorderMode] = useState(false);
+
+    useEffect(() => {
+        setChildren(initialChildren);
+    }, [initialChildren]);
+    useEffect(() => {
+        setPosts(initialPosts);
+    }, [initialPosts]);
+
     const childNamespaceCreateUrl = `${namespaceCreate.url()}?${new URLSearchParams({ parent: String(namespace.id) }).toString()}`;
+
+    const sensors = useSensors(
+        useSensor(PointerSensor),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates,
+        }),
+    );
+
+    function handleNamespaceDragEnd(event: DragEndEvent) {
+        const { active, over } = event;
+
+        if (!over || active.id === over.id) {
+            return;
+        }
+
+        const oldIndex = children.findIndex((c) => c.id === active.id);
+        const newIndex = children.findIndex((c) => c.id === over.id);
+        const reordered = arrayMove(children, oldIndex, newIndex);
+        setChildren(reordered);
+        router.patch(
+            reorderNamespaces.url(namespace.id),
+            { slugs: reordered.map((c) => c.slug) },
+            { preserveScroll: true },
+        );
+    }
+
+    function handlePostDragEnd(event: DragEndEvent) {
+        const { active, over } = event;
+
+        if (!over || active.id === over.id) {
+            return;
+        }
+
+        const oldIndex = posts.findIndex((p) => p.id === active.id);
+        const newIndex = posts.findIndex((p) => p.id === over.id);
+        const reordered = arrayMove(posts, oldIndex, newIndex);
+        setPosts(reordered);
+        router.patch(
+            reorderPosts.url(namespace.id),
+            { slugs: reordered.map((p) => p.slug) },
+            { preserveScroll: true },
+        );
+    }
 
     setLayoutProps({
         breadcrumbs: [
@@ -79,82 +326,66 @@ export default function Namespace({
             <Head title={`Posts — ${namespace.name}`} />
 
             <div className="space-y-6 p-4">
-                <div className="flex items-center justify-between">
-                    <div>
-                        <h1 className="text-2xl font-semibold">
-                            {namespace.name}
-                        </h1>
-                        <p className="text-sm text-muted-foreground">
-                            /{namespace.slug}
-                        </p>
-                    </div>
-                    <div className="flex items-center gap-2">
-                        <Button variant="outline" asChild>
-                            <Link href={childNamespaceCreateUrl}>
-                                New Child Namespace
-                            </Link>
-                        </Button>
-                        <Button asChild>
-                            <Link href={create.url(namespace.id)}>
-                                New Post
-                            </Link>
-                        </Button>
-                    </div>
-                </div>
+                <NamespaceHeader namespace={namespace} />
 
                 {children.length > 0 && (
                     <div className="space-y-2">
-                        <h2 className="text-sm font-medium text-muted-foreground">
-                            Child Namespaces
-                        </h2>
-                        <div className="rounded-xl border">
-                            <table className="w-full text-sm">
-                                <tbody>
-                                    {children.map((child) => (
-                                        <tr
-                                            key={child.id}
-                                            className="border-b last:border-0"
-                                        >
-                                            <td className="px-4 py-3">
-                                                <div className="flex items-center gap-2">
-                                                    <FolderOpen className="size-4 text-muted-foreground" />
-                                                    <Link
-                                                        href={namespaceRoute.url(
-                                                            child.id,
-                                                        )}
-                                                        className="font-medium text-primary hover:underline"
-                                                    >
-                                                        {child.name}
-                                                    </Link>
-                                                </div>
-                                            </td>
-                                            <td className="px-4 py-3 text-muted-foreground">
-                                                /{child.full_path}
-                                            </td>
-                                            <td className="px-4 py-3">
-                                                {child.is_published ? (
-                                                    <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
-                                                        <CheckCircle2 className="size-3" />
-                                                        Published
-                                                    </span>
-                                                ) : (
-                                                    <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                                                        <FilePen className="size-3" />
-                                                        Draft
-                                                    </span>
-                                                )}
-                                            </td>
-                                            <td className="px-4 py-3 text-muted-foreground">
-                                                {child.posts_count}{' '}
-                                                {child.posts_count === 1
-                                                    ? 'post'
-                                                    : 'posts'}
-                                            </td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </table>
+                        <div className="flex items-center justify-between">
+                            <h2 className="text-sm font-medium text-muted-foreground">
+                                Child Namespaces
+                            </h2>
+                            <Button
+                                variant={
+                                    namespacesReorderMode
+                                        ? 'secondary'
+                                        : 'outline'
+                                }
+                                size="sm"
+                                onClick={() =>
+                                    setNamespacesReorderMode((v) => !v)
+                                }
+                            >
+                                {namespacesReorderMode ? (
+                                    <>
+                                        <Check className="size-4" />
+                                        Done
+                                    </>
+                                ) : (
+                                    <>
+                                        <ArrowUpDown className="size-4" />
+                                        Reorder
+                                    </>
+                                )}
+                            </Button>
                         </div>
+                        <DndContext
+                            sensors={sensors}
+                            collisionDetection={closestCenter}
+                            onDragEnd={handleNamespaceDragEnd}
+                        >
+                            <div className="rounded-xl border">
+                                <table className="w-full text-sm">
+                                    <tbody>
+                                        <SortableContext
+                                            items={children.map((c) => c.id)}
+                                            strategy={
+                                                verticalListSortingStrategy
+                                            }
+                                        >
+                                            {children.map((child) => (
+                                                <SortableChildRow
+                                                    key={child.id}
+                                                    child={child}
+                                                    reorderMode={
+                                                        namespacesReorderMode
+                                                    }
+                                                />
+                                            ))}
+                                        </SortableContext>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </DndContext>
                     </div>
                 )}
 
@@ -166,97 +397,92 @@ export default function Namespace({
                         <div className="mt-4 flex items-center justify-center gap-2">
                             <Button variant="outline" asChild>
                                 <Link href={childNamespaceCreateUrl}>
+                                    <FolderPlus className="size-4" />
                                     Create a child namespace
                                 </Link>
                             </Button>
                             <Button asChild>
                                 <Link href={create.url(namespace.id)}>
+                                    <FilePlus2 className="size-4" />
                                     Create your first post
                                 </Link>
                             </Button>
                         </div>
                     </div>
                 ) : (
-                    <div className="rounded-xl border">
-                        <table className="w-full text-sm">
-                            <thead>
-                                <tr className="border-b bg-muted/50">
-                                    <th className="px-4 py-3 text-left font-medium">
-                                        Title
-                                    </th>
-                                    <th className="px-4 py-3 text-left font-medium">
-                                        Slug
-                                    </th>
-                                    <th className="px-4 py-3 text-left font-medium">
-                                        Status
-                                    </th>
-                                    <th className="px-4 py-3 text-left font-medium">
-                                        Created
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {posts.map((post) => (
-                                    <tr
-                                        key={post.id}
-                                        className="border-b last:border-0"
-                                    >
-                                        <td className="px-4 py-3 font-medium">
-                                            <div className="flex items-center gap-2">
-                                                <Link
-                                                    href={post.admin_url}
-                                                    className="hover:underline"
-                                                >
-                                                    {post.title}
-                                                </Link>
-                                                <a
-                                                    href={`/${post.full_path}`}
-                                                    target="_blank"
-                                                    rel="noreferrer"
-                                                    className="text-muted-foreground transition-colors hover:text-foreground"
-                                                >
-                                                    <ExternalLink className="size-3.5" />
-                                                </a>
-                                            </div>
-                                        </td>
-                                        <td className="px-4 py-3 text-muted-foreground">
-                                            /{namespace.full_path}/{post.slug}
-                                        </td>
-                                        <td className="px-4 py-3">
-                                            {post.is_draft ? (
-                                                <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                                                    <FilePen className="size-3" />
-                                                    Draft
-                                                </span>
-                                            ) : !post.published_at ||
-                                              new Date(post.published_at) >
-                                                  new Date() ? (
-                                                <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
-                                                    <Clock className="size-3" />
-                                                    Scheduled
-                                                </span>
-                                            ) : (
-                                                <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
-                                                    <CheckCircle2 className="size-3" />
-                                                    Published
-                                                </span>
-                                            )}
-                                        </td>
-                                        <td className="px-4 py-3 text-muted-foreground">
-                                            {new Date(
-                                                post.created_at,
-                                            ).toLocaleString(undefined, {
-                                                dateStyle: 'medium',
-                                                timeStyle: 'short',
-                                            })}
-                                            <span className="ml-1.5 text-xs opacity-60">
-                                                ({timeAgo(post.created_at)})
-                                            </span>
-                                        </td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
+                    <div className="space-y-2">
+                        <div className="flex items-center justify-between">
+                            <h2 className="text-sm font-medium text-muted-foreground">
+                                Posts
+                            </h2>
+                            <Button
+                                variant={
+                                    postsReorderMode ? 'secondary' : 'outline'
+                                }
+                                size="sm"
+                                onClick={() => setPostsReorderMode((v) => !v)}
+                            >
+                                {postsReorderMode ? (
+                                    <>
+                                        <Check className="size-4" />
+                                        Done
+                                    </>
+                                ) : (
+                                    <>
+                                        <ArrowUpDown className="size-4" />
+                                        Reorder
+                                    </>
+                                )}
+                            </Button>
+                        </div>
+                        <DndContext
+                            sensors={sensors}
+                            collisionDetection={closestCenter}
+                            onDragEnd={handlePostDragEnd}
+                        >
+                            <div className="rounded-xl border">
+                                <table className="w-full text-sm">
+                                    <thead>
+                                        <tr className="border-b bg-muted/50">
+                                            <th className="w-8 px-2 py-3" />
+                                            <th className="px-4 py-3 text-left font-medium">
+                                                Title
+                                            </th>
+                                            <th className="px-4 py-3 text-left font-medium">
+                                                Slug
+                                            </th>
+                                            <th className="px-4 py-3 text-left font-medium">
+                                                Status
+                                            </th>
+                                            <th className="px-4 py-3 text-left font-medium">
+                                                Created
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <SortableContext
+                                            items={posts.map((p) => p.id)}
+                                            strategy={
+                                                verticalListSortingStrategy
+                                            }
+                                        >
+                                            {posts.map((post) => (
+                                                <SortablePostRow
+                                                    key={post.id}
+                                                    post={post}
+                                                    namespaceFullPath={
+                                                        namespace.full_path
+                                                    }
+                                                    reorderMode={
+                                                        postsReorderMode
+                                                    }
+                                                />
+                                            ))}
+                                        </SortableContext>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </DndContext>
                     </div>
                 )}
             </div>

--- a/resources/js/pages/admin/posts/namespace.tsx
+++ b/resources/js/pages/admin/posts/namespace.tsx
@@ -1,5 +1,4 @@
 import { Head, Link, setLayoutProps } from '@inertiajs/react';
-import { Form } from '@inertiajs/react';
 import {
     CheckCircle2,
     Clock,
@@ -8,15 +7,13 @@ import {
     FolderOpen,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { timeAgo } from '@/lib/time';
 import { dashboard } from '@/routes';
 import { create as namespaceCreate } from '@/routes/admin/namespaces';
 import {
     index,
     namespace as namespaceRoute,
     create,
-    edit,
-    destroy,
-    show,
 } from '@/routes/admin/posts';
 
 type Namespace = {
@@ -39,9 +36,12 @@ type Post = {
     id: number;
     title: string;
     slug: string;
+    full_path: string;
     is_draft: boolean;
     published_at: string | null;
     created_at: string;
+    canonical_url: string | null;
+    admin_url: string;
 };
 
 type Ancestor = {
@@ -193,9 +193,6 @@ export default function Namespace({
                                     <th className="px-4 py-3 text-left font-medium">
                                         Created
                                     </th>
-                                    <th className="px-4 py-3 text-right font-medium">
-                                        Actions
-                                    </th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -205,15 +202,22 @@ export default function Namespace({
                                         className="border-b last:border-0"
                                     >
                                         <td className="px-4 py-3 font-medium">
-                                            <Link
-                                                href={show.url({
-                                                    namespace: namespace.id,
-                                                    post: post.slug,
-                                                })}
-                                                className="hover:underline"
-                                            >
-                                                {post.title}
-                                            </Link>
+                                            <div className="flex items-center gap-2">
+                                                <Link
+                                                    href={post.admin_url}
+                                                    className="hover:underline"
+                                                >
+                                                    {post.title}
+                                                </Link>
+                                                <a
+                                                    href={`/${post.full_path}`}
+                                                    target="_blank"
+                                                    rel="noreferrer"
+                                                    className="text-muted-foreground transition-colors hover:text-foreground"
+                                                >
+                                                    <ExternalLink className="size-3.5" />
+                                                </a>
+                                            </div>
                                         </td>
                                         <td className="px-4 py-3 text-muted-foreground">
                                             /{namespace.full_path}/{post.slug}
@@ -241,65 +245,13 @@ export default function Namespace({
                                         <td className="px-4 py-3 text-muted-foreground">
                                             {new Date(
                                                 post.created_at,
-                                            ).toLocaleDateString()}
-                                        </td>
-                                        <td className="px-4 py-3 text-right">
-                                            <div className="flex items-center justify-end gap-2">
-                                                {!post.is_draft &&
-                                                    post.published_at &&
-                                                    new Date(
-                                                        post.published_at,
-                                                    ) <= new Date() && (
-                                                        <Button
-                                                            variant="outline"
-                                                            size="sm"
-                                                            asChild
-                                                        >
-                                                            <a
-                                                                href={`/${namespace.full_path}/${post.slug}`}
-                                                                target="_blank"
-                                                                rel="noreferrer"
-                                                            >
-                                                                <ExternalLink className="size-4" />
-                                                                View
-                                                            </a>
-                                                        </Button>
-                                                    )}
-                                                <Button
-                                                    variant="outline"
-                                                    size="sm"
-                                                    asChild
-                                                >
-                                                    <Link
-                                                        href={edit.url({
-                                                            namespace:
-                                                                namespace.id,
-                                                            post: post.slug,
-                                                        })}
-                                                    >
-                                                        Edit
-                                                    </Link>
-                                                </Button>
-                                                <Form
-                                                    {...destroy.form({
-                                                        namespace: namespace.id,
-                                                        post: post.slug,
-                                                    })}
-                                                >
-                                                    {({ processing }) => (
-                                                        <Button
-                                                            type="submit"
-                                                            variant="destructive"
-                                                            size="sm"
-                                                            disabled={
-                                                                processing
-                                                            }
-                                                        >
-                                                            Delete
-                                                        </Button>
-                                                    )}
-                                                </Form>
-                                            </div>
+                                            ).toLocaleString(undefined, {
+                                                dateStyle: 'medium',
+                                                timeStyle: 'short',
+                                            })}
+                                            <span className="ml-1.5 text-xs opacity-60">
+                                                ({timeAgo(post.created_at)})
+                                            </span>
                                         </td>
                                     </tr>
                                 ))}

--- a/resources/js/pages/admin/posts/revisions.tsx
+++ b/resources/js/pages/admin/posts/revisions.tsx
@@ -113,7 +113,7 @@ export default function Revisions({
                 title: 'Edit',
                 href: edit.url({ namespace: namespace.id, post: post.slug }),
             },
-            { title: '変更履歴' },
+            { title: 'Revision History' },
         ],
     });
 
@@ -150,13 +150,15 @@ export default function Revisions({
 
     return (
         <>
-            <Head title={`変更履歴: ${post.title}`} />
+            <Head title={`Revision History: ${post.title}`} />
 
             <div className="space-y-4 p-4">
                 <div className="flex items-center justify-between gap-3">
                     <div className="flex items-center gap-2">
                         <History className="size-5" />
-                        <h1 className="text-2xl font-semibold">変更履歴</h1>
+                        <h1 className="text-2xl font-semibold">
+                            Revision History
+                        </h1>
                     </div>
                     <Button asChild variant="outline" size="sm">
                         <Link

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -13,7 +13,12 @@ import { useMarkdownToc } from '@/hooks/use-markdown-toc';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { normalizeMarkdownHeadingText } from '@/lib/markdown-heading-text';
 import { dashboard } from '@/routes';
-import { edit, index, namespace as namespaceRoute, show } from '@/routes/admin/posts';
+import {
+    edit,
+    index,
+    namespace as namespaceRoute,
+    show,
+} from '@/routes/admin/posts';
 
 function findHeadingOffset(
     content: string,

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -1,26 +1,19 @@
-import { Form, Head, Link, router, setLayoutProps } from '@inertiajs/react';
+import { Head, router, setLayoutProps } from '@inertiajs/react';
 import {
-    CheckCircle2,
-    Clock,
-    FilePen,
+    AlertTriangle,
+    ExternalLink,
     PanelRightClose,
     PanelRightOpen,
 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import MarkdownContent from '@/components/markdown-content';
+import PostHeader from '@/components/post-header';
 import TableOfContents from '@/components/table-of-contents';
-import { Button } from '@/components/ui/button';
 import { useMarkdownToc } from '@/hooks/use-markdown-toc';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { normalizeMarkdownHeadingText } from '@/lib/markdown-heading-text';
 import { dashboard } from '@/routes';
-import {
-    destroy,
-    edit,
-    index,
-    namespace as namespaceRoute,
-    show,
-} from '@/routes/admin/posts';
+import { edit, index, namespace as namespaceRoute, show } from '@/routes/admin/posts';
 
 function findHeadingOffset(
     content: string,
@@ -93,12 +86,14 @@ type Namespace = {
     id: number;
     name: string;
     slug: string;
+    full_path: string;
 };
 
 type Post = {
     id: number;
     title: string;
     slug: string;
+    full_path: string;
     content: string;
     is_draft: boolean;
     published_at: string | null;
@@ -157,7 +152,6 @@ export default function Show({
     const entry = toc.get(post.slug);
     const hasHeadings = (entry?.headings.length ?? 0) > 0;
     const tocVisible = tocOverride ?? !isMobile;
-
     setLayoutProps({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
@@ -175,35 +169,30 @@ export default function Show({
             <Head title={post.title} />
 
             <div className="space-y-6 p-4">
-                <div className="flex items-start justify-between gap-4">
-                    <div className="space-y-1">
-                        <h1 className="text-2xl font-semibold">{post.title}</h1>
-                        <div className="flex items-center gap-3 text-sm text-muted-foreground">
-                            <span>
-                                {namespace.slug}/{post.slug}
-                            </span>
-                            <span>·</span>
-                            {post.is_draft ? (
-                                <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                                    <FilePen className="size-3" />
-                                    Draft
-                                </span>
-                            ) : !post.published_at ||
-                              new Date(post.published_at) > new Date() ? (
-                                <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
-                                    <Clock className="size-3" />
-                                    Scheduled
-                                </span>
-                            ) : (
-                                <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
-                                    <CheckCircle2 className="size-3" />
-                                    Published
-                                </span>
-                            )}
-                        </div>
-                    </div>
+                <PostHeader namespace={namespace} post={post} />
 
-                    <div className="flex shrink-0 items-center gap-2">
+                <section className="space-y-4">
+                    <div className="flex items-center justify-between gap-4 rounded-xl border bg-card px-5 py-4">
+                        <div className="flex items-center gap-3">
+                            <div>
+                                <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                                    Preview
+                                </p>
+                                <p className="mt-1 text-sm text-muted-foreground">
+                                    Canonical rendering inside the admin
+                                    workflow.
+                                </p>
+                            </div>
+                            <a
+                                href={`/${post.full_path}`}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-muted-foreground transition-colors hover:text-foreground"
+                                title="Open canonical URL"
+                            >
+                                <ExternalLink className="size-4" />
+                            </a>
+                        </div>
                         {hasHeadings && (
                             <button
                                 type="button"
@@ -222,70 +211,11 @@ export default function Show({
                                 TOC
                             </button>
                         )}
-                        <Button variant="outline" asChild>
-                            <Link
-                                href={edit.url({
-                                    namespace: namespace.id,
-                                    post: post.slug,
-                                })}
-                            >
-                                Edit
-                            </Link>
-                        </Button>
-                        <Form
-                            {...destroy.form({
-                                namespace: namespace.id,
-                                post: post.slug,
-                            })}
-                        >
-                            {({ processing }) => (
-                                <Button
-                                    type="submit"
-                                    variant="destructive"
-                                    disabled={processing}
-                                >
-                                    Delete
-                                </Button>
-                            )}
-                        </Form>
-                    </div>
-                </div>
-
-                {tocVisible && hasHeadings && (
-                    <div className="lg:hidden">
-                        <TableOfContents
-                            posts={[
-                                {
-                                    id: post.id,
-                                    title: post.title,
-                                    slug: post.slug,
-                                    headings: entry!.headings,
-                                },
-                            ]}
-                        />
-                    </div>
-                )}
-
-                <div
-                    className={
-                        tocVisible && hasHeadings
-                            ? 'lg:grid lg:grid-cols-[1fr_240px] lg:gap-8'
-                            : ''
-                    }
-                >
-                    <div className="min-w-0 rounded-xl border p-6">
-                        <div className="prose max-w-none prose-neutral dark:prose-invert">
-                            <MarkdownContent
-                                content={post.content}
-                                components={entry?.components}
-                            />
-                        </div>
                     </div>
 
                     {tocVisible && hasHeadings && (
-                        <aside className="hidden lg:block">
+                        <div className="xl:hidden">
                             <TableOfContents
-                                sticky
                                 posts={[
                                     {
                                         id: post.id,
@@ -295,9 +225,87 @@ export default function Show({
                                     },
                                 ]}
                             />
-                        </aside>
+                        </div>
                     )}
-                </div>
+
+                    <div
+                        className={
+                            tocVisible && hasHeadings
+                                ? 'xl:grid xl:grid-cols-[1fr_240px] xl:gap-8'
+                                : ''
+                        }
+                    >
+                        <div className="min-w-0 rounded-xl border bg-card p-6">
+                            <div className="mb-6 rounded-lg border bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
+                                /{post.full_path}
+                            </div>
+                            {post.is_draft && (
+                                <div className="mb-6 flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800/40 dark:bg-amber-900/20">
+                                    <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                                    <div className="text-amber-800 dark:text-amber-400">
+                                        <p className="font-semibold">
+                                            Draft — not publicly visible
+                                        </p>
+                                        <p className="text-sm">
+                                            This post is saved as a draft.
+                                            Visitors will see a 404.
+                                        </p>
+                                    </div>
+                                </div>
+                            )}
+                            {!post.is_draft &&
+                                post.published_at &&
+                                new Date(post.published_at) > new Date() && (
+                                    <div className="mb-6 flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800/40 dark:bg-blue-900/20">
+                                        <AlertTriangle className="mt-0.5 size-4 shrink-0 text-blue-600 dark:text-blue-400" />
+                                        <div className="text-blue-800 dark:text-blue-400">
+                                            <p className="font-semibold">
+                                                Scheduled — not yet public
+                                            </p>
+                                            <p className="text-sm">
+                                                Publicly accessible from{' '}
+                                                <span className="font-medium">
+                                                    {new Date(
+                                                        post.published_at,
+                                                    ).toLocaleString(
+                                                        undefined,
+                                                        {
+                                                            dateStyle: 'long',
+                                                            timeStyle: 'short',
+                                                        },
+                                                    )}
+                                                </span>
+                                                . Visitors will see a 404 until
+                                                then.
+                                            </p>
+                                        </div>
+                                    </div>
+                                )}
+                            <div className="prose max-w-none prose-neutral dark:prose-invert">
+                                <MarkdownContent
+                                    content={post.content}
+                                    components={entry?.components}
+                                />
+                            </div>
+                        </div>
+
+                        {tocVisible && hasHeadings && (
+                            <aside className="hidden xl:block">
+                                <TableOfContents
+                                    sticky
+                                    posts={[
+                                        {
+                                            id: post.id,
+                                            title: post.title,
+                                            slug: post.slug,
+                                            headings: entry!.headings,
+                                        },
+                                    ]}
+                                />
+                            </aside>
+                        )}
+                    </div>
+                </section>
             </div>
         </>
     );

--- a/resources/js/pages/posts/index.tsx
+++ b/resources/js/pages/posts/index.tsx
@@ -1,5 +1,5 @@
 import { Head, Link, usePage } from '@inertiajs/react';
-import { ImageOff } from 'lucide-react';
+import { ImageOff, Settings2 } from 'lucide-react';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import { Button } from '@/components/ui/button';
 import { useCurrentUrl } from '@/hooks/use-current-url';
@@ -32,7 +32,13 @@ export default function Index({ namespaces }: { namespaces: PostNamespace[] }) {
                         <h1 className="text-2xl font-bold">ThinkStream</h1>
                         {auth.user ? (
                             <Button asChild variant="outline" size="sm">
-                                <Link href={dashboard()}>Dashboard</Link>
+                                <Link
+                                    href={dashboard()}
+                                    className="inline-flex items-center gap-1.5"
+                                >
+                                    <Settings2 className="size-4" />
+                                    Manage
+                                </Link>
                             </Button>
                         ) : (
                             <Button asChild variant="outline" size="sm">

--- a/resources/js/pages/posts/index.tsx
+++ b/resources/js/pages/posts/index.tsx
@@ -1,8 +1,9 @@
 import { Head, Link, usePage } from '@inertiajs/react';
 import { ImageOff } from 'lucide-react';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
-import { login } from '@/routes';
-import { index as adminPosts } from '@/routes/admin/posts';
+import { Button } from '@/components/ui/button';
+import { useCurrentUrl } from '@/hooks/use-current-url';
+import { dashboard, login } from '@/routes';
 import { path as contentPath } from '@/routes/posts';
 
 type PostNamespace = {
@@ -19,6 +20,7 @@ export default function Index({ namespaces }: { namespaces: PostNamespace[] }) {
     const { auth } = usePage<{
         auth: { user: { id: number; name: string } | null };
     }>().props;
+    const { currentUrl } = useCurrentUrl();
 
     return (
         <>
@@ -29,19 +31,19 @@ export default function Index({ namespaces }: { namespaces: PostNamespace[] }) {
                     <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-6">
                         <h1 className="text-2xl font-bold">ThinkStream</h1>
                         {auth.user ? (
-                            <Link
-                                href={adminPosts.url()}
-                                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-                            >
-                                Admin
-                            </Link>
+                            <Button asChild variant="outline" size="sm">
+                                <Link href={dashboard()}>Dashboard</Link>
+                            </Button>
                         ) : (
-                            <Link
-                                href={login.url()}
-                                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-                            >
-                                Login
-                            </Link>
+                            <Button asChild variant="outline" size="sm">
+                                <Link
+                                    href={login.url({
+                                        query: { intended: currentUrl },
+                                    })}
+                                >
+                                    Login
+                                </Link>
+                            </Button>
                         )}
                     </div>
                 </header>

--- a/resources/js/pages/posts/index.tsx
+++ b/resources/js/pages/posts/index.tsx
@@ -1,9 +1,10 @@
 import { Head, Link, usePage } from '@inertiajs/react';
 import { ImageOff, Settings2 } from 'lucide-react';
-import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import { Button } from '@/components/ui/button';
+import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import { useCurrentUrl } from '@/hooks/use-current-url';
-import { dashboard, login } from '@/routes';
+import { login } from '@/routes';
+import { namespace as adminNamespaceRoute } from '@/routes/admin/posts';
 import { path as contentPath } from '@/routes/posts';
 
 type PostNamespace = {
@@ -30,17 +31,7 @@ export default function Index({ namespaces }: { namespaces: PostNamespace[] }) {
                 <header className="border-b">
                     <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-6">
                         <h1 className="text-2xl font-bold">ThinkStream</h1>
-                        {auth.user ? (
-                            <Button asChild variant="outline" size="sm">
-                                <Link
-                                    href={dashboard()}
-                                    className="inline-flex items-center gap-1.5"
-                                >
-                                    <Settings2 className="size-4" />
-                                    Manage
-                                </Link>
-                            </Button>
-                        ) : (
+                        {!auth.user && (
                             <Button asChild variant="outline" size="sm">
                                 <Link
                                     href={login.url({
@@ -62,34 +53,40 @@ export default function Index({ namespaces }: { namespaces: PostNamespace[] }) {
                     ) : (
                         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
                             {namespaces.map((ns) => (
-                                <Link
+                                <div
                                     key={ns.id}
-                                    href={contentPath.url(ns.full_path)}
                                     className="group overflow-hidden rounded-xl border transition-colors hover:bg-muted/50"
                                 >
                                     <div className="relative aspect-video overflow-hidden border-b">
-                                        {ns.cover_image_url ? (
-                                            <img
-                                                src={ns.cover_image_url}
-                                                alt={ns.name}
-                                                className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
-                                            />
-                                        ) : (
-                                            <>
-                                                <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
-                                                <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 text-muted-foreground/50">
-                                                    <ImageOff className="size-6" />
-                                                    <span className="text-xs font-medium tracking-wide uppercase">
-                                                        No image
-                                                    </span>
-                                                </div>
-                                            </>
-                                        )}
+                                        <Link
+                                            href={contentPath.url(ns.full_path)}
+                                        >
+                                            {ns.cover_image_url ? (
+                                                <img
+                                                    src={ns.cover_image_url}
+                                                    alt={ns.name}
+                                                    className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                                                />
+                                            ) : (
+                                                <>
+                                                    <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
+                                                    <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 text-muted-foreground/50">
+                                                        <ImageOff className="size-6" />
+                                                        <span className="text-xs font-medium tracking-wide uppercase">
+                                                            No image
+                                                        </span>
+                                                    </div>
+                                                </>
+                                            )}
+                                        </Link>
                                     </div>
                                     <div className="flex flex-col gap-1 p-5">
-                                        <span className="leading-snug font-semibold">
+                                        <Link
+                                            href={contentPath.url(ns.full_path)}
+                                            className="leading-snug font-semibold hover:underline"
+                                        >
                                             {ns.name}
-                                        </span>
+                                        </Link>
                                         {ns.description && (
                                             <span className="line-clamp-2 text-sm text-muted-foreground">
                                                 {ns.description}
@@ -104,8 +101,27 @@ export default function Index({ namespaces }: { namespaces: PostNamespace[] }) {
                                                 ? 'post'
                                                 : 'posts'}
                                         </span>
+                                        {auth.user && (
+                                            <div className="mt-3">
+                                                <Button
+                                                    asChild
+                                                    variant="outline"
+                                                    size="sm"
+                                                >
+                                                    <Link
+                                                        href={adminNamespaceRoute.url(
+                                                            ns.id,
+                                                        )}
+                                                        className="inline-flex items-center gap-1.5"
+                                                    >
+                                                        <Settings2 className="size-4" />
+                                                        Manage
+                                                    </Link>
+                                                </Button>
+                                            </div>
+                                        )}
                                     </div>
-                                </Link>
+                                </div>
                             ))}
                         </div>
                     )}

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -8,10 +8,12 @@ import {
 import { useState } from 'react';
 import type { ContentNavNode } from '@/components/content-nav-tree';
 import ContentNavTree from '@/components/content-nav-tree';
+import { Button } from '@/components/ui/button';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
+import { useCurrentUrl } from '@/hooks/use-current-url';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { login } from '@/routes';
-import { index as adminPosts } from '@/routes/admin/posts';
+import { dashboard, login } from '@/routes';
+import { edit as editNamespace } from '@/routes/admin/namespaces';
 import { path as contentPath } from '@/routes/posts';
 
 type PostNamespace = {
@@ -51,6 +53,7 @@ export default function Namespace({
     const { auth } = usePage<{
         auth: { user: { id: number; name: string } | null };
     }>().props;
+    const { currentUrl } = useCurrentUrl();
     const isMobile = useIsMobile();
     const [navOverride, setNavOverride] = useState<boolean | null>(null);
     const navVisible = navOverride ?? !isMobile;
@@ -120,19 +123,37 @@ export default function Namespace({
                                 Toggle Nav
                             </button>
                             {auth.user ? (
-                                <Link
-                                    href={adminPosts.url()}
-                                    className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-                                >
-                                    Admin
-                                </Link>
+                                <>
+                                    <Button asChild variant="outline" size="sm">
+                                        <Link
+                                            href={editNamespace.url(
+                                                namespace.id,
+                                                {
+                                                    query: {
+                                                        return_to: currentUrl,
+                                                    },
+                                                },
+                                            )}
+                                        >
+                                            Edit Section
+                                        </Link>
+                                    </Button>
+                                    <Button asChild variant="outline" size="sm">
+                                        <Link href={dashboard()}>
+                                            Dashboard
+                                        </Link>
+                                    </Button>
+                                </>
                             ) : (
-                                <Link
-                                    href={login.url()}
-                                    className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-                                >
-                                    Login
-                                </Link>
+                                <Button asChild variant="outline" size="sm">
+                                    <Link
+                                        href={login.url({
+                                            query: { intended: currentUrl },
+                                        })}
+                                    >
+                                        Login
+                                    </Link>
+                                </Button>
                             )}
                         </div>
                     </div>

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -1,19 +1,27 @@
-import { Head, Link, usePage } from '@inertiajs/react';
+import { Head, Link, useForm, usePage } from '@inertiajs/react';
 import {
+    Check,
     ChevronRight,
+    FilePenLine,
     ImageOff,
     PanelLeftClose,
     PanelLeftOpen,
+    Pencil,
+    Settings2,
 } from 'lucide-react';
 import { useState } from 'react';
 import type { ContentNavNode } from '@/components/content-nav-tree';
 import ContentNavTree from '@/components/content-nav-tree';
 import { Button } from '@/components/ui/button';
+import InputError from '@/components/input-error';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import { useCurrentUrl } from '@/hooks/use-current-url';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { dashboard, login } from '@/routes';
-import { edit as editNamespace } from '@/routes/admin/namespaces';
+import { create as createPost } from '@/routes/admin/posts';
+import { update as updateNamespace } from '@/routes/admin/namespaces';
 import { path as contentPath } from '@/routes/posts';
 
 type PostNamespace = {
@@ -23,6 +31,7 @@ type PostNamespace = {
     name: string;
     description?: string | null;
     cover_image_url: string | null;
+    is_published: boolean;
 };
 
 type ChildNamespace = PostNamespace & {
@@ -56,7 +65,42 @@ export default function Namespace({
     const { currentUrl } = useCurrentUrl();
     const isMobile = useIsMobile();
     const [navOverride, setNavOverride] = useState<boolean | null>(null);
+    const [isEditing, setIsEditing] = useState(false);
     const navVisible = navOverride ?? !isMobile;
+    const { data, setData, put, processing, errors, reset } = useForm<{
+        name: string;
+        slug: string;
+        description: string;
+        is_published: boolean;
+        return_to: string;
+    }>({
+        name: namespace.name,
+        slug: namespace.slug,
+        description: namespace.description ?? '',
+        is_published: namespace.is_published,
+        return_to: currentUrl,
+    });
+
+    function cancelEditing(): void {
+        reset();
+        setData('name', namespace.name);
+        setData('slug', namespace.slug);
+        setData('description', namespace.description ?? '');
+        setData('is_published', namespace.is_published);
+        setData('return_to', currentUrl);
+        setIsEditing(false);
+    }
+
+    function submitEditing(e: React.FormEvent<HTMLFormElement>): void {
+        e.preventDefault();
+
+        put(updateNamespace.url(namespace.id), {
+            preserveScroll: true,
+            onSuccess: () => {
+                setIsEditing(false);
+            },
+        });
+    }
 
     return (
         <>
@@ -124,23 +168,46 @@ export default function Namespace({
                             </button>
                             {auth.user ? (
                                 <>
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => {
+                                            if (isEditing) {
+                                                cancelEditing();
+
+                                                return;
+                                            }
+
+                                            setIsEditing(true);
+                                        }}
+                                    >
+                                        {isEditing ? (
+                                            <Check className="size-4" />
+                                        ) : (
+                                            <Pencil className="size-4" />
+                                        )}
+                                        {isEditing ? 'Done' : 'Edit Section'}
+                                    </Button>
                                     <Button asChild variant="outline" size="sm">
                                         <Link
-                                            href={editNamespace.url(
-                                                namespace.id,
-                                                {
-                                                    query: {
-                                                        return_to: currentUrl,
-                                                    },
+                                            href={createPost.url(namespace.id, {
+                                                query: {
+                                                    return_to: currentUrl,
                                                 },
-                                            )}
+                                            })}
+                                            className="inline-flex items-center gap-1.5"
                                         >
-                                            Edit Section
+                                            <FilePenLine className="size-4" />
+                                            New Post
                                         </Link>
                                     </Button>
                                     <Button asChild variant="outline" size="sm">
-                                        <Link href={dashboard()}>
-                                            Dashboard
+                                        <Link
+                                            href={dashboard()}
+                                            className="inline-flex items-center gap-1.5"
+                                        >
+                                            <Settings2 className="size-4" />
+                                            Manage
                                         </Link>
                                     </Button>
                                 </>
@@ -187,11 +254,87 @@ export default function Namespace({
                             <p className="text-sm text-muted-foreground">
                                 /{namespace.full_path}
                             </p>
-                            {namespace.description && (
+                            {auth.user && isEditing ? (
+                                <form
+                                    onSubmit={submitEditing}
+                                    className="max-w-3xl space-y-4 rounded-xl border bg-muted/20 p-4"
+                                >
+                                    <div className="grid gap-2">
+                                        <Label htmlFor="namespace_name">
+                                            Name
+                                        </Label>
+                                        <Input
+                                            id="namespace_name"
+                                            value={data.name}
+                                            onChange={(e) =>
+                                                setData('name', e.target.value)
+                                            }
+                                            required
+                                        />
+                                        <InputError message={errors.name} />
+                                    </div>
+                                    <div className="grid gap-2">
+                                        <Label htmlFor="namespace_description">
+                                            Description
+                                        </Label>
+                                        <textarea
+                                            id="namespace_description"
+                                            value={data.description}
+                                            onChange={(e) =>
+                                                setData(
+                                                    'description',
+                                                    e.target.value,
+                                                )
+                                            }
+                                            rows={4}
+                                            className="flex min-h-24 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                                        />
+                                        <InputError
+                                            message={errors.description}
+                                        />
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <input
+                                            id="namespace_published"
+                                            type="checkbox"
+                                            checked={data.is_published}
+                                            onChange={(e) =>
+                                                setData(
+                                                    'is_published',
+                                                    e.target.checked,
+                                                )
+                                            }
+                                            className="h-4 w-4 rounded border-input"
+                                        />
+                                        <Label htmlFor="namespace_published">
+                                            Published
+                                        </Label>
+                                    </div>
+                                    <div className="flex gap-3">
+                                        <Button
+                                            type="submit"
+                                            disabled={processing}
+                                        >
+                                            Save Changes
+                                        </Button>
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            onClick={cancelEditing}
+                                        >
+                                            Cancel
+                                        </Button>
+                                    </div>
+                                </form>
+                            ) : namespace.description ? (
                                 <p className="max-w-3xl text-base leading-7 text-muted-foreground">
                                     {namespace.description}
                                 </p>
-                            )}
+                            ) : auth.user ? (
+                                <p className="max-w-3xl text-base leading-7 text-muted-foreground">
+                                    No description yet.
+                                </p>
+                            ) : null}
                         </section>
 
                         {children.length > 0 && (

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -1,27 +1,22 @@
-import { Head, Link, useForm, usePage } from '@inertiajs/react';
+import { Head, Link, usePage } from '@inertiajs/react';
 import {
-    Check,
+    AlertTriangle,
+    ArrowRightLeft,
     ChevronRight,
-    FilePenLine,
     ImageOff,
     PanelLeftClose,
     PanelLeftOpen,
-    Pencil,
-    Settings2,
 } from 'lucide-react';
 import { useState } from 'react';
 import type { ContentNavNode } from '@/components/content-nav-tree';
 import ContentNavTree from '@/components/content-nav-tree';
 import { Button } from '@/components/ui/button';
-import InputError from '@/components/input-error';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
+import ViewContextBadge from '@/components/view-context-badge';
 import { useCurrentUrl } from '@/hooks/use-current-url';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { dashboard, login } from '@/routes';
-import { create as createPost } from '@/routes/admin/posts';
-import { update as updateNamespace } from '@/routes/admin/namespaces';
+import { login } from '@/routes';
+import { namespace as adminNamespaceRoute } from '@/routes/admin/posts';
 import { path as contentPath } from '@/routes/posts';
 
 type PostNamespace = {
@@ -52,12 +47,14 @@ export default function Namespace({
     navRoot,
     namespace,
     posts,
+    preview = false,
 }: {
     breadcrumbs: Array<{ name: string; full_path: string }>;
     children: ChildNamespace[];
     navRoot: ContentNavNode;
     namespace: PostNamespace;
     posts: Post[];
+    preview?: boolean;
 }) {
     const { auth } = usePage<{
         auth: { user: { id: number; name: string } | null };
@@ -65,48 +62,29 @@ export default function Namespace({
     const { currentUrl } = useCurrentUrl();
     const isMobile = useIsMobile();
     const [navOverride, setNavOverride] = useState<boolean | null>(null);
-    const [isEditing, setIsEditing] = useState(false);
     const navVisible = navOverride ?? !isMobile;
-    const { data, setData, put, processing, errors, reset } = useForm<{
-        name: string;
-        slug: string;
-        description: string;
-        is_published: boolean;
-        return_to: string;
-    }>({
-        name: namespace.name,
-        slug: namespace.slug,
-        description: namespace.description ?? '',
-        is_published: namespace.is_published,
-        return_to: currentUrl,
-    });
-
-    function cancelEditing(): void {
-        reset();
-        setData('name', namespace.name);
-        setData('slug', namespace.slug);
-        setData('description', namespace.description ?? '');
-        setData('is_published', namespace.is_published);
-        setData('return_to', currentUrl);
-        setIsEditing(false);
-    }
-
-    function submitEditing(e: React.FormEvent<HTMLFormElement>): void {
-        e.preventDefault();
-
-        put(updateNamespace.url(namespace.id), {
-            preserveScroll: true,
-            onSuccess: () => {
-                setIsEditing(false);
-            },
-        });
-    }
 
     return (
         <>
             <Head title={namespace.name} />
 
             <div className="min-h-screen bg-background">
+                {preview && (
+                    <div className="sticky top-0 z-[60] border-b border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-700 dark:bg-amber-900/40">
+                        <div className="mx-auto flex max-w-7xl items-center gap-3">
+                            <AlertTriangle className="size-5 shrink-0 text-amber-600 dark:text-amber-400" />
+                            <div className="flex flex-wrap items-baseline gap-x-2 text-sm font-semibold text-amber-800 dark:text-amber-300">
+                                <span className="tracking-wide uppercase">
+                                    Unpublished
+                                </span>
+                                <span className="font-normal opacity-80">
+                                    This namespace is not publicly visible. Only
+                                    logged-in users can see this preview.
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                )}
                 {namespace.cover_image_url && (
                     <div className="h-48 w-full overflow-hidden md:h-64">
                         <img
@@ -167,50 +145,23 @@ export default function Namespace({
                                 Toggle Nav
                             </button>
                             {auth.user ? (
-                                <>
-                                    <Button
-                                        variant="outline"
-                                        size="sm"
-                                        onClick={() => {
-                                            if (isEditing) {
-                                                cancelEditing();
-
-                                                return;
-                                            }
-
-                                            setIsEditing(true);
-                                        }}
-                                    >
-                                        {isEditing ? (
-                                            <Check className="size-4" />
-                                        ) : (
-                                            <Pencil className="size-4" />
-                                        )}
-                                        {isEditing ? 'Done' : 'Edit Section'}
-                                    </Button>
+                                <div className="flex flex-wrap items-center gap-2">
                                     <Button asChild variant="outline" size="sm">
                                         <Link
-                                            href={createPost.url(namespace.id, {
-                                                query: {
-                                                    return_to: currentUrl,
-                                                },
-                                            })}
+                                            href={adminNamespaceRoute.url(
+                                                namespace.id,
+                                            )}
                                             className="inline-flex items-center gap-1.5"
                                         >
-                                            <FilePenLine className="size-4" />
-                                            New Post
-                                        </Link>
-                                    </Button>
-                                    <Button asChild variant="outline" size="sm">
-                                        <Link
-                                            href={dashboard()}
-                                            className="inline-flex items-center gap-1.5"
-                                        >
-                                            <Settings2 className="size-4" />
+                                            <ArrowRightLeft className="size-4" />
                                             Manage
                                         </Link>
                                     </Button>
-                                </>
+                                    <ViewContextBadge
+                                        label="Site View"
+                                        variant="site"
+                                    />
+                                </div>
                             ) : (
                                 <Button asChild variant="outline" size="sm">
                                     <Link
@@ -254,79 +205,7 @@ export default function Namespace({
                             <p className="text-sm text-muted-foreground">
                                 /{namespace.full_path}
                             </p>
-                            {auth.user && isEditing ? (
-                                <form
-                                    onSubmit={submitEditing}
-                                    className="max-w-3xl space-y-4 rounded-xl border bg-muted/20 p-4"
-                                >
-                                    <div className="grid gap-2">
-                                        <Label htmlFor="namespace_name">
-                                            Name
-                                        </Label>
-                                        <Input
-                                            id="namespace_name"
-                                            value={data.name}
-                                            onChange={(e) =>
-                                                setData('name', e.target.value)
-                                            }
-                                            required
-                                        />
-                                        <InputError message={errors.name} />
-                                    </div>
-                                    <div className="grid gap-2">
-                                        <Label htmlFor="namespace_description">
-                                            Description
-                                        </Label>
-                                        <textarea
-                                            id="namespace_description"
-                                            value={data.description}
-                                            onChange={(e) =>
-                                                setData(
-                                                    'description',
-                                                    e.target.value,
-                                                )
-                                            }
-                                            rows={4}
-                                            className="flex min-h-24 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-                                        />
-                                        <InputError
-                                            message={errors.description}
-                                        />
-                                    </div>
-                                    <div className="flex items-center gap-2">
-                                        <input
-                                            id="namespace_published"
-                                            type="checkbox"
-                                            checked={data.is_published}
-                                            onChange={(e) =>
-                                                setData(
-                                                    'is_published',
-                                                    e.target.checked,
-                                                )
-                                            }
-                                            className="h-4 w-4 rounded border-input"
-                                        />
-                                        <Label htmlFor="namespace_published">
-                                            Published
-                                        </Label>
-                                    </div>
-                                    <div className="flex gap-3">
-                                        <Button
-                                            type="submit"
-                                            disabled={processing}
-                                        >
-                                            Save Changes
-                                        </Button>
-                                        <Button
-                                            type="button"
-                                            variant="outline"
-                                            onClick={cancelEditing}
-                                        >
-                                            Cancel
-                                        </Button>
-                                    </div>
-                                </form>
-                            ) : namespace.description ? (
+                            {namespace.description ? (
                                 <p className="max-w-3xl text-base leading-7 text-muted-foreground">
                                     {namespace.description}
                                 </p>

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -1,4 +1,4 @@
-import { Head, Link, usePage } from '@inertiajs/react';
+import { Head, Link, router, usePage } from '@inertiajs/react';
 import { siX } from 'simple-icons';
 import {
     ChevronRight,
@@ -12,13 +12,12 @@ import type { ContentNavNode } from '@/components/content-nav-tree';
 import ContentNavTree from '@/components/content-nav-tree';
 import MarkdownContent from '@/components/markdown-content';
 import TableOfContents from '@/components/table-of-contents';
+import { Button } from '@/components/ui/button';
+import { useCurrentUrl } from '@/hooks/use-current-url';
 import { useMarkdownToc } from '@/hooks/use-markdown-toc';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { login } from '@/routes';
-import {
-    edit as adminPostEdit,
-    index as adminPosts,
-} from '@/routes/admin/posts';
+import { dashboard, login } from '@/routes';
+import { edit as adminPostEdit } from '@/routes/admin/posts';
 import { path as contentPath } from '@/routes/posts';
 
 type PostNamespace = {
@@ -39,6 +38,73 @@ type Post = {
     updated_at: string;
 };
 
+function findHeadingOffset(
+    content: string,
+    headingText: string,
+    level: number,
+): number | null {
+    const normalizedTarget = headingText.trim().toLowerCase();
+
+    if (!normalizedTarget) {
+        return null;
+    }
+
+    const normalizedContent = content.replace(/\r\n/g, '\n');
+    const lines = normalizedContent.split('\n');
+    let offset = 0;
+    let activeFence: string | null = null;
+
+    for (const line of lines) {
+        const trimmedLine = line.trimStart();
+        const fenceMatch = /^(`{3,}|~{3,})/.exec(trimmedLine);
+
+        if (fenceMatch) {
+            const fence = fenceMatch[1];
+            const remainder = trimmedLine.slice(fence.length);
+
+            if (activeFence === null) {
+                activeFence = fence;
+            } else if (
+                fence[0] === activeFence[0] &&
+                fence.length >= activeFence.length &&
+                remainder.trim() === ''
+            ) {
+                activeFence = null;
+            }
+
+            offset +=
+                line.length +
+                (offset + line.length < normalizedContent.length ? 1 : 0);
+
+            continue;
+        }
+
+        if (activeFence !== null) {
+            offset +=
+                line.length +
+                (offset + line.length < normalizedContent.length ? 1 : 0);
+
+            continue;
+        }
+
+        const match = /^(#{1,6})\s+(.+?)(?:\s+#+\s*)?$/.exec(trimmedLine);
+
+        if (
+            match &&
+            match[1].length === level &&
+            match[2].trim().toLowerCase() === normalizedTarget
+        ) {
+            return offset;
+        }
+
+        offset +=
+            line.length +
+            (offset + line.length < normalizedContent.length ? 1 : 0);
+    }
+
+    return null;
+}
+
 export default function Show({
     breadcrumbs,
     cardImage,
@@ -57,11 +123,47 @@ export default function Show({
     const { auth } = usePage<{
         auth: { user: { id: number; name: string } | null };
     }>().props;
+    const { currentUrl } = useCurrentUrl();
+    const handleEditHeading = ({
+        level,
+        text,
+        id,
+    }: {
+        level: number;
+        text: string;
+        id: string;
+    }) => {
+        const offset = findHeadingOffset(post.content, text, level);
+
+        router.visit(
+            adminPostEdit.url(
+                {
+                    namespace: namespace.id,
+                    post: post.slug,
+                },
+                {
+                    query: {
+                        ...(typeof offset === 'number' ? { jump: offset } : {}),
+                        return_heading: id,
+                        return_to: currentUrl,
+                    },
+                },
+            ),
+        );
+    };
     const tocPosts = useMemo(
         () => [{ slug: post.slug, content: post.content }],
         [post.content, post.slug],
     );
-    const toc = useMarkdownToc(tocPosts);
+    const toc = useMarkdownToc(
+        tocPosts,
+        auth.user
+            ? {
+                  headingAnchorPlacement: 'gutter',
+                  onEditHeading: handleEditHeading,
+              }
+            : {},
+    );
     const entry = toc.get(post.slug);
     const isMobile = useIsMobile();
     const [tocOverride, setTocOverride] = useState<boolean | null>(null);
@@ -188,29 +290,39 @@ export default function Show({
                             )}
                             {auth.user ? (
                                 <>
-                                    <Link
-                                        href={adminPostEdit.url({
-                                            namespace: namespace.id,
-                                            post: post.slug,
-                                        })}
-                                        className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-                                    >
-                                        Edit
-                                    </Link>
-                                    <Link
-                                        href={adminPosts.url()}
-                                        className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-                                    >
-                                        Admin
-                                    </Link>
+                                    <Button asChild variant="outline" size="sm">
+                                        <Link
+                                            href={adminPostEdit.url(
+                                                {
+                                                    namespace: namespace.id,
+                                                    post: post.slug,
+                                                },
+                                                {
+                                                    query: {
+                                                        return_to: currentUrl,
+                                                    },
+                                                },
+                                            )}
+                                        >
+                                            Edit Page
+                                        </Link>
+                                    </Button>
+                                    <Button asChild variant="outline" size="sm">
+                                        <Link href={dashboard()}>
+                                            Dashboard
+                                        </Link>
+                                    </Button>
                                 </>
                             ) : (
-                                <Link
-                                    href={login.url()}
-                                    className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-                                >
-                                    Login
-                                </Link>
+                                <Button asChild variant="outline" size="sm">
+                                    <Link
+                                        href={login.url({
+                                            query: { intended: currentUrl },
+                                        })}
+                                    >
+                                        Login
+                                    </Link>
+                                </Button>
                             )}
                         </div>
                     </div>

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -1,25 +1,29 @@
 import { Head, Link, router, usePage } from '@inertiajs/react';
-import { siX } from 'simple-icons';
 import {
     AlertTriangle,
+    ArrowRightLeft,
     ChevronRight,
     PanelLeftClose,
     PanelLeftOpen,
     PanelRightClose,
     PanelRightOpen,
-    Settings2,
 } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { siX } from 'simple-icons';
 import type { ContentNavNode } from '@/components/content-nav-tree';
 import ContentNavTree from '@/components/content-nav-tree';
 import MarkdownContent from '@/components/markdown-content';
 import TableOfContents from '@/components/table-of-contents';
 import { Button } from '@/components/ui/button';
+import ViewContextBadge from '@/components/view-context-badge';
 import { useCurrentUrl } from '@/hooks/use-current-url';
 import { useMarkdownToc } from '@/hooks/use-markdown-toc';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { dashboard, login } from '@/routes';
-import { edit as adminPostEdit } from '@/routes/admin/posts';
+import { login } from '@/routes';
+import {
+    edit as adminPostEdit,
+    show as adminPostShow,
+} from '@/routes/admin/posts';
 import { path as contentPath } from '@/routes/posts';
 
 type PostNamespace = {
@@ -343,34 +347,24 @@ export default function Show({
                                 </button>
                             )}
                             {auth.user ? (
-                                <>
+                                <div className="flex flex-wrap items-center gap-2">
                                     <Button asChild variant="outline" size="sm">
                                         <Link
-                                            href={adminPostEdit.url(
-                                                {
-                                                    namespace: namespace.id,
-                                                    post: post.slug,
-                                                },
-                                                {
-                                                    query: {
-                                                        return_to: currentUrl,
-                                                    },
-                                                },
-                                            )}
-                                        >
-                                            Edit Page
-                                        </Link>
-                                    </Button>
-                                    <Button asChild variant="outline" size="sm">
-                                        <Link
-                                            href={dashboard()}
+                                            href={adminPostShow.url({
+                                                namespace: namespace.id,
+                                                post: post.slug,
+                                            })}
                                             className="inline-flex items-center gap-1.5"
                                         >
-                                            <Settings2 className="size-4" />
+                                            <ArrowRightLeft className="size-4" />
                                             Manage
                                         </Link>
                                     </Button>
-                                </>
+                                    <ViewContextBadge
+                                        label="Site View"
+                                        variant="site"
+                                    />
+                                </div>
                             ) : (
                                 <Button asChild variant="outline" size="sm">
                                     <Link

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -1,11 +1,13 @@
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import { siX } from 'simple-icons';
 import {
+    AlertTriangle,
     ChevronRight,
     PanelLeftClose,
     PanelLeftOpen,
     PanelRightClose,
     PanelRightOpen,
+    Settings2,
 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import type { ContentNavNode } from '@/components/content-nav-tree';
@@ -105,6 +107,11 @@ function findHeadingOffset(
     return null;
 }
 
+type Preview = {
+    status: 'draft' | 'scheduled';
+    published_at: string | null;
+} | null;
+
 export default function Show({
     breadcrumbs,
     cardImage,
@@ -112,6 +119,7 @@ export default function Show({
     namespace,
     post,
     postUrl,
+    preview = null,
 }: {
     breadcrumbs: Array<{ name: string; full_path: string }>;
     cardImage: string | null;
@@ -119,6 +127,7 @@ export default function Show({
     namespace: PostNamespace;
     post: Post;
     postUrl: string;
+    preview?: Preview;
 }) {
     const { auth } = usePage<{
         auth: { user: { id: number; name: string } | null };
@@ -208,6 +217,51 @@ export default function Show({
             </Head>
 
             <div className="min-h-screen bg-background">
+                {preview && (
+                    <div
+                        className={`sticky top-0 z-[60] border-b px-4 py-3 ${preview.status === 'draft' ? 'border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-900/40' : 'border-blue-300 bg-blue-50 dark:border-blue-700 dark:bg-blue-900/40'}`}
+                    >
+                        <div className="mx-auto flex max-w-7xl items-center gap-3">
+                            <AlertTriangle
+                                className={`size-5 shrink-0 ${preview.status === 'draft' ? 'text-amber-600 dark:text-amber-400' : 'text-blue-600 dark:text-blue-400'}`}
+                            />
+                            <div
+                                className={`flex flex-wrap items-baseline gap-x-2 text-sm font-semibold ${preview.status === 'draft' ? 'text-amber-800 dark:text-amber-300' : 'text-blue-800 dark:text-blue-300'}`}
+                            >
+                                {preview.status === 'draft' ? (
+                                    <>
+                                        <span className="tracking-wide uppercase">
+                                            Draft
+                                        </span>
+                                        <span className="font-normal opacity-80">
+                                            This post is not published. Only
+                                            logged-in users can see this
+                                            preview.
+                                        </span>
+                                    </>
+                                ) : (
+                                    <>
+                                        <span className="tracking-wide uppercase">
+                                            Scheduled
+                                        </span>
+                                        <span className="font-normal opacity-80">
+                                            Publishes on{' '}
+                                            {preview.published_at &&
+                                                new Date(
+                                                    preview.published_at,
+                                                ).toLocaleString(undefined, {
+                                                    dateStyle: 'long',
+                                                    timeStyle: 'short',
+                                                })}
+                                            . Only logged-in users can see this
+                                            preview.
+                                        </span>
+                                    </>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                )}
                 {namespace.cover_image_url && (
                     <div className="h-48 w-full overflow-hidden md:h-64">
                         <img
@@ -308,8 +362,12 @@ export default function Show({
                                         </Link>
                                     </Button>
                                     <Button asChild variant="outline" size="sm">
-                                        <Link href={dashboard()}>
-                                            Dashboard
+                                        <Link
+                                            href={dashboard()}
+                                            className="inline-flex items-center gap-1.5"
+                                        >
+                                            <Settings2 className="size-4" />
+                                            Manage
                                         </Link>
                                     </Button>
                                 </>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -13,6 +13,8 @@ Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () 
     Route::prefix('posts')->name('posts.')->group(function () {
         Route::get('/', [PostController::class, 'index'])->name('index');
         Route::get('/{namespace}', [PostController::class, 'namespaceIndex'])->name('namespace');
+        Route::patch('/{namespace}/reorder-posts', [PostController::class, 'reorderPosts'])->name('reorderPosts');
+        Route::patch('/{namespace}/reorder-namespaces', [PostController::class, 'reorderNamespaces'])->name('reorderNamespaces');
         Route::get('/{namespace}/create', [PostController::class, 'create'])->name('create');
         Route::post('/{namespace}/image', [PostController::class, 'uploadNamespaceImage'])->name('uploadNamespaceImage');
         Route::post('/{namespace}', [PostController::class, 'store'])->name('store');

--- a/tests-node/markdown/delete-confirmation.test.ts
+++ b/tests-node/markdown/delete-confirmation.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { matchesDeleteConfirmation } from '../../resources/js/lib/delete-confirmation.ts';
+
+test('matchesDeleteConfirmation requires the exact namespace name', () => {
+    assert.equal(matchesDeleteConfirmation('Guides', 'Guides'), true);
+    assert.equal(matchesDeleteConfirmation('guides', 'Guides'), false);
+    assert.equal(matchesDeleteConfirmation('Guides ', 'Guides'), true);
+    assert.equal(matchesDeleteConfirmation(' Guides', 'Guides'), true);
+});

--- a/tests/Feature/Admin/NamespaceControllerTest.php
+++ b/tests/Feature/Admin/NamespaceControllerTest.php
@@ -96,6 +96,27 @@ test('storing a namespace rejects reserved slugs', function (string $slug) {
     ReservedContentPath::ROOT_SEGMENTS,
 ));
 
+test('storing a child namespace allows reserved slugs', function (string $slug) {
+    $user = User::factory()->create();
+    $parent = PostNamespace::factory()->create(['slug' => 'guides']);
+
+    $this->actingAs($user)
+        ->post(route('admin.namespaces.store'), [
+            'parent_id' => $parent->id,
+            'slug' => $slug,
+            'name' => ucfirst($slug),
+        ])
+        ->assertRedirect(route('admin.posts.index'));
+
+    $this->assertDatabaseHas('namespaces', [
+        'parent_id' => $parent->id,
+        'slug' => $slug,
+    ]);
+})->with(fn (): array => array_combine(
+    ReservedContentPath::ROOT_SEGMENTS,
+    ReservedContentPath::ROOT_SEGMENTS,
+));
+
 test('updating a namespace rejects reserved slugs', function (string $slug) {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create(['slug' => 'guides']);
@@ -103,6 +124,32 @@ test('updating a namespace rejects reserved slugs', function (string $slug) {
     $this->actingAs($user)
         ->put(route('admin.namespaces.update', $namespace), ['slug' => $slug, 'name' => ucfirst($slug)])
         ->assertSessionHasErrors('slug');
+})->with(fn (): array => array_combine(
+    ReservedContentPath::ROOT_SEGMENTS,
+    ReservedContentPath::ROOT_SEGMENTS,
+));
+
+test('updating a child namespace allows reserved slugs', function (string $slug) {
+    $user = User::factory()->create();
+    $parent = PostNamespace::factory()->create(['slug' => 'guides']);
+    $namespace = PostNamespace::factory()->create([
+        'parent_id' => $parent->id,
+        'slug' => 'child',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.namespaces.update', $namespace), [
+            'parent_id' => $parent->id,
+            'slug' => $slug,
+            'name' => ucfirst($slug),
+        ])
+        ->assertRedirect(route('admin.posts.index'));
+
+    $this->assertDatabaseHas('namespaces', [
+        'id' => $namespace->id,
+        'parent_id' => $parent->id,
+        'slug' => $slug,
+    ]);
 })->with(fn (): array => array_combine(
     ReservedContentPath::ROOT_SEGMENTS,
     ReservedContentPath::ROOT_SEGMENTS,
@@ -200,6 +247,39 @@ test('authenticated users can update a namespace', function () {
     expect($namespace->fresh()->slug)->toBe('new-slug');
     expect($namespace->fresh()->name)->toBe('New Name');
     expect($namespace->fresh()->description)->toBe('Updated description');
+});
+
+test('updating a namespace redirects back to the updated canonical section page', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'full_path' => 'guides',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.namespaces.update', $namespace), [
+            'slug' => 'manuals',
+            'name' => 'Manuals',
+            'description' => 'Updated description',
+            'return_to' => '/guides',
+        ])
+        ->assertRedirect('/manuals');
+
+    expect($namespace->fresh()->slug)->toBe('manuals');
+    expect($namespace->fresh()->full_path)->toBe('manuals');
+});
+
+test('updating a namespace ignores unsafe return paths', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create(['slug' => 'guides']);
+
+    $this->actingAs($user)
+        ->put(route('admin.namespaces.update', $namespace), [
+            'slug' => 'guides',
+            'name' => 'Guides',
+            'return_to' => 'https://example.com/phish',
+        ])
+        ->assertRedirect(route('admin.posts.index'));
 });
 
 test('updating a namespace allows keeping the same slug', function () {

--- a/tests/Feature/Admin/NamespaceControllerTest.php
+++ b/tests/Feature/Admin/NamespaceControllerTest.php
@@ -372,6 +372,51 @@ test('authenticated users can delete a namespace', function () {
     expect($namespace->fresh())->toBeNull();
 });
 
+test('deleting a namespace also deletes its posts', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->create(['namespace_id' => $namespace->id]);
+
+    $this->actingAs($user)
+        ->delete(route('admin.namespaces.destroy', $namespace))
+        ->assertRedirect(route('admin.posts.index'));
+
+    expect($namespace->fresh())->toBeNull();
+    expect($post->fresh())->toBeNull();
+});
+
+test('deleting a namespace recursively deletes child namespaces', function () {
+    $user = User::factory()->create();
+    $parent = PostNamespace::factory()->create();
+    $child = PostNamespace::factory()->create(['parent_id' => $parent->id]);
+
+    $this->actingAs($user)
+        ->delete(route('admin.namespaces.destroy', $parent))
+        ->assertRedirect(route('admin.posts.index'));
+
+    expect($parent->fresh())->toBeNull();
+    expect($child->fresh())->toBeNull();
+});
+
+test('deleting a namespace recursively deletes child namespaces and their posts', function () {
+    $user = User::factory()->create();
+    $parent = PostNamespace::factory()->create();
+    $child = PostNamespace::factory()->create(['parent_id' => $parent->id]);
+    $grandchild = PostNamespace::factory()->create(['parent_id' => $child->id]);
+    $post = Post::factory()->create(['namespace_id' => $child->id]);
+    $grandchildPost = Post::factory()->create(['namespace_id' => $grandchild->id]);
+
+    $this->actingAs($user)
+        ->delete(route('admin.namespaces.destroy', $parent))
+        ->assertRedirect(route('admin.posts.index'));
+
+    expect($parent->fresh())->toBeNull();
+    expect($child->fresh())->toBeNull();
+    expect($grandchild->fresh())->toBeNull();
+    expect($post->fresh())->toBeNull();
+    expect($grandchildPost->fresh())->toBeNull();
+});
+
 test('storing a namespace can set is_published to false', function () {
     $user = User::factory()->create();
 

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -370,6 +370,49 @@ test('updating a post redirects back to the requested heading fragment', functio
         ->assertRedirect(route('admin.posts.show', [$namespace, 'my-slug']).'#my-slug-section-title');
 });
 
+test('updating a post redirects back to the updated canonical page', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create(['slug' => 'guides', 'full_path' => 'guides']);
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'my-slug',
+        'full_path' => 'guides/my-slug',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.posts.update', [$namespace, $post]), [
+            'title' => 'Updated Title',
+            'slug' => 'updated-slug',
+            'content' => 'Updated content.',
+            'return_heading' => 'updated-slug-section-title',
+            'return_to' => '/guides/my-slug',
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect('/guides/updated-slug#updated-slug-section-title');
+
+    expect($post->fresh()->slug)->toBe('updated-slug');
+    expect($post->fresh()->full_path)->toBe('guides/updated-slug');
+});
+
+test('updating a post ignores unsafe return paths', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'my-slug',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.posts.update', [$namespace, $post]), [
+            'title' => 'Updated Title',
+            'slug' => 'my-slug',
+            'content' => 'Updated content.',
+            'return_to' => 'https://example.com/phish',
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('admin.posts.show', [$namespace, 'my-slug']));
+});
+
 test('updating a post rejects a slug used by a child namespace in the same namespace', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create(['slug' => 'guide']);

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -177,6 +177,138 @@ test('namespace post list prefers canonical urls for live posts and admin urls f
         );
 });
 
+test('authenticated users can reorder posts while preserving child namespace order', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'post_order' => ['child-alpha', 'first-post', 'child-beta', 'second-post'],
+    ]);
+    PostNamespace::factory()->create([
+        'parent_id' => $namespace->id,
+        'slug' => 'child-alpha',
+    ]);
+    PostNamespace::factory()->create([
+        'parent_id' => $namespace->id,
+        'slug' => 'child-beta',
+    ]);
+    $firstPost = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'first-post',
+    ]);
+    $secondPost = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'second-post',
+    ]);
+
+    $this->actingAs($user)
+        ->from(route('admin.posts.namespace', $namespace))
+        ->patch(route('admin.posts.reorderPosts', $namespace), [
+            'slugs' => [$secondPost->slug, $firstPost->slug],
+        ])
+        ->assertRedirect(route('admin.posts.namespace', $namespace))
+        ->assertSessionHasNoErrors();
+
+    expect($namespace->fresh()->post_order)->toBe([
+        'child-alpha',
+        'child-beta',
+        'second-post',
+        'first-post',
+    ]);
+});
+
+test('reordering posts rejects slugs outside the namespace posts', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'post_order' => ['child-alpha', 'first-post'],
+    ]);
+    PostNamespace::factory()->create([
+        'parent_id' => $namespace->id,
+        'slug' => 'child-alpha',
+    ]);
+    Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'first-post',
+    ]);
+    $foreignPost = Post::factory()->for($user)->create([
+        'slug' => 'foreign-post',
+    ]);
+
+    $this->actingAs($user)
+        ->from(route('admin.posts.namespace', $namespace))
+        ->patch(route('admin.posts.reorderPosts', $namespace), [
+            'slugs' => [$foreignPost->slug],
+        ])
+        ->assertRedirect(route('admin.posts.namespace', $namespace))
+        ->assertSessionHasErrors('slugs.0');
+
+    expect($namespace->fresh()->post_order)->toBe(['child-alpha', 'first-post']);
+});
+
+test('authenticated users can reorder child namespaces while preserving post order', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'post_order' => ['child-alpha', 'first-post', 'child-beta', 'second-post'],
+    ]);
+    $firstChild = PostNamespace::factory()->create([
+        'parent_id' => $namespace->id,
+        'slug' => 'child-alpha',
+    ]);
+    $secondChild = PostNamespace::factory()->create([
+        'parent_id' => $namespace->id,
+        'slug' => 'child-beta',
+    ]);
+    Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'first-post',
+    ]);
+    Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'second-post',
+    ]);
+
+    $this->actingAs($user)
+        ->from(route('admin.posts.namespace', $namespace))
+        ->patch(route('admin.posts.reorderNamespaces', $namespace), [
+            'slugs' => [$secondChild->slug, $firstChild->slug],
+        ])
+        ->assertRedirect(route('admin.posts.namespace', $namespace))
+        ->assertSessionHasNoErrors();
+
+    expect($namespace->fresh()->post_order)->toBe([
+        'child-beta',
+        'child-alpha',
+        'first-post',
+        'second-post',
+    ]);
+});
+
+test('reordering child namespaces rejects slugs outside the namespace children', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'post_order' => ['child-alpha', 'first-post'],
+    ]);
+    PostNamespace::factory()->create([
+        'parent_id' => $namespace->id,
+        'slug' => 'child-alpha',
+    ]);
+    Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'first-post',
+    ]);
+    $foreignChild = PostNamespace::factory()->create([
+        'slug' => 'foreign-child',
+    ]);
+
+    $this->actingAs($user)
+        ->from(route('admin.posts.namespace', $namespace))
+        ->patch(route('admin.posts.reorderNamespaces', $namespace), [
+            'slugs' => [$foreignChild->slug],
+        ])
+        ->assertRedirect(route('admin.posts.namespace', $namespace))
+        ->assertSessionHasErrors('slugs.0');
+
+    expect($namespace->fresh()->post_order)->toBe(['child-alpha', 'first-post']);
+});
+
 test('authenticated users can view the create form', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create([

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -143,11 +143,54 @@ test('namespace post list defaults to latest posts when no custom order exists',
         );
 });
 
+test('namespace post list prefers canonical urls for live posts and admin urls for unpublished posts', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'full_path' => 'guides',
+    ]);
+    $livePost = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'live-post',
+        'full_path' => 'guides/live-post',
+        'is_draft' => false,
+        'published_at' => now()->subMinute(),
+    ]);
+    $draftPost = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'draft-post',
+        'full_path' => 'guides/draft-post',
+        'is_draft' => true,
+        'published_at' => null,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.namespace', $namespace))
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/namespace')
+            ->where('posts.0.id', $draftPost->id)
+            ->where('posts.0.canonical_url', null)
+            ->where('posts.0.admin_url', route('admin.posts.show', [$namespace, $draftPost], false))
+            ->where('posts.1.id', $livePost->id)
+            ->where('posts.1.canonical_url', '/guides/live-post')
+            ->where('posts.1.admin_url', route('admin.posts.show', [$namespace, $livePost], false))
+        );
+});
+
 test('authenticated users can view the create form', function () {
     $user = User::factory()->create();
-    $namespace = PostNamespace::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'full_path' => 'guides',
+    ]);
 
-    $this->actingAs($user)->get(route('admin.posts.create', $namespace))->assertOk();
+    $this->actingAs($user)
+        ->get(route('admin.posts.create', $namespace))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/create')
+            ->where('slugPrefix', 'guides/')
+        );
 });
 
 test('create form exposes a slug prefix for nested namespaces', function () {
@@ -169,6 +212,27 @@ test('create form exposes a slug prefix for nested namespaces', function () {
             ->component('admin/posts/create')
             ->where('namespace.id', $namespace->id)
             ->where('slugPrefix', 'guides/laravel/')
+        );
+});
+
+test('edit form exposes a slug prefix for root namespaces', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'full_path' => 'guides',
+    ]);
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'test',
+        'full_path' => 'guides/test',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.edit', [$namespace, $post]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/edit')
+            ->where('slugPrefix', 'guides/')
         );
 });
 
@@ -198,6 +262,25 @@ test('authenticated users can store a post', function () {
     ]);
 
     expect(Post::query()->where('slug', 'hello-world')->value('published_at'))->not->toBeNull();
+});
+
+test('storing a post redirects back to the canonical page when entered from a canonical namespace', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'full_path' => 'guides',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('admin.posts.store', $namespace), [
+            'title' => 'Hello World',
+            'slug' => 'hello-world',
+            'content' => '# Hello',
+            'published_at' => null,
+            'return_to' => '/guides',
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect('/guides/hello-world');
 });
 
 test('storing a post requires a title', function () {
@@ -323,11 +406,7 @@ test('authenticated users can update a post', function () {
             'published_at' => null,
         ])
         ->assertSessionHasNoErrors()
-        ->assertSessionHas('inertia.flash_data.toast', [
-            'type' => 'success',
-            'message' => 'Post saved.',
-        ])
-        ->assertRedirect(route('admin.posts.show', [$namespace, 'new-slug']));
+        ->assertRedirect(route('admin.posts.edit', [$namespace, 'new-slug']));
 
     $post->refresh();
     expect($post->title)->toBe('New Title');
@@ -346,7 +425,7 @@ test('updating a post allows keeping the same slug', function () {
             'slug' => 'my-slug',
             'content' => 'Updated content.',
         ])
-        ->assertRedirect(route('admin.posts.show', [$namespace, 'my-slug']));
+        ->assertRedirect(route('admin.posts.edit', [$namespace, 'my-slug']));
 
     expect($post->fresh()->slug)->toBe('my-slug');
 });
@@ -367,7 +446,7 @@ test('updating a post redirects back to the requested heading fragment', functio
             'return_heading' => 'my-slug-section-title',
         ])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(route('admin.posts.show', [$namespace, 'my-slug']).'#my-slug-section-title');
+        ->assertRedirect(route('admin.posts.edit', [$namespace, 'my-slug']).'#my-slug-section-title');
 });
 
 test('updating a post redirects back to the updated canonical page', function () {
@@ -410,7 +489,7 @@ test('updating a post ignores unsafe return paths', function () {
             'return_to' => 'https://example.com/phish',
         ])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(route('admin.posts.show', [$namespace, 'my-slug']));
+        ->assertRedirect(route('admin.posts.edit', [$namespace, 'my-slug']));
 });
 
 test('updating a post rejects a slug used by a child namespace in the same namespace', function () {

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -33,6 +33,34 @@ test('users can authenticate using the login screen', function () {
     $response->assertRedirect(route('dashboard', absolute: false));
 });
 
+test('users are redirected to the intended canonical page after logging in from the login screen', function () {
+    $user = User::factory()->create();
+
+    $this->get(route('login', ['intended' => '/guides']));
+
+    $response = $this->post(route('login.store'), [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
+
+    $this->assertAuthenticated();
+    $response->assertRedirect('/guides');
+});
+
+test('external intended paths are ignored on the login screen', function () {
+    $user = User::factory()->create();
+
+    $this->get(route('login', ['intended' => 'https://example.com/phish']));
+
+    $response = $this->post(route('login.store'), [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
+
+    $this->assertAuthenticated();
+    $response->assertRedirect(route('dashboard', absolute: false));
+});
+
 test('users with two factor enabled are redirected to two factor challenge', function () {
     $this->skipUnlessFortifyHas(Features::twoFactorAuthentication());
 

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Post;
 use App\Models\PostNamespace;
+use App\Models\User;
 use App\Support\ReservedContentPath;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -56,6 +57,8 @@ test('published namespace shows child namespaces and direct posts', function () 
     $namespace = PostNamespace::factory()->create([
         'is_published' => true,
         'slug' => 'guides',
+        'name' => 'Guides',
+        'description' => 'Practical guides for the canonical namespace page.',
     ]);
     $child = PostNamespace::factory()->create([
         'parent_id' => $namespace->id,
@@ -75,12 +78,47 @@ test('published namespace shows child namespaces and direct posts', function () 
         ->assertInertia(fn ($page) => $page
             ->component('posts/namespace')
             ->where('namespace.full_path', $namespace->full_path)
+            ->where('namespace.name', 'Guides')
+            ->where('namespace.description', 'Practical guides for the canonical namespace page.')
+            ->where('namespace.is_published', true)
             ->where('navRoot.full_path', $namespace->full_path)
             ->has('children', 1)
             ->where('navRoot.children.0.full_path', $child->full_path)
             ->where('children.0.full_path', $child->full_path)
             ->where('posts.0.full_path', $post->full_path)
             ->where('navRoot.posts.0.full_path', $post->full_path)
+        );
+});
+
+test('guest namespace page receives no authenticated user', function () {
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'is_published' => true,
+    ]);
+
+    $this->get(route('posts.path', ['path' => $namespace->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/namespace')
+            ->where('auth.user', null)
+        );
+});
+
+test('authenticated namespace page receives the current user for canonical controls', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'is_published' => true,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('posts.path', ['path' => $namespace->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/namespace')
+            ->where('auth.user.id', $user->id)
+            ->where('auth.user.name', $user->name)
+            ->where('namespace.id', $namespace->id)
         );
 });
 
@@ -154,6 +192,44 @@ test('published namespace shows post with breadcrumbs', function () {
             ->where('postUrl', route('posts.path', ['path' => $post->full_path]))
             ->where('breadcrumbs.0.full_path', $root->full_path)
             ->where('posts.0.full_path', $post->full_path)
+        );
+});
+
+test('guest post page receives no authenticated user', function () {
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'is_published' => true,
+    ]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'slug' => 'routing',
+    ]);
+
+    $this->get(route('posts.path', ['path' => $post->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/show')
+            ->where('auth.user', null)
+        );
+});
+
+test('authenticated post page receives the current user for canonical controls', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'is_published' => true,
+    ]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'slug' => 'routing',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('posts.path', ['path' => $post->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/show')
+            ->where('auth.user.id', $user->id)
+            ->where('auth.user.name', $user->name)
+            ->where('post.id', $post->id)
         );
 });
 

--- a/tests/Feature/SyntaxSeederTest.php
+++ b/tests/Feature/SyntaxSeederTest.php
@@ -121,3 +121,29 @@ test('routing check seeder creates wildcard routing lookalike namespaces', funct
     expect($administratorPost->content)->toContain('/administrator');
     expect($administratorPost->content)->toContain('/admin/*');
 });
+
+test('syntax seeder creates the meta namespace article for content url unification handoff', function () {
+    $this->seed(SyntaxSeeder::class);
+
+    $namespace = PostNamespace::query()
+        ->where('slug', 'meta')
+        ->first();
+
+    expect($namespace)->not->toBeNull();
+    expect($namespace->name)->toBe('Meta');
+    expect($namespace->post_order)->toContain('content-url-unification-handoff');
+
+    $post = Post::query()
+        ->where('namespace_id', $namespace->id)
+        ->where('slug', 'content-url-unification-handoff')
+        ->first();
+
+    expect($post)->not->toBeNull();
+    expect($post->title)->toBe('Content URL 統一ハンドオフ');
+    expect($post->content)->toContain('# Content URL 統一ハンドオフ');
+    expect($post->content)->toContain('## 現在の評価');
+    expect($post->content)->toContain('canonical post page から直接 edit に入れる');
+    expect($post->content)->toContain('いまの主問題は、「同じコンテンツに URL が 2 つあること」そのものではありません。');
+    expect($post->content)->toContain('admin namespace post table が `canonical_url` を尊重するように揃える');
+    expect($post->published_at)->not->toBeNull();
+});

--- a/tsconfig.markdown-tests.json
+++ b/tsconfig.markdown-tests.json
@@ -12,6 +12,7 @@
     },
     "include": [
         "resources/js/lib/markdown-card-href.ts",
+        "resources/js/lib/delete-confirmation.ts",
         "resources/js/lib/markdown-syntax-manifest.ts",
         "resources/js/lib/markdown-syntax.ts",
         "resources/js/lib/remark-tabs-directive.ts",


### PR DESCRIPTION
## Summary
- make canonical post and namespace pages the primary edit/preview surface
- recompute admin create and save redirects from current canonical paths and add recursive namespace deletion coverage
- refresh the content URL handoff with current evaluation and next work

## Validation
- vendor/bin/sail artisan test --compact tests/Feature/Admin/PostControllerTest.php tests/Feature/Admin/NamespaceControllerTest.php tests/Feature/PostControllerTest.php
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build
- vendor/bin/sail bin pint --dirty --format agent