### PR TITLE
Improve namespace cover image flow

### DIFF
--- a/app/Http/Controllers/Admin/NamespaceController.php
+++ b/app/Http/Controllers/Admin/NamespaceController.php
@@ -75,6 +75,7 @@ class NamespaceController extends Controller
     public function edit(PostNamespace $namespace): InertiaResponse
     {
         return Inertia::render('admin/namespaces/edit', [
+            'ancestors' => $this->ancestorOptions($namespace),
             'namespace' => $namespace,
         ]);
     }
@@ -92,13 +93,7 @@ class NamespaceController extends Controller
 
         $namespace->update($data);
 
-        $returnTo = $this->safeReturnPath($request->string('return_to')->toString());
-
-        if ($returnTo !== null) {
-            return redirect()->to(route('posts.path', ['path' => $namespace->full_path], absolute: false));
-        }
-
-        return to_route('admin.posts.index');
+        return to_route('admin.posts.namespace', $namespace);
     }
 
     public function destroy(PostNamespace $namespace): RedirectResponse
@@ -108,21 +103,51 @@ class NamespaceController extends Controller
         return to_route('admin.posts.index');
     }
 
-    private function safeReturnPath(string $path): ?string
+    /**
+     * @return array<int, array{id: int, name: string}>
+     */
+    private function ancestorOptions(PostNamespace $namespace): array
     {
-        if ($path === '') {
-            return null;
+        $segments = array_values(array_filter(
+            explode('/', trim($namespace->full_path, '/')),
+            fn (string $segment): bool => $segment !== '',
+        ));
+
+        array_pop($segments);
+
+        if ($segments === []) {
+            return [];
         }
 
-        if (
-            ! str_starts_with($path, '/')
-            || str_starts_with($path, '//')
-            || parse_url($path, PHP_URL_SCHEME) !== null
-            || parse_url($path, PHP_URL_HOST) !== null
-        ) {
-            return null;
+        $paths = [];
+        $currentPath = '';
+
+        foreach ($segments as $segment) {
+            $currentPath = $currentPath === '' ? $segment : "{$currentPath}/{$segment}";
+            $paths[] = $currentPath;
         }
 
-        return $path;
+        $ancestorsByPath = PostNamespace::query()
+            ->whereIn('full_path', $paths)
+            ->get(['id', 'name', 'full_path'])
+            ->keyBy('full_path');
+
+        return collect($paths)
+            ->map(function (string $path) use ($ancestorsByPath): ?array {
+                /** @var ?PostNamespace $ancestor */
+                $ancestor = $ancestorsByPath->get($path);
+
+                if ($ancestor === null) {
+                    return null;
+                }
+
+                return [
+                    'id' => $ancestor->id,
+                    'name' => $ancestor->name,
+                ];
+            })
+            ->filter()
+            ->values()
+            ->all();
     }
 }

--- a/app/Http/Requests/Admin/StoreNamespaceRequest.php
+++ b/app/Http/Requests/Admin/StoreNamespaceRequest.php
@@ -7,6 +7,7 @@ use App\Support\ReservedContentPath;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Validator;
 
 class StoreNamespaceRequest extends FormRequest
@@ -63,8 +64,22 @@ class StoreNamespaceRequest extends FormRequest
             ],
             'name' => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
-            'cover_image' => ['nullable', 'image', 'max:2048'],
+            'cover_image' => [
+                'nullable',
+                File::image()->max(2048),
+                Rule::dimensions()->ratio(16 / 9),
+            ],
             'is_published' => ['boolean'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'cover_image.dimensions' => 'Cover image must use a 16:9 ratio.',
         ];
     }
 

--- a/app/Http/Requests/Admin/UpdateNamespaceRequest.php
+++ b/app/Http/Requests/Admin/UpdateNamespaceRequest.php
@@ -8,6 +8,7 @@ use App\Support\ReservedContentPath;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Validator;
 
 class UpdateNamespaceRequest extends FormRequest
@@ -99,8 +100,22 @@ class UpdateNamespaceRequest extends FormRequest
             ],
             'name' => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
-            'cover_image' => ['nullable', 'image', 'max:2048'],
+            'cover_image' => [
+                'nullable',
+                File::image()->max(2048),
+                Rule::dimensions()->ratio(16 / 9),
+            ],
             'is_published' => ['boolean'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'cover_image.dimensions' => 'Cover image must use a 16:9 ratio.',
         ];
     }
 

--- a/resources/js/components/cover-image-dropzone.tsx
+++ b/resources/js/components/cover-image-dropzone.tsx
@@ -1,7 +1,35 @@
-import { ImageUp, Pencil, X } from 'lucide-react';
+import { ImageMinus, ImagePlus, ImageUp, Pencil, X } from 'lucide-react';
+import type { CSSProperties } from 'react';
 import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
 import InputError from '@/components/input-error';
 import { cn } from '@/lib/utils';
+
+const COVER_IMAGE_ASPECT_RATIO = 16 / 9;
+const CROP_STAGE_ASPECT_RATIO = 5 / 4;
+const MAX_EXPORT_WIDTH = 1600;
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 3;
+const CROP_FRAME_WIDTH_PERCENT = 78;
+const CROP_FRAME_HEIGHT_PERCENT =
+    (CROP_FRAME_WIDTH_PERCENT * CROP_STAGE_ASPECT_RATIO) /
+    COVER_IMAGE_ASPECT_RATIO;
+const MOBILE_HEADER_ASPECT_RATIO = 390 / 192;
+const DESKTOP_HEADER_ASPECT_RATIO = 1248 / 256;
+const BACKGROUND_PRESETS = [
+    { key: 'transparent', label: 'Transparent', color: null },
+    { key: 'white', label: 'White', color: '#ffffff' },
+    { key: 'black', label: 'Black', color: '#09090b' },
+    { key: 'custom', label: 'Custom', color: null },
+] as const;
 
 type Props = {
     id?: string;
@@ -10,6 +38,15 @@ type Props = {
     onChange?: (file: File | null) => void;
     error?: string;
 };
+
+type CropDraft = {
+    file: File;
+    url: string;
+    width: number;
+    height: number;
+};
+
+type BackgroundPreset = (typeof BACKGROUND_PRESETS)[number]['key'];
 
 export default function CoverImageDropzone({
     id,
@@ -21,11 +58,31 @@ export default function CoverImageDropzone({
     const inputRef = useRef<HTMLInputElement>(null);
     const [isDragging, setIsDragging] = useState(false);
     const [preview, setPreview] = useState<string | null>(null);
+    const [cropDraft, setCropDraft] = useState<CropDraft | null>(null);
+    const [cropPosition, setCropPosition] = useState(50);
+    const [zoom, setZoom] = useState(1);
+    const [headerPreviewViewport, setHeaderPreviewViewport] = useState<
+        'mobile' | 'desktop'
+    >('desktop');
+    const [showHeaderPreview, setShowHeaderPreview] = useState(false);
+    const [backgroundPreset, setBackgroundPreset] =
+        useState<BackgroundPreset>('transparent');
+    const [customBackgroundColor, setCustomBackgroundColor] =
+        useState('#f5f5f5');
     const dragCounterRef = useRef(0);
     const previewUrlRef = useRef<string | null>(null);
     const inputId = id ?? name;
 
     const displayImage = preview ?? currentImageUrl ?? null;
+    const hasExistingImage = currentImageUrl !== null;
+    const hasReplacementPreview = preview !== null;
+    const sourceRatio = cropDraft ? cropDraft.width / cropDraft.height : null;
+    const isLandscapeCrop =
+        cropDraft !== null &&
+        cropDraft.width / cropDraft.height > COVER_IMAGE_ASPECT_RATIO;
+    const needsCropAdjustment =
+        sourceRatio !== null &&
+        Math.abs(sourceRatio - COVER_IMAGE_ASPECT_RATIO) > 0.01;
 
     useEffect(() => {
         return () => {
@@ -34,6 +91,14 @@ export default function CoverImageDropzone({
             }
         };
     }, []);
+
+    useEffect(() => {
+        return () => {
+            if (cropDraft?.url) {
+                URL.revokeObjectURL(cropDraft.url);
+            }
+        };
+    }, [cropDraft]);
 
     function replacePreview(nextUrl: string | null) {
         if (previewUrlRef.current) {
@@ -44,19 +109,281 @@ export default function CoverImageDropzone({
         setPreview(nextUrl);
     }
 
-    function handleFile(file: File) {
+    function basePreviewSize() {
+        if (!sourceRatio) {
+            return { width: 100, height: 100 };
+        }
+
+        if (sourceRatio > COVER_IMAGE_ASPECT_RATIO) {
+            return {
+                width: 100,
+                height: (COVER_IMAGE_ASPECT_RATIO / sourceRatio) * 100,
+            };
+        }
+
+        if (sourceRatio < COVER_IMAGE_ASPECT_RATIO) {
+            return {
+                width: (sourceRatio / COVER_IMAGE_ASPECT_RATIO) * 100,
+                height: 100,
+            };
+        }
+
+        return { width: 100, height: 100 };
+    }
+
+    function framePreviewSize() {
+        const previewSize = basePreviewSize();
+
+        return {
+            width: previewSize.width * zoom,
+            height: previewSize.height * zoom,
+        };
+    }
+
+    function headerImageFrame(containerAspectRatio: number): {
+        width: number;
+        height: number;
+        left: number;
+        top: number;
+    } {
+        if (containerAspectRatio > COVER_IMAGE_ASPECT_RATIO) {
+            const height =
+                (containerAspectRatio / COVER_IMAGE_ASPECT_RATIO) * 100;
+
+            return {
+                width: 100,
+                height,
+                left: 0,
+                top: (100 - height) / 2,
+            };
+        }
+
+        const width = (COVER_IMAGE_ASPECT_RATIO / containerAspectRatio) * 100;
+
+        return {
+            width,
+            height: 100,
+            left: (100 - width) / 2,
+            top: 0,
+        };
+    }
+
+    function resolvedBackgroundColor(): string | null {
+        if (backgroundPreset === 'custom') {
+            return customBackgroundColor;
+        }
+
+        return (
+            BACKGROUND_PRESETS.find(
+                (background) => background.key === backgroundPreset,
+            )?.color ?? null
+        );
+    }
+
+    function previewBackgroundStyle(): CSSProperties {
+        const color = resolvedBackgroundColor();
+
+        if (color) {
+            return { backgroundColor: color };
+        }
+
+        return {
+            backgroundColor: '#ffffff',
+            backgroundImage:
+                'linear-gradient(45deg, #e5e7eb 25%, transparent 25%), linear-gradient(-45deg, #e5e7eb 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #e5e7eb 75%), linear-gradient(-45deg, transparent 75%, #e5e7eb 75%)',
+            backgroundPosition: '0 0, 0 10px, 10px -10px, -10px 0px',
+            backgroundSize: '20px 20px',
+        };
+    }
+
+    async function readImageSize(file: File): Promise<{
+        width: number;
+        height: number;
+    }> {
+        const objectUrl = URL.createObjectURL(file);
+
+        try {
+            const image = await new Promise<HTMLImageElement>(
+                (resolve, reject) => {
+                    const nextImage = new Image();
+                    nextImage.onload = () => resolve(nextImage);
+                    nextImage.onerror = () =>
+                        reject(new Error('Unable to load image.'));
+                    nextImage.src = objectUrl;
+                },
+            );
+
+            return {
+                width: image.naturalWidth,
+                height: image.naturalHeight,
+            };
+        } finally {
+            URL.revokeObjectURL(objectUrl);
+        }
+    }
+
+    async function handleFile(file: File) {
         if (!file.type.startsWith('image/')) {
             return;
         }
 
-        replacePreview(URL.createObjectURL(file));
-        onChange?.(file);
+        const { width, height } = await readImageSize(file);
+
+        if (cropDraft?.url) {
+            URL.revokeObjectURL(cropDraft.url);
+        }
+
+        setCropDraft({
+            file,
+            url: URL.createObjectURL(file),
+            width,
+            height,
+        });
+        setCropPosition(50);
+        setZoom(1);
+        setHeaderPreviewViewport('desktop');
+        setShowHeaderPreview(false);
+        setBackgroundPreset('transparent');
+        setCustomBackgroundColor('#f5f5f5');
+    }
+
+    async function exportCroppedFile(): Promise<File | null> {
+        if (!cropDraft) {
+            return null;
+        }
+
+        const image = await new Promise<HTMLImageElement>((resolve, reject) => {
+            const nextImage = new Image();
+            nextImage.onload = () => resolve(nextImage);
+            nextImage.onerror = () =>
+                reject(new Error('Unable to load image.'));
+            nextImage.src = cropDraft.url;
+        });
+
+        const sourceWidth = image.naturalWidth;
+        const sourceHeight = image.naturalHeight;
+        const sourceRatio = sourceWidth / sourceHeight;
+        const position = cropPosition / 100;
+        const normalizedZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom));
+        const exportWidth = MAX_EXPORT_WIDTH;
+        const exportHeight = Math.round(exportWidth / COVER_IMAGE_ASPECT_RATIO);
+        const canvas = document.createElement('canvas');
+        canvas.width = exportWidth;
+        canvas.height = exportHeight;
+
+        const context = canvas.getContext('2d');
+
+        if (!context) {
+            return null;
+        }
+
+        const backgroundColor = resolvedBackgroundColor();
+
+        if (backgroundColor) {
+            context.fillStyle = backgroundColor;
+            context.fillRect(0, 0, exportWidth, exportHeight);
+        } else if (cropDraft.file.type === 'image/jpeg') {
+            context.fillStyle = '#ffffff';
+            context.fillRect(0, 0, exportWidth, exportHeight);
+        }
+
+        let drawWidth = exportWidth;
+        let drawHeight = exportHeight;
+
+        if (sourceRatio > COVER_IMAGE_ASPECT_RATIO) {
+            drawWidth = exportWidth;
+            drawHeight = exportWidth / sourceRatio;
+        } else if (sourceRatio < COVER_IMAGE_ASPECT_RATIO) {
+            drawWidth = exportHeight * sourceRatio;
+            drawHeight = exportHeight;
+        }
+
+        drawWidth *= normalizedZoom;
+        drawHeight *= normalizedZoom;
+
+        let drawX = (exportWidth - drawWidth) / 2;
+        let drawY = (exportHeight - drawHeight) / 2;
+
+        if (sourceRatio > COVER_IMAGE_ASPECT_RATIO) {
+            drawX = (exportWidth - drawWidth) * position;
+        } else if (sourceRatio < COVER_IMAGE_ASPECT_RATIO) {
+            drawY = (exportHeight - drawHeight) * position;
+        }
+
+        context.drawImage(image, drawX, drawY, drawWidth, drawHeight);
+
+        const mimeType = ['image/jpeg', 'image/png', 'image/webp'].includes(
+            cropDraft.file.type,
+        )
+            ? cropDraft.file.type
+            : 'image/png';
+        const extension = mimeType.split('/')[1] ?? 'png';
+        const fileName = cropDraft.file.name.replace(
+            /\.[^.]+$/,
+            `.${extension}`,
+        );
+
+        const blob = await new Promise<Blob | null>((resolve) => {
+            canvas.toBlob(
+                resolve,
+                mimeType,
+                mimeType === 'image/png' ? undefined : 0.92,
+            );
+        });
+
+        if (!blob) {
+            return null;
+        }
+
+        return new File([blob], fileName, {
+            type: mimeType,
+            lastModified: Date.now(),
+        });
+    }
+
+    async function applyCrop() {
+        const croppedFile = await exportCroppedFile();
+
+        if (!croppedFile) {
+            return;
+        }
+
+        replacePreview(URL.createObjectURL(croppedFile));
+        onChange?.(croppedFile);
 
         if (inputRef.current) {
             const dt = new DataTransfer();
-            dt.items.add(file);
+            dt.items.add(croppedFile);
             inputRef.current.files = dt.files;
         }
+
+        if (cropDraft?.url) {
+            URL.revokeObjectURL(cropDraft.url);
+        }
+
+        setCropDraft(null);
+        setZoom(1);
+        setHeaderPreviewViewport('desktop');
+        setShowHeaderPreview(false);
+        setBackgroundPreset('transparent');
+        setCustomBackgroundColor('#f5f5f5');
+    }
+
+    function cancelCrop() {
+        if (cropDraft?.url) {
+            URL.revokeObjectURL(cropDraft.url);
+        }
+
+        if (inputRef.current) {
+            inputRef.current.value = '';
+        }
+
+        setCropDraft(null);
+        setZoom(1);
+        setHeaderPreviewViewport('desktop');
+        setShowHeaderPreview(false);
+        setBackgroundPreset('transparent');
+        setCustomBackgroundColor('#f5f5f5');
     }
 
     function handleDragEnter(e: React.DragEvent<HTMLDivElement>) {
@@ -80,7 +407,7 @@ export default function CoverImageDropzone({
         const file = e.dataTransfer.files[0];
 
         if (file) {
-            handleFile(file);
+            void handleFile(file);
         }
     }
 
@@ -93,6 +420,40 @@ export default function CoverImageDropzone({
             inputRef.current.files = dt.files;
         }
     }
+
+    const previewSize = framePreviewSize();
+    const previewWidth = previewSize.width;
+    const previewHeight = previewSize.height;
+    const previewLeft =
+        sourceRatio && sourceRatio > COVER_IMAGE_ASPECT_RATIO
+            ? (100 - previewWidth) * (cropPosition / 100)
+            : (100 - previewWidth) / 2;
+    const previewTop =
+        sourceRatio && sourceRatio < COVER_IMAGE_ASPECT_RATIO
+            ? (100 - previewHeight) * (cropPosition / 100)
+            : (100 - previewHeight) / 2;
+    const frameLeft = (100 - CROP_FRAME_WIDTH_PERCENT) / 2;
+    const frameTop = (100 - CROP_FRAME_HEIGHT_PERCENT) / 2;
+    const stagePreviewWidth = (previewWidth * CROP_FRAME_WIDTH_PERCENT) / 100;
+    const stagePreviewHeight =
+        (previewHeight * CROP_FRAME_HEIGHT_PERCENT) / 100;
+    const stagePreviewLeft =
+        frameLeft + (previewLeft * CROP_FRAME_WIDTH_PERCENT) / 100;
+    const stagePreviewTop =
+        frameTop + (previewTop * CROP_FRAME_HEIGHT_PERCENT) / 100;
+    const mobileHeaderFrame = headerImageFrame(MOBILE_HEADER_ASPECT_RATIO);
+    const desktopHeaderFrame = headerImageFrame(DESKTOP_HEADER_ASPECT_RATIO);
+    const activeHeaderAspectRatio =
+        headerPreviewViewport === 'mobile'
+            ? MOBILE_HEADER_ASPECT_RATIO
+            : DESKTOP_HEADER_ASPECT_RATIO;
+    const activeHeaderFrame =
+        headerPreviewViewport === 'mobile'
+            ? mobileHeaderFrame
+            : desktopHeaderFrame;
+    const activeHeaderLabel =
+        headerPreviewViewport === 'mobile' ? 'Mobile' : 'Desktop';
+    const previewBackground = previewBackgroundStyle();
 
     return (
         <div className="grid gap-2">
@@ -126,10 +487,23 @@ export default function CoverImageDropzone({
                             alt="Cover preview"
                             className="h-40 w-full object-cover"
                         />
-                        <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
-                            <div className="flex items-center gap-1.5 rounded-full bg-black/60 px-3 py-1.5 text-xs font-medium text-white">
+                        <div className="absolute inset-0 bg-linear-to-t from-black/70 via-black/20 to-black/10" />
+                        <div className="absolute inset-x-3 bottom-3 flex items-center justify-between gap-3">
+                            <div className="rounded-full bg-black/65 px-3 py-1.5 text-xs font-medium text-white">
+                                {hasReplacementPreview
+                                    ? 'Previewing new image'
+                                    : hasExistingImage
+                                      ? 'Existing image'
+                                      : 'Selected image'}
+                            </div>
+                            <div className="rounded-full border border-white/15 bg-black/55 px-3 py-1.5 text-xs text-white/90">
+                                Drag and drop to replace
+                            </div>
+                        </div>
+                        <div className="absolute inset-0 flex items-center justify-center bg-black/45 opacity-0 transition-opacity group-hover:opacity-100">
+                            <div className="flex items-center gap-1.5 rounded-full bg-black/70 px-3 py-1.5 text-xs font-medium text-white">
                                 <Pencil className="size-3" />
-                                Replace image
+                                Click or drag and drop to replace
                             </div>
                         </div>
                     </>
@@ -153,20 +527,20 @@ export default function CoverImageDropzone({
                         <div className="flex flex-col items-center gap-1">
                             <p className="text-sm font-medium">
                                 {isDragging
-                                    ? 'Drop to upload'
-                                    : 'Drop image here'}
+                                    ? 'Drop here to upload'
+                                    : 'Drag an image here'}
                             </p>
                             {!isDragging && (
                                 <p className="text-xs">
-                                    or{' '}
+                                    Or{' '}
                                     <span className="underline underline-offset-2">
-                                        click to browse
+                                        click to choose
                                     </span>
                                 </p>
                             )}
                         </div>
                         <p className="text-xs opacity-60">
-                            JPEG, PNG, GIF, or WebP · Max 2 MB
+                            JPEG, PNG, GIF, or WebP · Saved at 16:9 · Max 2 MB
                         </p>
                     </div>
                 )}
@@ -176,7 +550,7 @@ export default function CoverImageDropzone({
                         <div className="flex flex-col items-center gap-2 text-white">
                             <ImageUp className="size-8" />
                             <p className="text-sm font-medium">
-                                Drop to replace
+                                Drop here to replace
                             </p>
                         </div>
                     </div>
@@ -190,7 +564,7 @@ export default function CoverImageDropzone({
                     className="flex w-fit items-center gap-1 text-xs text-muted-foreground hover:text-destructive"
                 >
                     <X className="size-3" />
-                    Clear selection
+                    {hasExistingImage ? 'Undo changes' : 'Clear selection'}
                 </button>
             )}
 
@@ -205,13 +579,318 @@ export default function CoverImageDropzone({
                     const file = e.target.files?.[0];
 
                     if (file) {
-                        handleFile(file);
+                        void handleFile(file);
                     }
                 }}
                 className="sr-only"
             />
 
             <InputError message={error} />
+
+            <Dialog
+                open={cropDraft !== null}
+                onOpenChange={(open) => !open && cancelCrop()}
+            >
+                <DialogContent className="flex max-h-[92vh] max-w-4xl flex-col gap-0 overflow-hidden p-0 sm:max-w-4xl">
+                    <DialogHeader className="px-6 pt-6">
+                        <DialogTitle>Adjust cover image</DialogTitle>
+                        <DialogDescription>
+                            The area inside the light frame is what will actually be used. Recommended size is at least 1600x900.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    <div className="min-h-0 flex-1 overflow-y-auto">
+                        <div className="bg-black/55 px-6 py-5">
+                            <div className="relative mx-auto aspect-[5/4] w-full max-w-3xl overflow-hidden rounded-xl border border-white/15 bg-neutral-950 shadow-2xl">
+                                <div
+                                    className="absolute"
+                                    style={{
+                                        ...previewBackground,
+                                        left: `${frameLeft}%`,
+                                        top: `${frameTop}%`,
+                                        width: `${CROP_FRAME_WIDTH_PERCENT}%`,
+                                        height: `${CROP_FRAME_HEIGHT_PERCENT}%`,
+                                    }}
+                                />
+                                {cropDraft && (
+                                    <img
+                                        src={cropDraft.url}
+                                        alt="Crop preview"
+                                        className="absolute rounded-md select-none"
+                                        style={{
+                                            width: `${stagePreviewWidth}%`,
+                                            height: `${stagePreviewHeight}%`,
+                                            left: `${stagePreviewLeft}%`,
+                                            top: `${stagePreviewTop}%`,
+                                        }}
+                                    />
+                                )}
+                                <div
+                                    className="absolute inset-x-0 top-0 bg-black/48"
+                                    style={{ height: `${frameTop}%` }}
+                                />
+                                <div
+                                    className="absolute inset-x-0 bottom-0 bg-black/48"
+                                    style={{ height: `${frameTop}%` }}
+                                />
+                                <div
+                                    className="absolute left-0 bg-black/48"
+                                    style={{
+                                        top: `${frameTop}%`,
+                                        width: `${frameLeft}%`,
+                                        height: `${CROP_FRAME_HEIGHT_PERCENT}%`,
+                                    }}
+                                />
+                                <div
+                                    className="absolute right-0 bg-black/48"
+                                    style={{
+                                        top: `${frameTop}%`,
+                                        width: `${frameLeft}%`,
+                                        height: `${CROP_FRAME_HEIGHT_PERCENT}%`,
+                                    }}
+                                />
+                                <div
+                                    className="pointer-events-none absolute border border-white/85 shadow-[0_0_0_1px_rgba(255,255,255,0.25)]"
+                                    style={{
+                                        left: `${frameLeft}%`,
+                                        top: `${frameTop}%`,
+                                        width: `${CROP_FRAME_WIDTH_PERCENT}%`,
+                                        height: `${CROP_FRAME_HEIGHT_PERCENT}%`,
+                                    }}
+                                >
+                                    <div className="absolute inset-0 grid grid-cols-3 grid-rows-3">
+                                        {Array.from({ length: 9 }).map(
+                                            (_, index) => (
+                                                <div
+                                                    key={index}
+                                                    className="border border-white/12"
+                                                />
+                                            ),
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="border-t bg-background px-6 py-5">
+                            <div className="mb-5 space-y-3">
+                                <div className="flex items-center justify-between gap-3">
+                                    <p className="text-xs font-medium text-foreground">
+                                        Live header preview
+                                    </p>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() =>
+                                            setShowHeaderPreview(
+                                                (current) => !current,
+                                            )
+                                        }
+                                    >
+                                        {showHeaderPreview
+                                            ? 'Hide preview'
+                                            : 'Show preview'}
+                                    </Button>
+                                </div>
+                                {showHeaderPreview && (
+                                    <div className="rounded-xl border bg-white p-3 shadow-xs">
+                                        <div className="mb-3 flex items-center justify-between gap-3">
+                                            <div className="text-[11px] text-muted-foreground">
+                                                <span>{activeHeaderLabel}</span>
+                                                <span className="ml-2">
+                                                    Public page appearance
+                                                </span>
+                                            </div>
+                                            <div className="inline-flex rounded-lg border bg-muted/40 p-1">
+                                                <button
+                                                    type="button"
+                                                    onClick={() =>
+                                                        setHeaderPreviewViewport(
+                                                            'mobile',
+                                                        )
+                                                    }
+                                                    className={cn(
+                                                        'rounded-md px-2.5 py-1 text-xs transition-colors',
+                                                        headerPreviewViewport ===
+                                                            'mobile'
+                                                            ? 'bg-background text-foreground shadow-xs'
+                                                            : 'text-muted-foreground',
+                                                    )}
+                                                >
+                                                    Mobile
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={() =>
+                                                        setHeaderPreviewViewport(
+                                                            'desktop',
+                                                        )
+                                                    }
+                                                    className={cn(
+                                                        'rounded-md px-2.5 py-1 text-xs transition-colors',
+                                                        headerPreviewViewport ===
+                                                            'desktop'
+                                                            ? 'bg-background text-foreground shadow-xs'
+                                                            : 'text-muted-foreground',
+                                                    )}
+                                                >
+                                                    Desktop
+                                                </button>
+                                            </div>
+                                        </div>
+                                        <div
+                                            className="relative w-full overflow-hidden rounded-md border"
+                                            style={{
+                                                ...previewBackground,
+                                                aspectRatio: String(
+                                                    activeHeaderAspectRatio,
+                                                ),
+                                            }}
+                                        >
+                                            {cropDraft && (
+                                                <div
+                                                    className="absolute overflow-hidden"
+                                                    style={{
+                                                        width: `${activeHeaderFrame.width}%`,
+                                                        height: `${activeHeaderFrame.height}%`,
+                                                        left: `${activeHeaderFrame.left}%`,
+                                                        top: `${activeHeaderFrame.top}%`,
+                                                    }}
+                                                >
+                                                    <img
+                                                        src={cropDraft.url}
+                                                        alt={`${activeHeaderLabel} header preview`}
+                                                        className="absolute select-none"
+                                                        style={{
+                                                            width: `${previewWidth}%`,
+                                                            height: `${previewHeight}%`,
+                                                            left: `${previewLeft}%`,
+                                                            top: `${previewTop}%`,
+                                                        }}
+                                                    />
+                                                </div>
+                                            )}
+                                        </div>
+                                        <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
+                                            <p>
+                                                This preview matches the header frame on the public page.
+                                            </p>
+                                            <p>
+                                                It is meant to check the visible area, not the raw exported image.
+                                            </p>
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="border-t bg-background/95 px-6 py-4 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+                        <div className="mx-auto max-w-md">
+                            <div className="mb-5 space-y-2">
+                                <p className="text-center text-xs text-muted-foreground">
+                                    Background color
+                                </p>
+                                <div className="flex flex-wrap items-center justify-center gap-2">
+                                    {BACKGROUND_PRESETS.map((background) => (
+                                        <button
+                                            key={background.key}
+                                            type="button"
+                                            onClick={() =>
+                                                setBackgroundPreset(
+                                                    background.key,
+                                                )
+                                            }
+                                            className={cn(
+                                                'rounded-full border px-3 py-1.5 text-xs transition-colors',
+                                                backgroundPreset ===
+                                                    background.key
+                                                    ? 'border-foreground bg-foreground text-background'
+                                                    : 'border-input bg-background text-foreground',
+                                            )}
+                                        >
+                                            {background.label}
+                                        </button>
+                                    ))}
+                                </div>
+                                {backgroundPreset === 'custom' && (
+                                    <div className="flex items-center justify-center gap-3">
+                                        <input
+                                            type="color"
+                                            value={customBackgroundColor}
+                                            onChange={(e) =>
+                                                setCustomBackgroundColor(
+                                                    e.target.value,
+                                                )
+                                            }
+                                            className="h-9 w-12 rounded border border-input bg-background p-1"
+                                        />
+                                        <span className="text-xs text-muted-foreground">
+                                            {customBackgroundColor}
+                                        </span>
+                                    </div>
+                                )}
+                            </div>
+
+                            <div className="flex items-center gap-4">
+                                <ImageUp className="size-4 text-muted-foreground" />
+                                <input
+                                    type="range"
+                                    min="0"
+                                    max="100"
+                                    step="1"
+                                    value={cropPosition}
+                                    onChange={(e) =>
+                                        setCropPosition(Number(e.target.value))
+                                    }
+                                    className="w-full"
+                                    disabled={!needsCropAdjustment}
+                                />
+                                <Pencil className="size-4 text-muted-foreground" />
+                            </div>
+                            <p className="mt-2 text-center text-xs text-muted-foreground">
+                                {!needsCropAdjustment
+                                    ? 'This image is already 16:9'
+                                    : isLandscapeCrop
+                                      ? 'Adjust horizontal position'
+                                      : 'Adjust vertical position'}
+                            </p>
+                            <div className="mt-5 flex items-center gap-4">
+                                <ImageMinus className="size-4 text-muted-foreground" />
+                                <input
+                                    type="range"
+                                    min={MIN_ZOOM}
+                                    max={MAX_ZOOM}
+                                    step="0.05"
+                                    value={zoom}
+                                    onChange={(e) =>
+                                        setZoom(Number(e.target.value))
+                                    }
+                                    className="w-full"
+                                />
+                                <ImagePlus className="size-4 text-muted-foreground" />
+                            </div>
+                            <p className="mt-2 text-center text-xs text-muted-foreground">
+                                Zoom {zoom.toFixed(2)}x
+                            </p>
+                        </div>
+                    </div>
+
+                    <DialogFooter className="border-t bg-muted/20 px-6 py-4">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={cancelCrop}
+                        >
+                            Cancel
+                        </Button>
+                        <Button type="button" onClick={() => void applyCrop()}>
+                            Save
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </div>
     );
 }

--- a/resources/js/components/cover-image-dropzone.tsx
+++ b/resources/js/components/cover-image-dropzone.tsx
@@ -595,7 +595,9 @@ export default function CoverImageDropzone({
                     <DialogHeader className="px-6 pt-6">
                         <DialogTitle>Adjust cover image</DialogTitle>
                         <DialogDescription>
-                            The area inside the light frame is what will actually be used. Recommended size is at least 1600x900.
+                            The area inside the light frame is what will
+                            actually be used. Recommended size is at least
+                            1600x900.
                         </DialogDescription>
                     </DialogHeader>
 
@@ -774,10 +776,13 @@ export default function CoverImageDropzone({
                                         </div>
                                         <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
                                             <p>
-                                                This preview matches the header frame on the public page.
+                                                This preview matches the header
+                                                frame on the public page.
                                             </p>
                                             <p>
-                                                It is meant to check the visible area, not the raw exported image.
+                                                It is meant to check the visible
+                                                area, not the raw exported
+                                                image.
                                             </p>
                                         </div>
                                     </div>

--- a/resources/js/components/namespace-header.tsx
+++ b/resources/js/components/namespace-header.tsx
@@ -137,9 +137,7 @@ export default function NamespaceHeader({
                             </DropdownMenuContent>
                         </DropdownMenu>
                         <Button variant="outline" asChild>
-                            <Link
-                                href={editNamespace.url(namespace.id)}
-                            >
+                            <Link href={editNamespace.url(namespace.id)}>
                                 <Pencil className="size-4" />
                                 Edit Namespace
                             </Link>

--- a/resources/js/components/namespace-header.tsx
+++ b/resources/js/components/namespace-header.tsx
@@ -17,7 +17,6 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import ViewContextBadge from '@/components/view-context-badge';
-import { useCurrentUrl } from '@/hooks/use-current-url';
 import {
     create as namespaceCreate,
     edit as editNamespace,
@@ -44,7 +43,6 @@ export default function NamespaceHeader({
 }: {
     namespace: Namespace;
 }) {
-    const { currentUrl } = useCurrentUrl();
     const childNamespaceCreateUrl = `${namespaceCreate.url()}?${new URLSearchParams({ parent: String(namespace.id) }).toString()}`;
     const siteUrl = `/${namespace.full_path}`;
 
@@ -140,9 +138,7 @@ export default function NamespaceHeader({
                         </DropdownMenu>
                         <Button variant="outline" asChild>
                             <Link
-                                href={editNamespace.url(namespace.id, {
-                                    query: { return_to: currentUrl },
-                                })}
+                                href={editNamespace.url(namespace.id)}
                             >
                                 <Pencil className="size-4" />
                                 Edit Namespace

--- a/resources/js/pages/admin/namespaces/create.tsx
+++ b/resources/js/pages/admin/namespaces/create.tsx
@@ -196,6 +196,9 @@ export default function Create({
                                     name="cover_image"
                                     error={errors.cover_image}
                                 />
+                                <p className="text-xs text-muted-foreground">
+                                    Saved with 16:9 cropping. Recommended size is at least 1600x900.
+                                </p>
                             </div>
 
                             <div className="flex items-center gap-2">

--- a/resources/js/pages/admin/namespaces/create.tsx
+++ b/resources/js/pages/admin/namespaces/create.tsx
@@ -197,7 +197,8 @@ export default function Create({
                                     error={errors.cover_image}
                                 />
                                 <p className="text-xs text-muted-foreground">
-                                    Saved with 16:9 cropping. Recommended size is at least 1600x900.
+                                    Saved with 16:9 cropping. Recommended size
+                                    is at least 1600x900.
                                 </p>
                             </div>
 

--- a/resources/js/pages/admin/namespaces/edit.tsx
+++ b/resources/js/pages/admin/namespaces/edit.tsx
@@ -1,5 +1,4 @@
 import { Head, setLayoutProps, useForm } from '@inertiajs/react';
-import { useMemo } from 'react';
 import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import CoverImageDropzone from '@/components/cover-image-dropzone';
 import InputError from '@/components/input-error';
@@ -7,8 +6,15 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { dashboard } from '@/routes';
-import { edit } from '@/routes/admin/namespaces';
-import { index as postsIndex } from '@/routes/admin/posts';
+import {
+    index as namespacesIndex,
+    namespace as namespaceRoute,
+} from '@/routes/admin/posts';
+
+type Ancestor = {
+    id: number;
+    name: string;
+};
 
 type Namespace = {
     id: number;
@@ -19,20 +25,23 @@ type Namespace = {
     cover_image_url: string | null;
 };
 
-export default function Edit({ namespace }: { namespace: Namespace }) {
-    const returnTo = useMemo(() => {
-        if (typeof window === 'undefined') {
-            return null;
-        }
-
-        return new URLSearchParams(window.location.search).get('return_to');
-    }, []);
-
+export default function Edit({
+    ancestors,
+    namespace,
+}: {
+    ancestors: Ancestor[];
+    namespace: Namespace;
+}) {
     setLayoutProps({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
-            { title: 'Posts', href: postsIndex.url() },
-            { title: namespace.name, href: edit.url(namespace.id) },
+            { title: 'Namespaces', href: namespacesIndex.url() },
+            ...ancestors.map((ancestor) => ({
+                title: ancestor.name,
+                href: namespaceRoute.url(ancestor.id),
+            })),
+            { title: namespace.name, href: namespaceRoute.url(namespace.id) },
+            { title: 'Edit' },
         ],
     });
 
@@ -43,7 +52,6 @@ export default function Edit({ namespace }: { namespace: Namespace }) {
         description: string;
         is_published: boolean;
         cover_image: File | null;
-        return_to: string;
     }>({
         _method: 'put',
         name: namespace.name,
@@ -51,7 +59,6 @@ export default function Edit({ namespace }: { namespace: Namespace }) {
         description: namespace.description ?? '',
         is_published: namespace.is_published,
         cover_image: null,
-        return_to: returnTo ?? '',
     });
 
     function submit(e: React.FormEvent) {
@@ -126,6 +133,9 @@ export default function Edit({ namespace }: { namespace: Namespace }) {
                             onChange={(file) => setData('cover_image', file)}
                             error={errors.cover_image}
                         />
+                        <p className="text-xs text-muted-foreground">
+                            Saved with 16:9 cropping. Recommended size is at least 1600x900.
+                        </p>
                     </div>
 
                     <div className="flex items-center gap-2">
@@ -146,7 +156,7 @@ export default function Edit({ namespace }: { namespace: Namespace }) {
                             Save Changes
                         </Button>
                         <Button type="button" variant="outline" asChild>
-                            <a href={returnTo ?? postsIndex.url()}>Cancel</a>
+                            <a href={namespaceRoute.url(namespace.id)}>Cancel</a>
                         </Button>
                     </div>
                 </form>

--- a/resources/js/pages/admin/namespaces/edit.tsx
+++ b/resources/js/pages/admin/namespaces/edit.tsx
@@ -134,7 +134,8 @@ export default function Edit({
                             error={errors.cover_image}
                         />
                         <p className="text-xs text-muted-foreground">
-                            Saved with 16:9 cropping. Recommended size is at least 1600x900.
+                            Saved with 16:9 cropping. Recommended size is at
+                            least 1600x900.
                         </p>
                     </div>
 
@@ -156,7 +157,9 @@ export default function Edit({
                             Save Changes
                         </Button>
                         <Button type="button" variant="outline" asChild>
-                            <a href={namespaceRoute.url(namespace.id)}>Cancel</a>
+                            <a href={namespaceRoute.url(namespace.id)}>
+                                Cancel
+                            </a>
                         </Button>
                     </div>
                 </form>

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { MARKDOWN_SYNTAX_MANIFEST } from '../../resources/js/lib/markdown-syntax-manifest.ts';
 import {
     parseMarkdownImageMetadata,
     preprocessMarkdownContent,
     preprocessMarkdownSyntax,
 } from '../../resources/js/lib/markdown-syntax.ts';
-import { MARKDOWN_SYNTAX_MANIFEST } from '../../resources/js/lib/markdown-syntax-manifest.ts';
 
 test('preprocessMarkdownSyntax normalizes Zenn shorthand and Mintlify tabs', () => {
     const output = preprocessMarkdownSyntax(`:::message alert

--- a/tests/Feature/Admin/NamespaceControllerTest.php
+++ b/tests/Feature/Admin/NamespaceControllerTest.php
@@ -143,7 +143,7 @@ test('updating a child namespace allows reserved slugs', function (string $slug)
             'slug' => $slug,
             'name' => ucfirst($slug),
         ])
-        ->assertRedirect(route('admin.posts.index'));
+        ->assertRedirect(route('admin.posts.namespace', $namespace));
 
     $this->assertDatabaseHas('namespaces', [
         'id' => $namespace->id,
@@ -228,6 +228,28 @@ test('authenticated users can view the edit form', function () {
     $this->actingAs($user)->get(route('admin.namespaces.edit', $namespace))->assertOk();
 });
 
+test('edit form includes ancestor namespaces', function () {
+    $user = User::factory()->create();
+    $root = PostNamespace::factory()->create([
+        'name' => 'Inertia.js v3',
+        'slug' => 'inertiajs-v3',
+    ]);
+    $namespace = PostNamespace::factory()->create([
+        'parent_id' => $root->id,
+        'name' => 'Introduction',
+        'slug' => 'introduction',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.namespaces.edit', $namespace))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('ancestors.0.id', $root->id)
+            ->where('ancestors.0.name', 'Inertia.js v3')
+            ->where('namespace.id', $namespace->id)
+        );
+});
+
 test('authenticated users can update a namespace', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create([
@@ -242,14 +264,14 @@ test('authenticated users can update a namespace', function () {
             'name' => 'New Name',
             'description' => 'Updated description',
         ])
-        ->assertRedirect(route('admin.posts.index'));
+        ->assertRedirect(route('admin.posts.namespace', $namespace));
 
     expect($namespace->fresh()->slug)->toBe('new-slug');
     expect($namespace->fresh()->name)->toBe('New Name');
     expect($namespace->fresh()->description)->toBe('Updated description');
 });
 
-test('updating a namespace redirects back to the updated canonical section page', function () {
+test('updating a namespace redirects to the admin namespace page', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create([
         'slug' => 'guides',
@@ -261,25 +283,11 @@ test('updating a namespace redirects back to the updated canonical section page'
             'slug' => 'manuals',
             'name' => 'Manuals',
             'description' => 'Updated description',
-            'return_to' => '/guides',
         ])
-        ->assertRedirect('/manuals');
+        ->assertRedirect(route('admin.posts.namespace', $namespace->fresh()));
 
     expect($namespace->fresh()->slug)->toBe('manuals');
     expect($namespace->fresh()->full_path)->toBe('manuals');
-});
-
-test('updating a namespace ignores unsafe return paths', function () {
-    $user = User::factory()->create();
-    $namespace = PostNamespace::factory()->create(['slug' => 'guides']);
-
-    $this->actingAs($user)
-        ->put(route('admin.namespaces.update', $namespace), [
-            'slug' => 'guides',
-            'name' => 'Guides',
-            'return_to' => 'https://example.com/phish',
-        ])
-        ->assertRedirect(route('admin.posts.index'));
 });
 
 test('updating a namespace allows keeping the same slug', function () {
@@ -291,7 +299,7 @@ test('updating a namespace allows keeping the same slug', function () {
             'slug' => 'my-ns',
             'name' => 'Updated Name',
         ])
-        ->assertRedirect(route('admin.posts.index'));
+        ->assertRedirect(route('admin.posts.namespace', $namespace));
 
     expect($namespace->fresh()->slug)->toBe('my-ns');
 });
@@ -307,7 +315,7 @@ test('updating a namespace accepts a valid parent namespace', function () {
             'slug' => $namespace->slug,
             'name' => $namespace->name,
         ])
-        ->assertRedirect(route('admin.posts.index'));
+        ->assertRedirect(route('admin.posts.namespace', $namespace));
 
     expect($namespace->fresh()->parent_id)->toBe($parent->id);
     expect($namespace->fresh()->full_path)->toBe('parent/child');
@@ -472,7 +480,7 @@ test('updating a namespace can toggle is_published', function () {
             'name' => $namespace->name,
             'is_published' => '0',
         ])
-        ->assertRedirect(route('admin.posts.index'));
+        ->assertRedirect(route('admin.posts.namespace', $namespace));
 
     expect($namespace->fresh()->is_published)->toBeFalse();
 });
@@ -480,7 +488,7 @@ test('updating a namespace can toggle is_published', function () {
 test('storing a namespace with a cover image saves the file', function () {
     Storage::fake('public');
     $user = User::factory()->create();
-    $image = UploadedFile::fake()->image('cover.jpg', 800, 400);
+    $image = UploadedFile::fake()->image('cover.jpg', 1600, 900);
 
     $this->actingAs($user)
         ->post(route('admin.namespaces.store'), [
@@ -503,7 +511,7 @@ test('updating a namespace with a new cover image replaces the old file', functi
     $oldPath = $oldImage->store('namespaces', 'public');
     $namespace = PostNamespace::factory()->create(['cover_image' => $oldPath]);
 
-    $newImage = UploadedFile::fake()->image('new.jpg');
+    $newImage = UploadedFile::fake()->image('new.jpg', 1600, 900);
 
     $this->actingAs($user)
         ->put(route('admin.namespaces.update', $namespace), [
@@ -511,12 +519,39 @@ test('updating a namespace with a new cover image replaces the old file', functi
             'name' => $namespace->name,
             'cover_image' => $newImage,
         ])
-        ->assertRedirect(route('admin.posts.index'));
+        ->assertRedirect(route('admin.posts.namespace', $namespace));
 
     Storage::disk('public')->assertMissing($oldPath);
     $newPath = $namespace->fresh()->cover_image;
     expect($newPath)->not->toBe($oldPath);
     Storage::disk('public')->assertExists($newPath);
+});
+
+test('storing a namespace rejects a cover image that is not 16 by 9', function () {
+    Storage::fake('public');
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('admin.namespaces.store'), [
+            'slug' => 'guides',
+            'name' => 'Guides',
+            'cover_image' => UploadedFile::fake()->image('cover.jpg', 1200, 1200),
+        ])
+        ->assertSessionHasErrors(['cover_image' => 'Cover image must use a 16:9 ratio.']);
+});
+
+test('updating a namespace rejects a cover image that is not 16 by 9', function () {
+    Storage::fake('public');
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+
+    $this->actingAs($user)
+        ->put(route('admin.namespaces.update', $namespace), [
+            'slug' => $namespace->slug,
+            'name' => $namespace->name,
+            'cover_image' => UploadedFile::fake()->image('cover.jpg', 1200, 1200),
+        ])
+        ->assertSessionHasErrors(['cover_image' => 'Cover image must use a 16:9 ratio.']);
 });
 
 test('deleting a namespace removes the cover image file', function () {


### PR DESCRIPTION
## Summary
- add 16:9 cover image cropping guidance and validation for namespace create/edit
- redirect namespace edits back to the admin namespace page with ancestor breadcrumbs
- cover the new namespace edit and cover-image behavior in feature tests

## Testing
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail artisan test --compact tests/Feature/Admin/NamespaceControllerTest.php
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run markdown:test