### PR TITLE
Add post page view tracking

### DIFF
--- a/app/Console/Commands/NamespaceBackupCommand.php
+++ b/app/Console/Commands/NamespaceBackupCommand.php
@@ -94,6 +94,7 @@ class NamespaceBackupCommand extends Command
                 'title' => $post->title,
                 'slug' => $post->slug,
                 'full_path' => $post->full_path,
+                'page_views' => $post->page_views,
                 'is_draft' => $post->is_draft,
                 'published_at' => $post->published_at?->toIso8601String(),
             ];

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -339,7 +339,17 @@ class PostController extends Controller
     {
         return Inertia::render('admin/posts/show', [
             'namespace' => $namespace,
-            'post' => $post,
+            'post' => $post->only([
+                'id',
+                'title',
+                'slug',
+                'full_path',
+                'content',
+                'is_draft',
+                'published_at',
+                'created_at',
+                'page_views',
+            ]),
         ]);
     }
 

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class DashboardController extends Controller
+{
+    public function __invoke(): Response
+    {
+        $topPosts = Post::query()
+            ->where('page_views', '>', 0)
+            ->orderByDesc('page_views')
+            ->orderByDesc('updated_at')
+            ->limit(10)
+            ->get([
+                'id',
+                'namespace_id',
+                'title',
+                'slug',
+                'full_path',
+                'page_views',
+                'is_draft',
+                'published_at',
+            ])
+            ->map(fn (Post $post): array => [
+                'id' => $post->id,
+                'title' => $post->title,
+                'slug' => $post->slug,
+                'full_path' => $post->full_path,
+                'page_views' => $post->page_views,
+                'canonical_url' => ! $post->is_draft && $post->published_at !== null && $post->published_at->isPast()
+                    ? route('posts.path', ['path' => $post->full_path], absolute: false)
+                    : null,
+                'admin_url' => route('admin.posts.show', [
+                    'namespace' => $post->namespace_id,
+                    'post' => $post->slug,
+                ], absolute: false),
+            ])
+            ->values()
+            ->all();
+
+        return Inertia::render('dashboard', [
+            'top_posts' => $topPosts,
+        ]);
+    }
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -6,14 +6,36 @@ use App\Models\Post;
 use App\Models\PostNamespace;
 use App\Support\ReservedContentPath;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Cookie;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class PostController extends Controller
 {
+    private const PAGE_VIEW_COOKIE_TTL_MINUTES = 60;
+
+    /**
+     * @var array<int, string>
+     */
+    private const BOT_USER_AGENT_FRAGMENTS = [
+        'bot',
+        'crawler',
+        'spider',
+        'slurp',
+        'facebookexternalhit',
+        'twitterbot',
+        'slackbot',
+        'discordbot',
+        'linkedinbot',
+        'embedly',
+        'curl',
+        'wget',
+    ];
+
     public function index(): Response
     {
         $namespaces = PostNamespace::published()
@@ -52,7 +74,7 @@ class PostController extends Controller
         );
     }
 
-    public function resolve(string $path): Response
+    public function resolve(Request $request, string $path): Response
     {
         $normalizedPath = trim($path, '/');
 
@@ -62,6 +84,7 @@ class PostController extends Controller
 
         if ($resolvedPost !== null) {
             return $this->renderPost(
+                $request,
                 $resolvedPost['post'],
                 $resolvedPost['ancestors'],
                 $resolvedPost['preview'],
@@ -144,15 +167,27 @@ class PostController extends Controller
     /**
      * @param  Collection<int, PostNamespace>  $ancestors
      */
-    private function renderPost(Post $post, Collection $ancestors, bool $preview = false): Response
+    private function renderPost(Request $request, Post $post, Collection $ancestors, bool $preview = false): Response
     {
         $namespace = $post->namespace;
         $rootNamespace = $this->rootNamespace($namespace, $ancestors);
+        $pageViews = $post->page_views;
         $posts = $namespace->posts()
             ->tap(fn (Builder $query) => $this->applyPublishedPostScope($query))
             ->orderBy('published_at')
             ->orderBy('id')
             ->get(['id', 'slug', 'full_path', 'title', 'published_at']);
+
+        if (
+            ! $preview
+            && ! $this->isBotRequest($request)
+            && ! $request->hasCookie($this->pageViewCookieName($post))
+        ) {
+            $post->increment('page_views');
+            $pageViews++;
+
+            Cookie::queue($this->pageViewCookieName($post), '1', self::PAGE_VIEW_COOKIE_TTL_MINUTES);
+        }
 
         return Inertia::render('posts/show', [
             'breadcrumbs' => $this->breadcrumbs($ancestors),
@@ -160,13 +195,38 @@ class PostController extends Controller
             'navRoot' => $this->buildNavigationNode($rootNamespace),
             'namespace' => $namespace->only(['id', 'slug', 'full_path', 'name', 'cover_image_url']),
             'postUrl' => route('posts.path', ['path' => $post->full_path]),
-            'post' => $post->only(['id', 'slug', 'full_path', 'title', 'content', 'published_at', 'updated_at']),
+            'post' => [
+                ...$post->only(['id', 'slug', 'full_path', 'title', 'content', 'published_at', 'updated_at']),
+                'page_views' => $pageViews,
+            ],
             'posts' => $namespace->sortPosts($posts),
             'preview' => $preview ? [
                 'status' => $post->is_draft ? 'draft' : 'scheduled',
                 'published_at' => $post->published_at?->toISOString(),
             ] : null,
         ]);
+    }
+
+    private function pageViewCookieName(Post $post): string
+    {
+        return 'post_viewed_'.$post->id;
+    }
+
+    private function isBotRequest(Request $request): bool
+    {
+        $userAgent = strtolower($request->userAgent() ?? '');
+
+        if ($userAgent === '') {
+            return false;
+        }
+
+        foreach (self::BOT_USER_AGENT_FRAGMENTS as $fragment) {
+            if (str_contains($userAgent, $fragment)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function resolveCardImage(Post $post, PostNamespace $namespace): ?string

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -19,6 +19,7 @@ class Post extends Model
         'slug',
         'full_path',
         'content',
+        'page_views',
         'user_id',
         'is_draft',
         'published_at',
@@ -28,6 +29,7 @@ class Post extends Model
     {
         return [
             'is_draft' => 'boolean',
+            'page_views' => 'integer',
             'published_at' => 'datetime',
         ];
     }

--- a/app/Support/NamespaceRestoreArchive.php
+++ b/app/Support/NamespaceRestoreArchive.php
@@ -271,6 +271,7 @@ class NamespaceRestoreArchive
             $post->title = (string) $frontmatter['title'];
             $post->slug = (string) $frontmatter['slug'];
             $post->content = $body;
+            $post->page_views = (int) ($frontmatter['page_views'] ?? 0);
             $post->is_draft = (bool) ($frontmatter['is_draft'] ?? false);
             $post->published_at = $frontmatter['published_at'] ?? null;
             $post->save();

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -23,6 +23,7 @@ class PostFactory extends Factory
             'title' => $title,
             'slug' => Str::slug($title),
             'content' => implode("\n\n", fake()->paragraphs(3)),
+            'page_views' => 0,
             'is_draft' => false,
             'published_at' => now(),
         ];

--- a/database/migrations/2026_04_23_071241_add_page_views_to_posts_table.php
+++ b/database/migrations/2026_04_23_071241_add_page_views_to_posts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->unsignedBigInteger('page_views')->default(0)->after('content');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('page_views');
+        });
+    }
+};

--- a/resources/js/components/post-header.tsx
+++ b/resources/js/components/post-header.tsx
@@ -9,6 +9,7 @@ import {
     ArrowLeft,
     Pencil,
     Trash2,
+    Eye,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -35,6 +36,7 @@ type Post = {
     title: string;
     slug: string;
     full_path: string;
+    page_views?: number;
     is_draft: boolean;
     published_at: string | null;
 };
@@ -138,6 +140,12 @@ export default function PostHeader({
                             </span>
                         )}
                     </div>
+                    {typeof post.page_views === 'number' && (
+                        <div className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-white/70 px-3 py-1 text-xs font-medium text-sky-800 dark:bg-sky-900/30 dark:text-sky-200">
+                            <Eye className="size-3.5" />
+                            {post.page_views.toLocaleString()} views
+                        </div>
+                    )}
                     {mode === 'edit' && (
                         <div className="mt-3">
                             <Button variant="outline" asChild>

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -101,6 +101,7 @@ type Post = {
     slug: string;
     full_path: string;
     content: string;
+    page_views: number;
     is_draft: boolean;
     published_at: string | null;
     created_at: string;

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,25 +1,109 @@
-import { Head } from '@inertiajs/react';
-import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
+import { Head, Link } from '@inertiajs/react';
+import { BarChart3, ExternalLink, Eye, FileText } from 'lucide-react';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
 import { dashboard } from '@/routes';
 
-export default function Dashboard() {
+type TopPost = {
+    id: number;
+    title: string;
+    slug: string;
+    full_path: string;
+    page_views: number;
+    canonical_url: string | null;
+    admin_url: string;
+};
+
+export default function Dashboard({ top_posts }: { top_posts: TopPost[] }) {
+    const totalViews = top_posts.reduce(
+        (sum, post) => sum + post.page_views,
+        0,
+    );
+
     return (
         <>
             <Head title="Dashboard" />
-            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
-                <div className="grid auto-rows-min gap-4 md:grid-cols-3">
-                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                        <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
-                    </div>
-                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                        <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
-                    </div>
-                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                        <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
-                    </div>
-                </div>
-                <div className="relative min-h-[100vh] flex-1 overflow-hidden rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border">
-                    <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
+            <div className="flex flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
+                <div className="grid gap-4 lg:grid-cols-[280px_1fr]">
+                    <Card className="border-sky-200/80 bg-linear-to-br from-sky-50 via-white to-cyan-50 shadow-none dark:border-sky-900/60 dark:from-sky-950/40 dark:via-background dark:to-cyan-950/30">
+                        <CardHeader>
+                            <CardDescription>Page Views</CardDescription>
+                            <CardTitle className="text-3xl">
+                                {totalViews.toLocaleString()}
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="flex items-center gap-3 text-sm text-muted-foreground">
+                            <div className="rounded-lg bg-sky-100 p-2 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
+                                <BarChart3 className="size-4" />
+                            </div>
+                            Current top 10 posts by tracked canonical views.
+                        </CardContent>
+                    </Card>
+
+                    <Card className="shadow-none">
+                        <CardHeader>
+                            <CardDescription>Top Posts</CardDescription>
+                            <CardTitle>View Top 10</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            {top_posts.length === 0 ? (
+                                <div className="rounded-xl border border-dashed px-6 py-10 text-center text-sm text-muted-foreground">
+                                    No tracked page views yet.
+                                </div>
+                            ) : (
+                                <div className="space-y-3">
+                                    {top_posts.map((post, index) => (
+                                        <div
+                                            key={post.id}
+                                            className="flex flex-col gap-3 rounded-xl border px-4 py-4 sm:flex-row sm:items-center sm:justify-between"
+                                        >
+                                            <div className="flex min-w-0 items-start gap-4">
+                                                <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-semibold text-muted-foreground">
+                                                    {index + 1}
+                                                </div>
+                                                <div className="min-w-0">
+                                                    <Link
+                                                        href={post.admin_url}
+                                                        className="inline-flex items-center gap-2 font-medium hover:underline"
+                                                    >
+                                                        <FileText className="size-4 shrink-0 text-muted-foreground" />
+                                                        <span className="truncate">
+                                                            {post.title}
+                                                        </span>
+                                                    </Link>
+                                                    <p className="mt-1 truncate text-sm text-muted-foreground">
+                                                        /{post.full_path}
+                                                    </p>
+                                                </div>
+                                            </div>
+                                            <div className="flex items-center justify-between gap-4 sm:justify-end">
+                                                <div className="inline-flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-sm font-medium">
+                                                    <Eye className="size-4 text-muted-foreground" />
+                                                    {post.page_views.toLocaleString()}
+                                                </div>
+                                                {post.canonical_url ? (
+                                                    <Link
+                                                        href={
+                                                            post.canonical_url
+                                                        }
+                                                        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                                                    >
+                                                        Canonical
+                                                        <ExternalLink className="size-4" />
+                                                    </Link>
+                                                ) : null}
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </CardContent>
+                    </Card>
                 </div>
             </div>
         </>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\OgpController;
+use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ImageController;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\SearchController;
@@ -25,7 +26,7 @@ Route::get('/api/ogp', [OgpController::class, 'fetch'])
     ->name('api.ogp');
 
 Route::middleware(['auth', 'verified'])->group(function () {
-    Route::inertia('dashboard', 'dashboard')->name('dashboard');
+    Route::get('dashboard', DashboardController::class)->name('dashboard');
 });
 
 require __DIR__.'/settings.php';

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -38,15 +38,21 @@ function addAdminNamespaceBackupTreeToZip(ZipArchive $zip, array $tree, string $
     ], 4));
 
     foreach ($tree['posts'] ?? [] as $post) {
+        $frontmatter = [
+            'title' => $post['title'],
+            'slug' => $post['slug'],
+            'full_path' => $post['full_path'] ?? (($tree['full_path'] ?? $tree['slug']).'/'.$post['slug']),
+            'is_draft' => $post['is_draft'] ?? false,
+            'published_at' => $post['published_at'] ?? now()->toIso8601String(),
+        ];
+
+        if (array_key_exists('page_views', $post)) {
+            $frontmatter['page_views'] = $post['page_views'];
+        }
+
         $zip->addFromString(
             $prefix.$post['slug'].'.md',
-            "---\n".Yaml::dump([
-                'title' => $post['title'],
-                'slug' => $post['slug'],
-                'full_path' => $post['full_path'] ?? (($tree['full_path'] ?? $tree['slug']).'/'.$post['slug']),
-                'is_draft' => $post['is_draft'] ?? false,
-                'published_at' => $post['published_at'] ?? now()->toIso8601String(),
-            ])."---\n\n".rtrim($post['content'])."\n"
+            "---\n".Yaml::dump($frontmatter)."---\n\n".rtrim($post['content'])."\n"
         );
     }
 
@@ -1079,6 +1085,7 @@ test('authenticated users can view a post details page', function () {
         'namespace_id' => $namespace->id,
         'title' => 'Release Notes',
         'slug' => 'release-notes',
+        'page_views' => 27,
         'is_draft' => false,
     ]);
 
@@ -1091,7 +1098,23 @@ test('authenticated users can view a post details page', function () {
             ->where('post.id', $post->id)
             ->where('post.slug', 'release-notes')
             ->where('post.title', 'Release Notes')
+            ->where('post.page_views', 27)
         );
+});
+
+test('admin post details page does not increment page views', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'page_views' => 12,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.show', [$namespace, $post]))
+        ->assertOk();
+
+    expect($post->fresh()->page_views)->toBe(12);
 });
 
 test('post details are scoped to their namespace', function () {

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Post;
+use App\Models\PostNamespace;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -15,5 +17,40 @@ test('authenticated users can visit the dashboard', function () {
     $this->actingAs($user);
 
     $response = $this->get(route('dashboard'));
-    $response->assertOk();
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('dashboard')
+            ->where('top_posts', [])
+        );
+});
+
+test('dashboard shows top 10 posts ordered by page views', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'full_path' => 'guides',
+    ]);
+
+    $topPosts = collect(range(1, 12))->map(function (int $index) use ($namespace, $user) {
+        return Post::factory()->for($user)->for($namespace, 'namespace')->published()->create([
+            'title' => "Post {$index}",
+            'slug' => "post-{$index}",
+            'full_path' => "guides/post-{$index}",
+            'page_views' => $index * 10,
+        ]);
+    });
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('dashboard')
+            ->has('top_posts', 10)
+            ->where('top_posts.0.title', $topPosts->last()->title)
+            ->where('top_posts.0.page_views', 120)
+            ->where('top_posts.0.admin_url', route('admin.posts.show', [$namespace->id, $topPosts->last()->slug], false))
+            ->where('top_posts.0.canonical_url', route('posts.path', ['path' => $topPosts->last()->full_path], false))
+            ->where('top_posts.9.title', $topPosts->get(2)->title)
+            ->where('top_posts.9.page_views', 30)
+        );
 });

--- a/tests/Feature/NamespaceBackupCommandTest.php
+++ b/tests/Feature/NamespaceBackupCommandTest.php
@@ -40,15 +40,21 @@ function addNamespaceBackupTreeToZip(ZipArchive $zip, array $tree, string $prefi
     ], 4));
 
     foreach ($tree['posts'] ?? [] as $post) {
+        $frontmatter = [
+            'title' => $post['title'],
+            'slug' => $post['slug'],
+            'full_path' => $post['full_path'] ?? (($tree['full_path'] ?? $tree['slug']).'/'.$post['slug']),
+            'is_draft' => $post['is_draft'] ?? false,
+            'published_at' => $post['published_at'] ?? now()->toIso8601String(),
+        ];
+
+        if (array_key_exists('page_views', $post)) {
+            $frontmatter['page_views'] = $post['page_views'];
+        }
+
         $zip->addFromString(
             $prefix.$post['slug'].'.md',
-            "---\n".Yaml::dump([
-                'title' => $post['title'],
-                'slug' => $post['slug'],
-                'full_path' => $post['full_path'] ?? (($tree['full_path'] ?? $tree['slug']).'/'.$post['slug']),
-                'is_draft' => $post['is_draft'] ?? false,
-                'published_at' => $post['published_at'] ?? now()->toIso8601String(),
-            ])."---\n\n".rtrim($post['content'])."\n"
+            "---\n".Yaml::dump($frontmatter)."---\n\n".rtrim($post['content'])."\n"
         );
 
         if (! empty($post['revisions'])) {
@@ -90,6 +96,7 @@ test('namespace backup command exports namespace metadata and markdown posts', f
         'title' => 'Routing',
         'slug' => 'routing',
         'full_path' => 'guides/routing',
+        'page_views' => 42,
         'content' => "# Routing\n\n![Diagram](/images/posts/123/diagram.png)\n\nBackup me.",
     ]);
 
@@ -124,6 +131,7 @@ test('namespace backup command exports namespace metadata and markdown posts', f
     expect($postMarkdown)->toContain('title: Routing')
         ->toContain('slug: routing')
         ->toContain('full_path: guides/routing')
+        ->toContain('page_views: 42')
         ->toContain('![Diagram](/images/posts/123/diagram.png)')
         ->toContain("# Routing\n\n![Diagram](/images/posts/123/diagram.png)\n\nBackup me.")
         ->and($coverImage)->toBe('cover-image-bytes')
@@ -147,6 +155,7 @@ test('namespace restore command imports a namespace backup zip', function () {
             [
                 'title' => 'Laravel AI SDK',
                 'slug' => 'laravel-ai-sdk',
+                'page_views' => 11,
                 'content' => "# Laravel AI SDK\n\n![Diagram](/images/posts/legacy-id/ai-sdk.png)\n\nIntro.",
             ],
             [
@@ -186,6 +195,8 @@ test('namespace restore command imports a namespace backup zip', function () {
                 'laravel-ai-sdk',
                 'upgrade-12-to-13',
             ])
+            ->and($posts->firstWhere('slug', 'laravel-ai-sdk')?->page_views)->toBe(11)
+            ->and($posts->firstWhere('slug', 'upgrade-12-to-13')?->page_views)->toBe(0)
             ->and($posts->pluck('user_id')->unique()->all())->toBe([$user->id]);
 
         Storage::disk('public')->assertExists('namespaces/laravel-13-cover.jpg');
@@ -273,6 +284,36 @@ test('namespace backup and restore commands preserve nested namespaces and posts
         ->and($restoredChildPost->full_path)->toBe('inertiajs-v3/childspace/page');
 
     File::delete($zipPath);
+});
+
+test('namespace restore command defaults page views to zero for older backups', function () {
+    $user = User::factory()->create();
+    $zipPath = createNamespaceBackupZip([
+        'slug' => 'legacy',
+        'name' => 'Legacy',
+        'full_path' => 'legacy',
+        'posts' => [
+            [
+                'title' => 'Old Post',
+                'slug' => 'old-post',
+                'content' => 'Legacy content',
+            ],
+        ],
+    ]);
+
+    try {
+        $this->artisan('namespace:restore', [
+            'path' => $zipPath,
+        ])->assertSuccessful();
+
+        $post = Post::query()->where('full_path', 'legacy/old-post')->first();
+
+        expect($post)->not->toBeNull()
+            ->and($post->user_id)->toBe($user->id)
+            ->and($post->page_views)->toBe(0);
+    } finally {
+        File::delete($zipPath);
+    }
 });
 
 test('namespace restore command fails when no user exists', function () {

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -195,6 +195,73 @@ test('published namespace shows post with breadcrumbs', function () {
         );
 });
 
+test('published post increments page views and queues a tracking cookie', function () {
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'is_published' => true,
+    ]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'slug' => 'routing',
+        'page_views' => 4,
+    ]);
+
+    $response = $this->get(route('posts.path', ['path' => $post->full_path]));
+
+    $response->assertSuccessful()
+        ->assertCookie('post_viewed_'.$post->id, '1')
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/show')
+            ->where('post.id', $post->id)
+            ->where('post.page_views', 5)
+        );
+
+    expect($post->fresh()->page_views)->toBe(5);
+});
+
+test('published post does not increment page views again while tracking cookie exists', function () {
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'is_published' => true,
+    ]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'slug' => 'routing',
+        'page_views' => 9,
+    ]);
+
+    $this->withCookie('post_viewed_'.$post->id, '1')
+        ->get(route('posts.path', ['path' => $post->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/show')
+            ->where('post.id', $post->id)
+            ->where('post.page_views', 9)
+        );
+
+    expect($post->fresh()->page_views)->toBe(9);
+});
+
+test('published post does not increment page views for bot user agents', function () {
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'is_published' => true,
+    ]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'slug' => 'routing',
+        'page_views' => 7,
+    ]);
+
+    $this->withHeader('User-Agent', 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)')
+        ->get(route('posts.path', ['path' => $post->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/show')
+            ->where('post.id', $post->id)
+            ->where('post.page_views', 7)
+        );
+
+    expect($post->fresh()->page_views)->toBe(7);
+});
+
 test('guest post page receives no authenticated user', function () {
     $namespace = PostNamespace::factory()->create([
         'slug' => 'guides',
@@ -308,6 +375,30 @@ test('authenticated users can access preview markdown for draft posts', function
         ->assertSeeText('Preview content')
         ->assertSeeText('# Draft Post')
         ->assertSeeText('Preview only.');
+});
+
+test('previewing a draft post does not increment page views', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'is_published' => true,
+    ]);
+    $post = Post::factory()->for($namespace, 'namespace')->draft()->create([
+        'slug' => 'routing',
+        'page_views' => 3,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('posts.path', ['path' => $post->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/show')
+            ->where('post.id', $post->id)
+            ->where('post.page_views', 3)
+            ->where('preview.status', 'draft')
+        );
+
+    expect($post->fresh()->page_views)->toBe(3);
 });
 
 test('homepage counts published posts from descendant namespaces', function () {


### PR DESCRIPTION
## Summary
- track canonical post page views with bot and repeat-visit suppression plus expose counts in canonical and admin post views
- add a dashboard controller and UI to show the top viewed posts with links to canonical and admin pages
- preserve page view counts in namespace backup and restore flows, using a forward migration for the new column

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/PostControllerTest.php tests/Feature/DashboardTest.php tests/Feature/Admin/PostControllerTest.php tests/Feature/NamespaceBackupCommandTest.php
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm exec -- eslint resources/js/components/post-header.tsx resources/js/pages/admin/posts/show.tsx resources/js/pages/dashboard.tsx
- vendor/bin/sail npm run build
- vendor/bin/sail bin pint --dirty --format agent