### PR TITLE
Fix admin post preview return flow and markdown rendering

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -369,10 +369,14 @@ class PostController extends Controller
         $post->update($data);
 
         $fragment = $request->string('return_heading')->toString();
-        $hash = $fragment !== '' ? '#'.ltrim($fragment, '#') : '';
+        $hash = $fragment !== '' ? '#'.rawurlencode(ltrim($fragment, '#')) : '';
         $returnTo = $this->safeReturnPath($request->string('return_to')->toString());
 
         if ($returnTo !== null) {
+            if (str_starts_with($returnTo, '/admin/posts/')) {
+                return redirect()->to(route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug], absolute: false).$hash);
+            }
+
             return redirect()->to(route('posts.path', ['path' => $post->full_path], absolute: false).$hash);
         }
 

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -155,3 +155,11 @@ details.details-block > summary + div {
     border-top: none;
     border-radius: 0 0 var(--radius) var(--radius);
 }
+
+details.details-block > summary + div > :first-child {
+    margin-top: 0;
+}
+
+details.details-block > summary + div > :last-child {
+    margin-bottom: 0;
+}

--- a/resources/js/components/code-block.tsx
+++ b/resources/js/components/code-block.tsx
@@ -206,7 +206,7 @@ export function CodeBlock({
                     </div>
                 </div>
                 <div className={wrap ? '' : 'overflow-x-auto'}>
-                    <pre className="my-0 font-mono text-sm">
+                    <pre className="my-0 font-mono text-sm text-gray-300">
                         <code>
                             {content.split('\n').map((line, index) => {
                                 let bgColor = 'transparent';

--- a/resources/js/components/github-embed.tsx
+++ b/resources/js/components/github-embed.tsx
@@ -146,24 +146,24 @@ export function GithubEmbed({ url }: GithubEmbedProps) {
     if (loading) {
         return (
             <div
-                className="not-prose my-4 overflow-hidden rounded-lg border border-gray-700 bg-[#282c34]"
+                className="not-prose my-4 overflow-hidden rounded-lg border border-border bg-card"
                 data-test="embed-github"
             >
-                <div className="flex items-center justify-between border-b border-gray-700 bg-gray-800 px-4 py-2">
+                <div className="flex items-center justify-between border-b border-border bg-muted/40 px-4 py-2">
                     <div className="flex min-w-0 items-center gap-2">
                         <FileCode
                             size={14}
-                            className="shrink-0 text-gray-400"
+                            className="shrink-0 text-muted-foreground"
                         />
-                        <div className="h-3.5 w-48 animate-pulse rounded bg-gray-600" />
+                        <div className="h-3.5 w-48 animate-pulse rounded bg-muted" />
                     </div>
-                    <div className="h-3.5 w-24 animate-pulse rounded bg-gray-600" />
+                    <div className="h-3.5 w-24 animate-pulse rounded bg-muted" />
                 </div>
                 <div className="space-y-2 px-4 py-3">
                     {Array.from({ length: 4 }).map((_, i) => (
                         <div
                             key={i}
-                            className="h-3 animate-pulse rounded bg-gray-700"
+                            className="h-3 animate-pulse rounded bg-muted"
                             style={{ width: `${60 + (i % 3) * 15}%` }}
                         />
                     ))}
@@ -175,14 +175,14 @@ export function GithubEmbed({ url }: GithubEmbedProps) {
     if (error || lines === null) {
         return (
             <div
-                className="not-prose my-4 overflow-hidden rounded-lg border border-gray-700 bg-[#282c34]"
+                className="not-prose my-4 overflow-hidden rounded-lg border border-border bg-card"
                 data-test="embed-github"
             >
-                <div className="flex items-center justify-between border-b border-gray-700 bg-gray-800 px-4 py-2">
-                    <div className="flex min-w-0 items-center gap-2 truncate font-mono text-xs text-gray-300">
+                <div className="flex items-center justify-between border-b border-border bg-muted/40 px-4 py-2">
+                    <div className="flex min-w-0 items-center gap-2 truncate font-mono text-xs text-foreground">
                         <FileCode
                             size={14}
-                            className="shrink-0 text-gray-400"
+                            className="shrink-0 text-muted-foreground"
                         />
                         <span className="truncate">{headerLabel}</span>
                     </div>
@@ -190,13 +190,14 @@ export function GithubEmbed({ url }: GithubEmbedProps) {
                         href={url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="ml-3 flex shrink-0 items-center gap-1 text-xs text-gray-400 hover:text-gray-200"
+                        data-test="embed-github-open-link"
+                        className="ml-3 flex shrink-0 items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
                     >
                         <ExternalLink size={12} />
                         View
                     </a>
                 </div>
-                <div className="px-4 py-3 font-mono text-xs text-gray-400">
+                <div className="px-4 py-3 font-mono text-xs text-muted-foreground">
                     Failed to load file content.
                 </div>
             </div>
@@ -221,37 +222,43 @@ export function GithubEmbed({ url }: GithubEmbedProps) {
 
     return (
         <div
-            className="not-prose my-4 overflow-hidden rounded-lg border border-gray-700 bg-[#282c34]"
+            className="not-prose my-4 overflow-hidden rounded-lg border border-border bg-card"
             data-test="embed-github"
         >
-            <div className="flex items-center justify-between border-b border-gray-700 bg-gray-800 px-4 py-2">
-                <div className="flex min-w-0 items-center gap-2 font-mono text-xs text-gray-300">
-                    <FileCode size={14} className="shrink-0 text-gray-400" />
+            <div className="flex items-center justify-between border-b border-border bg-muted/40 px-4 py-2">
+                <div className="flex min-w-0 items-center gap-2 font-mono text-xs text-foreground">
+                    <FileCode
+                        size={14}
+                        className="shrink-0 text-muted-foreground"
+                    />
                     <a
                         href={url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="truncate hover:text-white hover:underline"
+                        className="truncate hover:text-foreground hover:underline"
                         title={headerLabel}
                     >
                         {filename}
                     </a>
                     {lineLabel && (
-                        <span className="text-gray-500">{lineLabel}</span>
+                        <span className="text-muted-foreground">
+                            {lineLabel}
+                        </span>
                     )}
                 </div>
                 <a
                     href={url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="ml-3 flex shrink-0 items-center gap-1 text-xs text-gray-400 hover:text-gray-200"
+                    data-test="embed-github-repo-link"
+                    className="ml-3 flex shrink-0 items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
                 >
                     <ExternalLink size={12} />
                     {info.owner}/{info.repo}
                 </a>
             </div>
-            <div className="overflow-x-auto">
-                <pre className="my-0 font-mono text-sm">
+            <div className="overflow-x-auto bg-[#282c34]">
+                <pre className="my-0 font-mono text-sm text-gray-200">
                     <code>
                         {highlightedLines.map((html, index) => (
                             <div

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -52,7 +52,7 @@ function DetailsBox({
 }: React.ComponentPropsWithoutRef<'details'>) {
     return (
         <details
-            className="details-block not-prose my-4 rounded-md border border-border text-sm"
+            className="details-block my-6 rounded-md border border-border"
             data-test="details-block"
             {...props}
         >
@@ -67,7 +67,7 @@ function SummaryEl({
 }: React.ComponentPropsWithoutRef<'summary'>) {
     return (
         <summary
-            className="cursor-pointer rounded-md bg-muted px-4 py-2 leading-relaxed font-medium select-none"
+            className="not-prose cursor-pointer rounded-md bg-muted px-4 py-2 text-sm leading-relaxed font-medium select-none"
             {...props}
         >
             {children}

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -9,6 +9,7 @@ import { useMemo, useState } from 'react';
 import MarkdownContent from '@/components/markdown-content';
 import PostHeader from '@/components/post-header';
 import TableOfContents from '@/components/table-of-contents';
+import { useCurrentUrl } from '@/hooks/use-current-url';
 import { useMarkdownToc } from '@/hooks/use-markdown-toc';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { normalizeMarkdownHeadingText } from '@/lib/markdown-heading-text';
@@ -112,6 +113,7 @@ export default function Show({
     namespace: Namespace;
     post: Post;
 }) {
+    const { currentUrl } = useCurrentUrl();
     const isMobile = useIsMobile();
     const [tocOverride, setTocOverride] = useState<boolean | null>(null);
     const tocPosts = useMemo(
@@ -146,6 +148,8 @@ export default function Show({
         if (id) {
             params.set('return_heading', id);
         }
+
+        params.set('return_to', currentUrl);
 
         router.visit(`${editUrl}?${params.toString()}`);
     };

--- a/tests/Browser/ZennMarkdownRenderingTest.php
+++ b/tests/Browser/ZennMarkdownRenderingTest.php
@@ -99,7 +99,14 @@ test(':::details directive renders as details/summary element', function () {
 # Details Test
 
 :::details Show details
-Hidden content
+Before diff
+
+```diff
+- old value
++ new value
+```
+
+After diff
 :::
 MARKDOWN,
     ]);
@@ -109,6 +116,9 @@ MARKDOWN,
     $page
         ->assertNoJavaScriptErrors()
         ->assertPresent('[data-test="details-block"]')
+        ->assertPresent('[data-test="details-block"]:not(.not-prose)')
+        ->assertPresent('[data-test="details-block"] summary.not-prose')
+        ->assertPresent('[data-test="details-block"] pre.text-gray-300')
         ->assertSee('Show details');
 });
 
@@ -142,7 +152,9 @@ MARKDOWN,
     $page = visit(route('posts.path', ['path' => $post->full_path]));
 
     $page->assertNoJavaScriptErrors()
-        ->assertPresent('[data-test="embed-github"]');
+        ->assertPresent('[data-test="embed-github"]')
+        ->assertPresent('[data-test="embed-github"].bg-card');
+
 });
 
 test('@[github](URL) directive renders as github embed', function () {

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -1163,6 +1163,65 @@ test('updating a post redirects back to the requested heading fragment', functio
         ->assertRedirect(route('admin.posts.edit', [$namespace, 'my-slug']).'#my-slug-section-title');
 });
 
+test('updating a post returns to the admin show page when requested', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'my-slug',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.posts.update', [$namespace, $post]), [
+            'title' => 'Updated Title',
+            'slug' => 'my-slug',
+            'content' => 'Updated content.',
+            'return_heading' => 'my-slug-設定',
+            'return_to' => route('admin.posts.show', [$namespace, $post], false),
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('admin.posts.show', [$namespace, 'my-slug'], false).'#my-slug-%E8%A8%AD%E5%AE%9A');
+});
+
+test('updating a post returns to the updated admin show page when the slug changes', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'my-slug',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.posts.update', [$namespace, $post]), [
+            'title' => 'Updated Title',
+            'slug' => 'updated-slug',
+            'content' => 'Updated content.',
+            'return_heading' => 'updated-slug-設定',
+            'return_to' => route('admin.posts.show', [$namespace, $post], false),
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('admin.posts.show', [$namespace, 'updated-slug'], false).'#updated-slug-%E8%A8%AD%E5%AE%9A');
+});
+
+test('updating a post percent-encodes unicode heading fragments in redirects', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'my-slug',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.posts.update', [$namespace, $post]), [
+            'title' => 'Updated Title',
+            'slug' => 'my-slug',
+            'content' => 'Updated content.',
+            'return_heading' => 'my-slug-設定',
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('admin.posts.edit', [$namespace, 'my-slug']).'#my-slug-%E8%A8%AD%E5%AE%9A');
+});
+
 test('updating a post redirects back to the updated canonical page', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create(['slug' => 'guides', 'full_path' => 'guides']);
@@ -1185,6 +1244,27 @@ test('updating a post redirects back to the updated canonical page', function ()
 
     expect($post->fresh()->slug)->toBe('updated-slug');
     expect($post->fresh()->full_path)->toBe('guides/updated-slug');
+});
+
+test('updating a post preserves unicode heading fragments on canonical redirects', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create(['slug' => 'guides', 'full_path' => 'guides']);
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'my-slug',
+        'full_path' => 'guides/my-slug',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.posts.update', [$namespace, $post]), [
+            'title' => 'Updated Title',
+            'slug' => 'updated-slug',
+            'content' => 'Updated content.',
+            'return_heading' => 'updated-slug-設定',
+            'return_to' => '/guides/my-slug',
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect('/guides/updated-slug#updated-slug-%E8%A8%AD%E5%AE%9A');
 });
 
 test('updating a post ignores unsafe return paths', function () {


### PR DESCRIPTION
## Summary
- keep admin post edits returning to the admin preview when editing from the preview page, including slug changes and unicode heading anchors
- refine markdown details/code/github embed styling so nested code blocks and embed cards render with the intended admin/public theme treatment
- add regression coverage for redirect fragments, admin preview return flow, and markdown rendering selectors

## Validation
- vendor/bin/sail npm run build
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail bash -lc './vendor/bin/pest --ci tests/Feature/Admin/PostControllerTest.php'
- vendor/bin/sail bash -lc './vendor/bin/pest --ci tests/Browser/ZennMarkdownRenderingTest.php' *(existing browser suite still fails broadly in this environment; feature test and frontend checks passed)*