### PR TITLE
Add post reference metadata

### DIFF
--- a/app/Console/Commands/NamespaceBackupCommand.php
+++ b/app/Console/Commands/NamespaceBackupCommand.php
@@ -97,6 +97,8 @@ class NamespaceBackupCommand extends Command
                 'page_views' => $post->page_views,
                 'is_draft' => $post->is_draft,
                 'published_at' => $post->published_at?->toIso8601String(),
+                'reference_title' => $post->reference_title,
+                'reference_url' => $post->reference_url,
             ];
 
             $content = "---\n".Yaml::dump($frontmatter)."---\n\n".$post->content."\n";

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -349,6 +349,8 @@ class PostController extends Controller
                 'published_at',
                 'created_at',
                 'page_views',
+                'reference_title',
+                'reference_url',
             ]),
         ]);
     }
@@ -357,7 +359,17 @@ class PostController extends Controller
     {
         return Inertia::render('admin/posts/edit', [
             'namespace' => $namespace,
-            'post' => $post,
+            'post' => $post->only([
+                'id',
+                'title',
+                'slug',
+                'full_path',
+                'content',
+                'is_draft',
+                'published_at',
+                'reference_title',
+                'reference_url',
+            ]),
             'slugPrefix' => trim($namespace->full_path, '/').'/',
         ]);
     }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -196,7 +196,7 @@ class PostController extends Controller
             'namespace' => $namespace->only(['id', 'slug', 'full_path', 'name', 'cover_image_url']),
             'postUrl' => route('posts.path', ['path' => $post->full_path]),
             'post' => [
-                ...$post->only(['id', 'slug', 'full_path', 'title', 'content', 'published_at', 'updated_at']),
+                ...$post->only(['id', 'slug', 'full_path', 'title', 'content', 'published_at', 'updated_at', 'reference_title', 'reference_url']),
                 'page_views' => $pageViews,
             ],
             'posts' => $namespace->sortPosts($posts),

--- a/app/Http/Requests/Admin/StorePostRequest.php
+++ b/app/Http/Requests/Admin/StorePostRequest.php
@@ -55,6 +55,8 @@ class StorePostRequest extends FormRequest
             'content' => ['required', 'string'],
             'is_draft' => ['boolean'],
             'published_at' => ['nullable', 'date'],
+            'reference_title' => ['nullable', 'string', 'max:255'],
+            'reference_url' => ['nullable', 'url', 'max:2048'],
         ];
     }
 

--- a/app/Http/Requests/Admin/UpdatePostRequest.php
+++ b/app/Http/Requests/Admin/UpdatePostRequest.php
@@ -57,6 +57,8 @@ class UpdatePostRequest extends FormRequest
             'content' => ['required', 'string'],
             'is_draft' => ['boolean'],
             'published_at' => ['nullable', 'date'],
+            'reference_title' => ['nullable', 'string', 'max:255'],
+            'reference_url' => ['nullable', 'url', 'max:2048'],
         ];
     }
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -25,6 +25,8 @@ class Post extends Model
         'user_id',
         'is_draft',
         'published_at',
+        'reference_title',
+        'reference_url',
     ];
 
     protected function casts(): array

--- a/app/Support/NamespaceRestoreArchive.php
+++ b/app/Support/NamespaceRestoreArchive.php
@@ -274,6 +274,8 @@ class NamespaceRestoreArchive
             $post->page_views = (int) ($frontmatter['page_views'] ?? 0);
             $post->is_draft = (bool) ($frontmatter['is_draft'] ?? false);
             $post->published_at = $frontmatter['published_at'] ?? null;
+            $post->reference_title = $frontmatter['reference_title'] ?? null;
+            $post->reference_url = $frontmatter['reference_url'] ?? null;
             $post->save();
 
             if ($withRevisions) {

--- a/database/migrations/2026_04_24_004045_add_reference_fields_to_posts_table.php
+++ b/database/migrations/2026_04_24_004045_add_reference_fields_to_posts_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('reference_title')->nullable()->after('published_at');
+            $table->string('reference_url', 2048)->nullable()->after('reference_title');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn(['reference_title', 'reference_url']);
+        });
+    }
+};

--- a/resources/js/components/cover-image-dropzone.tsx
+++ b/resources/js/components/cover-image-dropzone.tsx
@@ -1,6 +1,7 @@
 import { ImageMinus, ImagePlus, ImageUp, Pencil, X } from 'lucide-react';
 import type { CSSProperties } from 'react';
 import { useEffect, useRef, useState } from 'react';
+import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -10,7 +11,6 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
-import InputError from '@/components/input-error';
 import { cn } from '@/lib/utils';
 
 const COVER_IMAGE_ASPECT_RATIO = 16 / 9;

--- a/resources/js/pages/admin/posts/create.tsx
+++ b/resources/js/pages/admin/posts/create.tsx
@@ -175,6 +175,37 @@ export default function Create({
                                 )}
                             />
 
+                            <div className="grid gap-4 rounded-lg border border-dashed p-4">
+                                <p className="text-sm font-medium text-muted-foreground">
+                                    Reference (optional)
+                                </p>
+                                <div className="grid gap-2">
+                                    <Label htmlFor="reference_title">
+                                        Title
+                                    </Label>
+                                    <Input
+                                        id="reference_title"
+                                        name="reference_title"
+                                        placeholder="Reference title"
+                                    />
+                                    <InputError
+                                        message={errors.reference_title}
+                                    />
+                                </div>
+                                <div className="grid gap-2">
+                                    <Label htmlFor="reference_url">URL</Label>
+                                    <Input
+                                        id="reference_url"
+                                        name="reference_url"
+                                        type="url"
+                                        placeholder="https://example.com"
+                                    />
+                                    <InputError
+                                        message={errors.reference_url}
+                                    />
+                                </div>
+                            </div>
+
                             <div className="flex items-center gap-2">
                                 <input
                                     type="hidden"

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -34,6 +34,8 @@ type Post = {
     content: string;
     is_draft: boolean;
     published_at: string | null;
+    reference_title: string | null;
+    reference_url: string | null;
 };
 
 export default function Edit({
@@ -245,6 +247,41 @@ export default function Edit({
                                 })}
                                 jumpTo={jumpTo}
                             />
+
+                            <div className="grid gap-4 rounded-lg border border-dashed p-4">
+                                <p className="text-sm font-medium text-muted-foreground">
+                                    Reference (optional)
+                                </p>
+                                <div className="grid gap-2">
+                                    <Label htmlFor="reference_title">
+                                        Title
+                                    </Label>
+                                    <Input
+                                        id="reference_title"
+                                        name="reference_title"
+                                        placeholder="Reference title"
+                                        defaultValue={
+                                            post.reference_title ?? ''
+                                        }
+                                    />
+                                    <InputError
+                                        message={errors.reference_title}
+                                    />
+                                </div>
+                                <div className="grid gap-2">
+                                    <Label htmlFor="reference_url">URL</Label>
+                                    <Input
+                                        id="reference_url"
+                                        name="reference_url"
+                                        type="url"
+                                        placeholder="https://example.com"
+                                        defaultValue={post.reference_url ?? ''}
+                                    />
+                                    <InputError
+                                        message={errors.reference_url}
+                                    />
+                                </div>
+                            </div>
 
                             <div className="flex items-center gap-2">
                                 <input

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -105,6 +105,8 @@ type Post = {
     is_draft: boolean;
     published_at: string | null;
     created_at: string;
+    reference_title: string | null;
+    reference_url: string | null;
 };
 
 export default function Show({
@@ -246,9 +248,26 @@ export default function Show({
                         }
                     >
                         <div className="min-w-0 rounded-xl border bg-card p-6">
-                            <div className="mb-6 rounded-lg border bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
-                                /{post.full_path}
-                            </div>
+                            {post.reference_url && (
+                                <div className="mb-6 flex justify-end">
+                                    <a
+                                        href={post.reference_url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="inline-flex items-center gap-2 rounded-md border border-border/60 px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                                    >
+                                        <span className="text-muted-foreground/60">
+                                            Source
+                                        </span>
+                                        <span className="h-3 w-px bg-border" />
+                                        <span className="max-w-64 truncate">
+                                            {post.reference_title ??
+                                                post.reference_url}
+                                        </span>
+                                        <ExternalLink className="size-3 shrink-0" />
+                                    </a>
+                                </div>
+                            )}
                             {post.is_draft && (
                                 <div className="mb-6 flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800/40 dark:bg-amber-900/20">
                                     <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />

--- a/resources/js/pages/posts/index.tsx
+++ b/resources/js/pages/posts/index.tsx
@@ -1,10 +1,12 @@
 import { Head, Link, usePage } from '@inertiajs/react';
 import { ImageOff, Settings2 } from 'lucide-react';
 import DocsSearchTrigger from '@/components/docs-search-trigger';
+import { SimpleIconSvg } from '@/components/markdown-card-group';
 import SearchPopover from '@/components/search-popover';
 import { Button } from '@/components/ui/button';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import { useCurrentUrl } from '@/hooks/use-current-url';
+import { getSimpleIcon } from '@/lib/simple-icon-lookup';
 import { login } from '@/routes';
 import { namespace as adminNamespaceRoute } from '@/routes/admin/posts';
 import { path as contentPath } from '@/routes/posts';
@@ -24,6 +26,7 @@ export default function Index({ namespaces }: { namespaces: PostNamespace[] }) {
         auth: { user: { id: number; name: string } | null };
     }>().props;
     const { currentUrl } = useCurrentUrl();
+    const githubIcon = getSimpleIcon('github');
 
     return (
         <>
@@ -134,6 +137,31 @@ export default function Index({ namespaces }: { namespaces: PostNamespace[] }) {
                         </div>
                     )}
                 </div>
+
+                <footer className="border-t">
+                    <div className="mx-auto flex max-w-7xl justify-center px-4 py-6 text-sm text-muted-foreground">
+                        <p className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-center">
+                            <span>Powered by ThinkStream</span>
+                            <a
+                                href="https://github.com/catatsumuri/thinkstream"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-2 font-medium text-foreground underline underline-offset-4 transition-opacity hover:opacity-70"
+                                data-test="homepage-github-link"
+                            >
+                                {githubIcon && (
+                                    <span data-test="homepage-github-icon">
+                                        <SimpleIconSvg
+                                            icon={githubIcon}
+                                            className="size-4"
+                                        />
+                                    </span>
+                                )}
+                                github.com/catatsumuri/thinkstream
+                            </a>
+                        </p>
+                    </div>
+                </footer>
             </div>
         </>
     );

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -3,6 +3,7 @@ import {
     AlertTriangle,
     BookOpen,
     ChevronRight,
+    ExternalLink,
     List,
     PanelLeftClose,
     PanelLeftOpen,
@@ -63,6 +64,8 @@ type Post = {
     content: string;
     published_at: string;
     updated_at: string;
+    reference_title: string | null;
+    reference_url: string | null;
 };
 
 function findHeadingOffset(
@@ -526,6 +529,27 @@ export default function Show({
                                         </span>
                                     </div>
                                 </div>
+                                {post.reference_url && (
+                                    <div className="flex justify-end">
+                                        <a
+                                            href={post.reference_url}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="inline-flex items-center gap-2 rounded-md border border-border/60 px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                                        >
+                                            <span className="text-muted-foreground/60">
+                                                Source
+                                            </span>
+                                            <span className="h-3 w-px bg-border" />
+                                            <span className="max-w-64 truncate">
+                                                {post.reference_title ??
+                                                    post.reference_url}
+                                            </span>
+                                            <ExternalLink className="size-3 shrink-0" />
+                                        </a>
+                                    </div>
+                                )}
+
                                 <div className="flex flex-col gap-3">
                                     <div
                                         data-test="post-header-actions"
@@ -563,10 +587,10 @@ export default function Show({
                                 />
                             </div>
 
-                            <footer className="border-t pt-4">
+                            <footer className="flex justify-end border-t pt-4">
                                 <time
                                     dateTime={post.updated_at}
-                                    className="text-sm text-muted-foreground"
+                                    className="text-xs text-muted-foreground/60"
                                 >
                                     Last updated:{' '}
                                     {postDateFormatter.format(

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -14,7 +14,24 @@ test('top page loads', function () {
 
     $page
         ->assertSee('ThinkStream')
-        ->assertPresent('[data-test="docs-search-shortcut"]');
+        ->assertPresent('[data-test="docs-search-shortcut"]')
+        ->assertSee('Powered by ThinkStream')
+        ->assertAttribute(
+            '[data-test="homepage-github-link"]',
+            'href',
+            'https://github.com/catatsumuri/thinkstream',
+        )
+        ->assertAttribute(
+            '[data-test="homepage-github-link"]',
+            'target',
+            '_blank',
+        )
+        ->assertAttribute(
+            '[data-test="homepage-github-link"]',
+            'rel',
+            'noopener noreferrer',
+        )
+        ->assertPresent('[data-test="homepage-github-icon"]');
 });
 
 test('published post headings expose copyable anchor links', function () {

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -966,6 +966,8 @@ test('authenticated users can store a post', function () {
             'slug' => 'hello-world',
             'content' => '# Hello\n\nThis is a test post.',
             'published_at' => null,
+            'reference_title' => 'Laravel Routing',
+            'reference_url' => 'https://laravel.com/docs/routing',
         ])
         ->assertSessionHasNoErrors()
         ->assertSessionHas('inertia.flash_data.toast', [
@@ -979,6 +981,8 @@ test('authenticated users can store a post', function () {
         'title' => 'Hello World',
         'slug' => 'hello-world',
         'user_id' => $user->id,
+        'reference_title' => 'Laravel Routing',
+        'reference_url' => 'https://laravel.com/docs/routing',
     ]);
 
     expect(Post::query()->where('slug', 'hello-world')->value('published_at'))->not->toBeNull();
@@ -1087,6 +1091,8 @@ test('authenticated users can view a post details page', function () {
         'slug' => 'release-notes',
         'page_views' => 27,
         'is_draft' => false,
+        'reference_title' => 'Release Notes Source',
+        'reference_url' => 'https://example.com/release-notes',
     ]);
 
     $this->actingAs($user)
@@ -1099,6 +1105,8 @@ test('authenticated users can view a post details page', function () {
             ->where('post.slug', 'release-notes')
             ->where('post.title', 'Release Notes')
             ->where('post.page_views', 27)
+            ->where('post.reference_title', 'Release Notes Source')
+            ->where('post.reference_url', 'https://example.com/release-notes')
         );
 });
 
@@ -1141,6 +1149,8 @@ test('authenticated users can update a post', function () {
             'slug' => 'new-slug',
             'content' => 'Updated content.',
             'published_at' => null,
+            'reference_title' => 'Updated Reference',
+            'reference_url' => 'https://example.com/updated-reference',
         ])
         ->assertSessionHasNoErrors()
         ->assertRedirect(route('admin.posts.edit', [$namespace, 'new-slug']));
@@ -1149,6 +1159,8 @@ test('authenticated users can update a post', function () {
     expect($post->title)->toBe('New Title');
     expect($post->slug)->toBe('new-slug');
     expect($post->published_at)->not->toBeNull();
+    expect($post->reference_title)->toBe('Updated Reference');
+    expect($post->reference_url)->toBe('https://example.com/updated-reference');
 });
 
 test('updating a post allows keeping the same slug', function () {

--- a/tests/Feature/NamespaceBackupCommandTest.php
+++ b/tests/Feature/NamespaceBackupCommandTest.php
@@ -52,6 +52,14 @@ function addNamespaceBackupTreeToZip(ZipArchive $zip, array $tree, string $prefi
             $frontmatter['page_views'] = $post['page_views'];
         }
 
+        if (array_key_exists('reference_title', $post)) {
+            $frontmatter['reference_title'] = $post['reference_title'];
+        }
+
+        if (array_key_exists('reference_url', $post)) {
+            $frontmatter['reference_url'] = $post['reference_url'];
+        }
+
         $zip->addFromString(
             $prefix.$post['slug'].'.md',
             "---\n".Yaml::dump($frontmatter)."---\n\n".rtrim($post['content'])."\n"
@@ -97,6 +105,8 @@ test('namespace backup command exports namespace metadata and markdown posts', f
         'slug' => 'routing',
         'full_path' => 'guides/routing',
         'page_views' => 42,
+        'reference_title' => 'Laravel Routing Docs',
+        'reference_url' => 'https://laravel.com/docs/routing',
         'content' => "# Routing\n\n![Diagram](/images/posts/123/diagram.png)\n\nBackup me.",
     ]);
 
@@ -132,6 +142,8 @@ test('namespace backup command exports namespace metadata and markdown posts', f
         ->toContain('slug: routing')
         ->toContain('full_path: guides/routing')
         ->toContain('page_views: 42')
+        ->toContain("reference_title: 'Laravel Routing Docs'")
+        ->toContain("reference_url: 'https://laravel.com/docs/routing'")
         ->toContain('![Diagram](/images/posts/123/diagram.png)')
         ->toContain("# Routing\n\n![Diagram](/images/posts/123/diagram.png)\n\nBackup me.")
         ->and($coverImage)->toBe('cover-image-bytes')
@@ -156,6 +168,8 @@ test('namespace restore command imports a namespace backup zip', function () {
                 'title' => 'Laravel AI SDK',
                 'slug' => 'laravel-ai-sdk',
                 'page_views' => 11,
+                'reference_title' => 'Laravel AI SDK Docs',
+                'reference_url' => 'https://laravel.com/docs/ai',
                 'content' => "# Laravel AI SDK\n\n![Diagram](/images/posts/legacy-id/ai-sdk.png)\n\nIntro.",
             ],
             [
@@ -196,6 +210,8 @@ test('namespace restore command imports a namespace backup zip', function () {
                 'upgrade-12-to-13',
             ])
             ->and($posts->firstWhere('slug', 'laravel-ai-sdk')?->page_views)->toBe(11)
+            ->and($posts->firstWhere('slug', 'laravel-ai-sdk')?->reference_title)->toBe('Laravel AI SDK Docs')
+            ->and($posts->firstWhere('slug', 'laravel-ai-sdk')?->reference_url)->toBe('https://laravel.com/docs/ai')
             ->and($posts->firstWhere('slug', 'upgrade-12-to-13')?->page_views)->toBe(0)
             ->and($posts->pluck('user_id')->unique()->all())->toBe([$user->id]);
 

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -178,6 +178,8 @@ test('published namespace shows post with breadcrumbs', function () {
     ]);
     $post = Post::factory()->for($child, 'namespace')->published()->create([
         'slug' => 'routing',
+        'reference_title' => 'Laravel Routing',
+        'reference_url' => 'https://laravel.com/docs/routing',
     ]);
 
     $this->get(route('posts.path', ['path' => $post->full_path]))
@@ -189,6 +191,8 @@ test('published namespace shows post with breadcrumbs', function () {
             ->where('navRoot.children.0.posts.0.full_path', $post->full_path)
             ->where('namespace.full_path', $child->full_path)
             ->where('post.full_path', $post->full_path)
+            ->where('post.reference_title', 'Laravel Routing')
+            ->where('post.reference_url', 'https://laravel.com/docs/routing')
             ->where('postUrl', route('posts.path', ['path' => $post->full_path]))
             ->where('breadcrumbs.0.full_path', $root->full_path)
             ->where('posts.0.full_path', $post->full_path)


### PR DESCRIPTION
## Summary
- add reference title/url support to post create, edit, admin preview, public display, and backup/restore flows
- add a forward migration for the new post reference columns with a safe URL length
- extend feature and browser coverage for reference metadata and homepage footer rendering

## Testing
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail artisan test --compact tests/Feature/Admin/PostControllerTest.php tests/Feature/PostControllerTest.php tests/Feature/NamespaceBackupCommandTest.php
- vendor/bin/sail php vendor/bin/pest tests/Browser/SmokeTest.php --compact
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build