### PR TITLE
Add search entrypoints and placeholder results

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SearchController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        $query = $request->string('q')->trim()->toString();
+        $namespace = $request->string('namespace')->trim()->toString();
+
+        return Inertia::render('search/index', [
+            'query' => $query,
+            'namespace' => $namespace,
+            'results' => $this->results($query, $namespace),
+        ]);
+    }
+
+    /**
+     * @return list<array{
+     *     id: int,
+     *     page: string,
+     *     path: string,
+     *     href: string,
+     *     excerpt: string
+     * }>
+     */
+    private function results(string $query, string $namespace): array
+    {
+        if ($namespace !== '' && $namespace !== 'guides') {
+            return [];
+        }
+
+        $posts = Post::query()
+            ->where('is_draft', false)
+            ->where('published_at', '<=', now())
+            ->whereHas('namespace', function ($builder): void {
+                $builder
+                    ->where('full_path', 'guides')
+                    ->orWhere('full_path', 'like', 'guides/%');
+            })
+            ->orderByDesc('published_at')
+            ->orderByDesc('id')
+            ->limit(6)
+            ->get(['id', 'title', 'full_path', 'content']);
+
+        $results = $posts->map(function (Post $post): array {
+            $excerpt = Str::of($post->content)
+                ->replaceMatches('/[`#>*_\-\[\]\(\)!]/', ' ')
+                ->replaceMatches('/\s+/', ' ')
+                ->trim()
+                ->substr(0, 140)
+                ->toString();
+
+            return [
+                'id' => $post->id,
+                'page' => $post->title,
+                'path' => '/'.$post->full_path,
+                'href' => route('posts.path', ['path' => $post->full_path]),
+                'excerpt' => $excerpt,
+            ];
+        });
+
+        if ($query === '') {
+            return $results->all();
+        }
+
+        $needle = Str::lower($query);
+
+        return $results
+            ->filter(fn (array $result): bool => collect([
+                $result['page'],
+                $result['path'],
+                $result['excerpt'],
+            ])->contains(
+                fn (string $value): bool => Str::contains(Str::lower($value), $needle)
+            ))
+            ->values()
+            ->all();
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\PostNamespace;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 
@@ -40,6 +41,19 @@ class HandleInertiaRequests extends Middleware
             'name' => config('app.name'),
             'auth' => [
                 'user' => $request->user(),
+            ],
+            'search' => [
+                'namespaces' => fn () => PostNamespace::published()
+                    ->whereNull('parent_id')
+                    ->orderBy('name')
+                    ->get(['id', 'name', 'full_path'])
+                    ->map(fn (PostNamespace $namespace): array => [
+                        'value' => $namespace->full_path,
+                        'label' => $namespace->name,
+                        'path' => '/'.$namespace->full_path,
+                    ])
+                    ->values()
+                    ->all(),
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
             'imageUrl' => session('imageUrl'),

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -15,6 +15,8 @@ createInertiaApp({
         switch (true) {
             case name === 'welcome':
                 return null;
+            case name.startsWith('search/'):
+                return null;
             case name.startsWith('posts/'):
                 return AuthenticatedPublicLayout;
             case name.startsWith('auth/'):

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -4,6 +4,7 @@ import { index as adminPostsIndex } from '@/actions/App/Http/Controllers/Admin/P
 import AppLogo from '@/components/app-logo';
 import AppLogoIcon from '@/components/app-logo-icon';
 import { Breadcrumbs } from '@/components/breadcrumbs';
+import SearchPopover from '@/components/search-popover';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import {
@@ -197,13 +198,20 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
 
                     <div className="ml-auto flex items-center space-x-2">
                         <div className="relative flex items-center space-x-1">
-                            <Button
-                                variant="ghost"
-                                size="icon"
-                                className="group h-9 w-9 cursor-pointer"
-                            >
-                                <Search className="!size-5 opacity-80 group-hover:opacity-100" />
-                            </Button>
+                            <SearchPopover
+                                trigger={
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="group h-9 w-9 cursor-pointer"
+                                        type="button"
+                                        aria-label="Open search"
+                                        data-test="app-header-search-toggle"
+                                    >
+                                        <Search className="!size-5 opacity-80 group-hover:opacity-100" />
+                                    </Button>
+                                }
+                            />
                             <div className="ml-1 hidden gap-1 lg:flex">
                                 {rightNavItems.map((item) => (
                                     <Tooltip key={item.title}>

--- a/resources/js/components/search-popover.tsx
+++ b/resources/js/components/search-popover.tsx
@@ -1,0 +1,208 @@
+import { router, usePage } from '@inertiajs/react';
+import { Search } from 'lucide-react';
+import { useEffect, useId, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { search as searchRoute } from '@/routes';
+
+type SearchNamespaceOption = {
+    value: string;
+    label: string;
+    path: string;
+};
+
+type Props = {
+    align?: 'left' | 'right';
+    defaultNamespace?: string;
+    trigger: React.ReactNode;
+};
+
+export default function SearchPopover({
+    align = 'right',
+    defaultNamespace = '',
+    trigger,
+}: Props) {
+    const page = usePage();
+    const searchNamespaces = (page.props.search?.namespaces ??
+        []) as SearchNamespaceOption[];
+    const [isOpen, setIsOpen] = useState(false);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [searchNamespace, setSearchNamespace] = useState(defaultNamespace);
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const panelId = useId();
+
+    useEffect(() => {
+        setSearchNamespace(defaultNamespace);
+    }, [defaultNamespace]);
+
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        inputRef.current?.focus();
+        inputRef.current?.select();
+    }, [isOpen]);
+
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        function handlePointerDown(event: MouseEvent) {
+            if (
+                event.target instanceof Element &&
+                event.target.closest('[data-slot="select-content"]')
+            ) {
+                return;
+            }
+
+            if (
+                containerRef.current &&
+                !containerRef.current.contains(event.target as Node)
+            ) {
+                setIsOpen(false);
+            }
+        }
+
+        function handleKeyDown(event: KeyboardEvent) {
+            if (event.key === 'Escape') {
+                setIsOpen(false);
+            }
+        }
+
+        document.addEventListener('mousedown', handlePointerDown);
+        document.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            document.removeEventListener('mousedown', handlePointerDown);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [isOpen]);
+
+    function submitSearch(): void {
+        const query = searchQuery.trim();
+
+        router.visit(
+            searchRoute({
+                query: {
+                    ...(query === '' ? {} : { q: query }),
+                    ...(searchNamespace === ''
+                        ? {}
+                        : { namespace: searchNamespace }),
+                },
+            }),
+            {
+                preserveScroll: true,
+                onSuccess: () => {
+                    setIsOpen(false);
+                },
+            },
+        );
+    }
+
+    return (
+        <div ref={containerRef} className="relative">
+            <div
+                aria-expanded={isOpen}
+                aria-controls={panelId}
+                onClick={() => setIsOpen((current) => !current)}
+            >
+                {trigger}
+            </div>
+            {isOpen && (
+                <div
+                    id={panelId}
+                    data-test="search-popover-panel"
+                    className={`absolute top-full z-40 mt-3 w-[min(26rem,calc(100vw-2rem))] rounded-2xl border border-sidebar-border/80 bg-background/95 p-3 shadow-lg backdrop-blur ${
+                        align === 'left' ? 'left-0' : 'right-0'
+                    }`}
+                >
+                    <form
+                        role="search"
+                        className="flex flex-col gap-3"
+                        onSubmit={(event) => {
+                            event.preventDefault();
+                            submitSearch();
+                        }}
+                    >
+                        <div className="flex items-center gap-2">
+                            <Search className="size-4 shrink-0 text-muted-foreground" />
+                            <Input
+                                ref={inputRef}
+                                type="search"
+                                value={searchQuery}
+                                onChange={(event) =>
+                                    setSearchQuery(event.target.value)
+                                }
+                                placeholder="Search guides pages"
+                                autoComplete="off"
+                                data-test="search-popover-input"
+                                className="border-0 bg-transparent px-0 shadow-none focus-visible:ring-0"
+                            />
+                        </div>
+                        <Select
+                            value={searchNamespace || 'all'}
+                            onValueChange={(value) =>
+                                setSearchNamespace(value === 'all' ? '' : value)
+                            }
+                        >
+                            <SelectTrigger
+                                className="w-full"
+                                data-test="search-popover-scope"
+                            >
+                                <SelectValue placeholder="Choose search target" />
+                            </SelectTrigger>
+                            <SelectContent align="start">
+                                <SelectItem value="all">All</SelectItem>
+                                {searchNamespaces.map((option) => (
+                                    <SelectItem
+                                        key={option.value}
+                                        value={option.value}
+                                    >
+                                        {option.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                            <p>
+                                Open a quick search window from the current
+                                page.
+                            </p>
+                            <div className="flex items-center gap-1">
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    type="button"
+                                    data-test="search-popover-clear"
+                                    onClick={() => {
+                                        setSearchQuery('');
+                                        inputRef.current?.focus();
+                                    }}
+                                >
+                                    Clear
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    type="submit"
+                                    data-test="search-popover-submit"
+                                >
+                                    Search
+                                </Button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/resources/js/pages/posts/index.tsx
+++ b/resources/js/pages/posts/index.tsx
@@ -1,5 +1,6 @@
 import { Head, Link, usePage } from '@inertiajs/react';
-import { ImageOff, Settings2 } from 'lucide-react';
+import { ImageOff, Search, Settings2 } from 'lucide-react';
+import SearchPopover from '@/components/search-popover';
 import { Button } from '@/components/ui/button';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import { useCurrentUrl } from '@/hooks/use-current-url';
@@ -31,17 +32,28 @@ export default function Index({ namespaces }: { namespaces: PostNamespace[] }) {
                 <header className="border-b">
                     <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-6">
                         <h1 className="text-2xl font-bold">ThinkStream</h1>
-                        {!auth.user && (
-                            <Button asChild variant="outline" size="sm">
-                                <Link
-                                    href={login.url({
-                                        query: { intended: currentUrl },
-                                    })}
-                                >
-                                    Login
-                                </Link>
-                            </Button>
-                        )}
+                        <div className="flex items-center gap-2">
+                            <SearchPopover
+                                align="right"
+                                trigger={
+                                    <Button variant="outline" size="sm">
+                                        <Search className="size-4" />
+                                        Search
+                                    </Button>
+                                }
+                            />
+                            {!auth.user && (
+                                <Button asChild variant="outline" size="sm">
+                                    <Link
+                                        href={login.url({
+                                            query: { intended: currentUrl },
+                                        })}
+                                    >
+                                        Login
+                                    </Link>
+                                </Button>
+                            )}
+                        </div>
                     </div>
                 </header>
 

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -6,10 +6,12 @@ import {
     ImageOff,
     PanelLeftClose,
     PanelLeftOpen,
+    Search,
 } from 'lucide-react';
 import { useState } from 'react';
 import type { ContentNavNode } from '@/components/content-nav-tree';
 import ContentNavTree from '@/components/content-nav-tree';
+import SearchPopover from '@/components/search-popover';
 import { Button } from '@/components/ui/button';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import ViewContextBadge from '@/components/view-context-badge';
@@ -144,6 +146,16 @@ export default function Namespace({
                                 )}
                                 Toggle Nav
                             </button>
+                            <SearchPopover
+                                align="right"
+                                defaultNamespace={navRoot.full_path}
+                                trigger={
+                                    <Button variant="outline" size="sm">
+                                        <Search className="size-4" />
+                                        Search
+                                    </Button>
+                                }
+                            />
                             {auth.user ? (
                                 <div className="flex flex-wrap items-center gap-2">
                                     <Button asChild variant="default" size="sm">

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -7,12 +7,14 @@ import {
     PanelLeftOpen,
     PanelRightClose,
     PanelRightOpen,
+    Search,
 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { siX } from 'simple-icons';
 import type { ContentNavNode } from '@/components/content-nav-tree';
 import ContentNavTree from '@/components/content-nav-tree';
 import MarkdownContent from '@/components/markdown-content';
+import SearchPopover from '@/components/search-popover';
 import TableOfContents from '@/components/table-of-contents';
 import { Button } from '@/components/ui/button';
 import ViewContextBadge from '@/components/view-context-badge';
@@ -346,6 +348,16 @@ export default function Show({
                                     Toggle Nav
                                 </button>
                             )}
+                            <SearchPopover
+                                align="right"
+                                defaultNamespace={navRoot.full_path}
+                                trigger={
+                                    <Button variant="outline" size="sm">
+                                        <Search className="size-4" />
+                                        Search
+                                    </Button>
+                                }
+                            />
                             {auth.user ? (
                                 <div className="flex flex-wrap items-center gap-2">
                                     <Button asChild variant="default" size="sm">

--- a/resources/js/pages/search/index.tsx
+++ b/resources/js/pages/search/index.tsx
@@ -1,0 +1,167 @@
+import { Head, Link, usePage } from '@inertiajs/react';
+import { Search } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { search as searchRoute } from '@/routes';
+
+type SearchResult = {
+    id: number;
+    page: string;
+    path: string;
+    href: string;
+    excerpt: string;
+};
+
+export default function SearchIndex({
+    query,
+    namespace,
+    results,
+}: {
+    query: string;
+    namespace: string;
+    results: SearchResult[];
+}) {
+    const page = usePage();
+    const namespaceOptions = page.props.search?.namespaces ?? [];
+    const [selectedNamespace, setSelectedNamespace] = useState(namespace);
+
+    return (
+        <>
+            <Head title={query !== '' ? `Search: ${query}` : 'Search'} />
+
+            <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8">
+                <div className="space-y-4">
+                    <form
+                        action={searchRoute.url()}
+                        method="get"
+                        className="flex flex-col gap-3"
+                    >
+                        {selectedNamespace !== '' && (
+                            <input
+                                type="hidden"
+                                name="namespace"
+                                value={selectedNamespace}
+                            />
+                        )}
+                        <div className="flex flex-col gap-3 rounded-2xl border border-sidebar-border/80 bg-background p-3 shadow-sm sm:flex-row">
+                            <div className="flex flex-1 items-center gap-3">
+                                <Search className="size-4 text-muted-foreground" />
+                                <Input
+                                    type="search"
+                                    name="q"
+                                    defaultValue={query}
+                                    placeholder="Search guides pages"
+                                    data-test="search-page-input"
+                                    className="border-0 bg-transparent px-0 shadow-none focus-visible:ring-0"
+                                />
+                            </div>
+                            <Button
+                                type="submit"
+                                data-test="search-page-submit"
+                            >
+                                Search
+                            </Button>
+                        </div>
+                        <Select
+                            value={selectedNamespace || 'all'}
+                            onValueChange={(value) =>
+                                setSelectedNamespace(
+                                    value === 'all' ? '' : value,
+                                )
+                            }
+                        >
+                            <SelectTrigger
+                                className="w-full bg-background"
+                                data-test="search-page-scope"
+                            >
+                                <SelectValue placeholder="Choose search target" />
+                            </SelectTrigger>
+                            <SelectContent align="start">
+                                <SelectItem value="all">All</SelectItem>
+                                {namespaceOptions.map(
+                                    (option: {
+                                        value: string;
+                                        label: string;
+                                    }) => (
+                                        <SelectItem
+                                            key={option.value}
+                                            value={option.value}
+                                        >
+                                            {option.label}
+                                        </SelectItem>
+                                    ),
+                                )}
+                            </SelectContent>
+                        </Select>
+                    </form>
+
+                    <p className="text-sm text-muted-foreground">
+                        Dummy results are currently picked from `/guides`.
+                    </p>
+                </div>
+
+                {results.length > 0 ? (
+                    <div className="space-y-3" data-test="search-results-list">
+                        {results.map((result) => (
+                            <Link
+                                key={result.id}
+                                href={result.href}
+                                className="block rounded-2xl border border-sidebar-border/80 bg-card p-5 transition-colors hover:bg-accent/30"
+                                data-test={`search-result-${result.id}`}
+                            >
+                                <div className="space-y-2">
+                                    <p className="text-xs font-medium tracking-[0.18em] text-muted-foreground uppercase">
+                                        Page
+                                    </p>
+                                    <h2 className="text-lg font-semibold tracking-tight">
+                                        {result.page}
+                                    </h2>
+                                </div>
+                                <div className="mt-4 space-y-2 text-sm">
+                                    <p className="text-xs font-medium tracking-[0.18em] text-muted-foreground uppercase">
+                                        Path
+                                    </p>
+                                    <p className="break-all text-muted-foreground">
+                                        {result.path}
+                                    </p>
+                                </div>
+                                <div className="mt-4 space-y-2 text-sm">
+                                    <p className="text-xs font-medium tracking-[0.18em] text-muted-foreground uppercase">
+                                        Content
+                                    </p>
+                                    <p className="leading-6 text-muted-foreground">
+                                        {result.excerpt}
+                                    </p>
+                                </div>
+                            </Link>
+                        ))}
+                    </div>
+                ) : (
+                    <div
+                        className="rounded-2xl border border-dashed border-sidebar-border/80 bg-muted/20 p-10 text-center text-sm text-muted-foreground"
+                        data-test="search-empty-state"
+                    >
+                        No dummy guide results found.
+                    </div>
+                )}
+            </div>
+        </>
+    );
+}
+
+SearchIndex.layout = {
+    breadcrumbs: [
+        {
+            title: 'Search',
+            href: searchRoute(),
+        },
+    ],
+};

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -5,6 +5,13 @@ declare module '@inertiajs/core' {
         sharedPageProps: {
             name: string;
             auth: Auth;
+            search: {
+                namespaces: Array<{
+                    value: string;
+                    label: string;
+                    path: string;
+                }>;
+            };
             sidebarOpen: boolean;
             [key: string]: unknown;
         };

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,11 +3,13 @@
 use App\Http\Controllers\Api\OgpController;
 use App\Http\Controllers\ImageController;
 use App\Http\Controllers\PostController;
+use App\Http\Controllers\SearchController;
 use App\Support\ReservedContentPath;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('private.mode')->group(function () {
     Route::get('/', [PostController::class, 'index'])->name('home');
+    Route::get('search', SearchController::class)->name('search');
 
     Route::get('/images/{path}', [ImageController::class, 'show'])
         ->where('path', '.+')

--- a/tests/Browser/AppHeaderSearchTest.php
+++ b/tests/Browser/AppHeaderSearchTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('app header search submits to the work in progress results page', function () {
+    $user = User::factory()->create();
+    $guides = PostNamespace::factory()->create([
+        'name' => 'Guides',
+        'slug' => 'guides',
+        'full_path' => 'guides',
+        'is_published' => true,
+        'parent_id' => null,
+    ]);
+    PostNamespace::factory()->create([
+        'name' => 'Operations',
+        'slug' => 'operations',
+        'full_path' => 'operations',
+        'is_published' => true,
+        'parent_id' => null,
+    ]);
+    Post::factory()->published()->create([
+        'namespace_id' => $guides->id,
+        'title' => 'Markdown Syntax Guide',
+        'slug' => 'index',
+        'full_path' => 'guides/index',
+        'content' => 'Markdown basics and examples for guide pages.',
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('dashboard', absolute: false))->resize(1440, 900);
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertNotPresent('[data-test="search-popover-panel"]')
+        ->click('[data-test="app-header-search-toggle"]')
+        ->assertPresent('[data-test="search-popover-panel"]')
+        ->assertPresent('[data-test="search-popover-input"]')
+        ->assertSee('Open a quick search window from the current page.');
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const input = document.querySelector('[data-test="search-popover-input"]');
+
+            if (! input) {
+                return null;
+            }
+
+            return document.activeElement === input;
+        })()
+    JS))->toBeTrue();
+
+    $page
+        ->type('[data-test="search-popover-input"]', 'markdown')
+        ->assertValue('[data-test="search-popover-input"]', 'markdown')
+        ->click('[data-test="search-popover-clear"]')
+        ->assertValue('[data-test="search-popover-input"]', '')
+        ->type('[data-test="search-popover-input"]', 'markdown')
+        ->click('[data-test="search-popover-submit"]')
+        ->assertPathIs('/search')
+        ->assertQueryStringHas('q', 'markdown')
+        ->assertPresent('[data-test="search-results-list"]')
+        ->assertPresent('[data-test="search-result-1"]')
+        ->assertValue('[data-test="search-page-input"]', 'markdown');
+});

--- a/tests/Browser/CanonicalSearchAccessTest.php
+++ b/tests/Browser/CanonicalSearchAccessTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Models\PostNamespace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('canonical home shows search next to login for guests', function () {
+    PostNamespace::factory()->create([
+        'name' => 'Guides',
+        'slug' => 'guides',
+        'full_path' => 'guides',
+        'is_published' => true,
+        'parent_id' => null,
+    ]);
+
+    $page = visit(route('home', absolute: false));
+
+    $page
+        ->assertSee('Search')
+        ->assertSee('Login')
+        ->click('Search')
+        ->assertPresent('[data-test="search-popover-panel"]')
+        ->assertPresent('[data-test="search-popover-input"]');
+});

--- a/tests/Feature/SearchControllerTest.php
+++ b/tests/Feature/SearchControllerTest.php
@@ -1,0 +1,163 @@
+<?php
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+
+uses(RefreshDatabase::class);
+
+test('guests can open the search page', function () {
+    PostNamespace::factory()->create([
+        'name' => 'Guides',
+        'slug' => 'guides',
+        'full_path' => 'guides',
+        'is_published' => true,
+        'parent_id' => null,
+    ]);
+
+    $this->get(route('search'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('search/index')
+            ->where('query', '')
+            ->where('namespace', '')
+        );
+});
+
+test('authenticated users can open the search page with guide results', function () {
+    $user = User::factory()->create();
+    $guides = PostNamespace::factory()->create([
+        'name' => 'Guides',
+        'slug' => 'guides',
+        'full_path' => 'guides',
+        'is_published' => true,
+        'parent_id' => null,
+    ]);
+
+    $post = Post::factory()->for($guides, 'namespace')->published()->create([
+        'title' => 'Markdown Syntax Guide',
+        'slug' => 'index',
+        'full_path' => 'guides/index',
+        'content' => 'Markdown basics and examples for guide pages.',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('search'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('search/index')
+            ->where('query', '')
+            ->where('namespace', '')
+            ->has('results', 1)
+            ->where('results.0.id', $post->id)
+            ->where('results.0.page', 'Markdown Syntax Guide')
+            ->where('results.0.path', '/guides/index')
+            ->where('search.namespaces.0.value', 'guides')
+        );
+});
+
+test('search page filters guide results by query', function () {
+    $user = User::factory()->create();
+    $guides = PostNamespace::factory()->create([
+        'name' => 'Guides',
+        'slug' => 'guides',
+        'full_path' => 'guides',
+        'is_published' => true,
+        'parent_id' => null,
+    ]);
+
+    Post::factory()->for($guides, 'namespace')->published()->create([
+        'title' => 'Markdown Syntax Guide',
+        'slug' => 'index',
+        'full_path' => 'guides/index',
+        'content' => 'Markdown basics and examples for guide pages.',
+    ]);
+
+    Post::factory()->for($guides, 'namespace')->published()->create([
+        'title' => 'Mintlify Syntax',
+        'slug' => 'mintlify-syntax',
+        'full_path' => 'guides/mintlify-syntax',
+        'content' => 'Mintlify specific syntax reference.',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('search', ['q' => 'mintlify']))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('search/index')
+            ->where('query', 'mintlify')
+            ->has('results', 1)
+            ->where('results.0.page', 'Mintlify Syntax')
+        );
+});
+
+test('search page can be narrowed to guides namespace', function () {
+    $user = User::factory()->create();
+    $guides = PostNamespace::factory()->create([
+        'name' => 'Guides',
+        'slug' => 'guides',
+        'full_path' => 'guides',
+        'is_published' => true,
+        'parent_id' => null,
+    ]);
+    $other = PostNamespace::factory()->create([
+        'name' => 'Operations',
+        'slug' => 'operations',
+        'full_path' => 'operations',
+        'is_published' => true,
+        'parent_id' => null,
+    ]);
+
+    Post::factory()->for($guides, 'namespace')->published()->create([
+        'title' => 'Markdown Syntax Guide',
+        'slug' => 'index',
+        'full_path' => 'guides/index',
+        'content' => 'Markdown basics and examples for guide pages.',
+    ]);
+
+    Post::factory()->for($other, 'namespace')->published()->create([
+        'title' => 'Operations Guide',
+        'slug' => 'operations-guide',
+        'full_path' => 'operations/guide',
+        'content' => 'Operations content.',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('search', ['namespace' => 'guides']))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('search/index')
+            ->where('namespace', 'guides')
+            ->has('results', 1)
+            ->where('results.0.path', '/guides/index')
+        );
+});
+
+test('non guides namespace returns no dummy results', function () {
+    $user = User::factory()->create();
+    PostNamespace::factory()->create([
+        'name' => 'Guides',
+        'slug' => 'guides',
+        'full_path' => 'guides',
+        'is_published' => true,
+        'parent_id' => null,
+    ]);
+    PostNamespace::factory()->create([
+        'name' => 'Operations',
+        'slug' => 'operations',
+        'full_path' => 'operations',
+        'is_published' => true,
+        'parent_id' => null,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('search', ['namespace' => 'operations']))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('search/index')
+            ->where('namespace', 'operations')
+            ->has('results', 0)
+        );
+});


### PR DESCRIPTION
## Summary
- add a shared search popover and a placeholder search results page
- expose the search route and shared namespace options for public and app header entrypoints
- cover the flow with feature and browser tests

## Validation
- vendor/bin/sail npm run types:check
- vendor/bin/sail artisan test --compact tests/Feature/SearchControllerTest.php tests/Browser/AppHeaderSearchTest.php tests/Browser/CanonicalSearchAccessTest.php
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail npm run build