### PR TITLE
Fix admin post show navigation and backup lookup

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -16,6 +16,7 @@ use App\Support\NamespaceRestoreArchive;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\StreamedEvent;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
@@ -357,8 +358,11 @@ class PostController extends Controller
 
     public function show(PostNamespace $namespace, Post $post): Response
     {
+        $rootNamespace = $this->rootNamespace($namespace);
+
         return Inertia::render('admin/posts/show', [
             'namespace' => $namespace,
+            'navRoot' => $this->buildNavigationTree($rootNamespace),
             'post' => $post->only([
                 'id',
                 'title',
@@ -373,6 +377,105 @@ class PostController extends Controller
                 'reference_url',
             ]),
         ]);
+    }
+
+    private function rootNamespace(PostNamespace $namespace): PostNamespace
+    {
+        $root = $namespace;
+
+        while ($root->parent_id) {
+            $root = PostNamespace::select(['id', 'parent_id', 'slug', 'full_path', 'name', 'post_order'])
+                ->findOrFail($root->parent_id);
+        }
+
+        return $root;
+    }
+
+    private function buildNavigationTree(PostNamespace $rootNamespace): array
+    {
+        $rootPath = trim($rootNamespace->full_path, '/');
+
+        if ($rootPath === '') {
+            return $this->buildNavigationNodeRecursively($rootNamespace);
+        }
+
+        $namespaces = PostNamespace::query()
+            ->whereKey($rootNamespace->id)
+            ->orWhere('full_path', 'like', $rootPath.'/%')
+            ->get(['id', 'parent_id', 'slug', 'full_path', 'name', 'post_order'])
+            ->keyBy('id');
+
+        $namespacesByParent = $namespaces
+            ->groupBy(fn (PostNamespace $namespace): int => $namespace->parent_id ?? 0)
+            ->map(fn ($group) => $group->values());
+
+        $postsByNamespace = Post::query()
+            ->whereIn('namespace_id', $namespaces->keys())
+            ->orderBy('published_at')
+            ->orderBy('id')
+            ->get(['namespace_id', 'title', 'full_path', 'slug'])
+            ->groupBy('namespace_id')
+            ->map(fn ($group) => $group->values());
+
+        return $this->buildNavigationNode($rootNamespace, $namespacesByParent->all(), $postsByNamespace->all());
+    }
+
+    private function buildNavigationNodeRecursively(PostNamespace $namespace): array
+    {
+        $children = $namespace->children()->get(['id', 'slug', 'full_path', 'name', 'post_order']);
+        $posts = $namespace->sortPosts(
+            $namespace->posts()
+                ->orderBy('published_at')
+                ->orderBy('id')
+                ->get(['namespace_id', 'title', 'full_path', 'slug'])
+        );
+
+        return [
+            'name' => $namespace->name,
+            'full_path' => $namespace->full_path,
+            'href' => route('admin.posts.namespace', ['namespace' => $namespace], absolute: false),
+            'children' => $namespace->sortNamespaces($children)
+                ->map(fn (PostNamespace $child) => $this->buildNavigationNodeRecursively($child))
+                ->values()
+                ->all(),
+            'posts' => $posts->map(fn (Post $post) => [
+                'title' => $post->title,
+                'full_path' => $post->full_path,
+                'href' => route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug], absolute: false),
+            ])->values()->all(),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     name: string,
+     *     full_path: string,
+     *     href: string,
+     *     children: array<int, mixed>,
+     *     posts: array<int, array{title: string, full_path: string, href: string}>
+     * }
+     */
+    private function buildNavigationNode(PostNamespace $namespace, array $namespacesByParent, array $postsByNamespace): array
+    {
+        /** @var Collection<int, PostNamespace> $children */
+        $children = collect($namespacesByParent[$namespace->id] ?? []);
+        /** @var Collection<int, Post> $posts */
+        $posts = $namespace->sortPosts(collect($postsByNamespace[$namespace->id] ?? []));
+
+        return [
+            'name' => $namespace->name,
+            'full_path' => $namespace->full_path,
+            'href' => route('admin.posts.namespace', ['namespace' => $namespace], absolute: false),
+            'children' => $namespace->sortNamespaces($children)
+                ->map(fn (PostNamespace $child) => $this->buildNavigationNode($child, $namespacesByParent, $postsByNamespace))
+                ->values()
+                ->all(),
+            'posts' => $posts->map(fn (Post $post) => [
+                'title' => $post->title,
+                'full_path' => $post->full_path,
+                'href' => route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug], absolute: false),
+            ])->values()->all(),
+        ];
     }
 
     public function edit(PostNamespace $namespace, Post $post): Response
@@ -574,9 +677,15 @@ class PostController extends Controller
             return [];
         }
 
-        $backupPaths = collect(
-            File::glob($backupDirectory.'/'.NamespaceBackupArchive::currentPrefix($namespace).'-*.zip') ?: []
-        );
+        $backupPaths = collect([
+            ...(
+                File::glob($backupDirectory.'/'.NamespaceBackupArchive::currentPrefix($namespace).'-*.zip')
+                ?: []
+            ),
+            ...collect(NamespaceBackupArchive::legacyLookupPatterns($namespace))
+                ->flatMap(fn (string $pattern): array => File::glob($backupDirectory.'/'.$pattern.'-*.zip') ?: [])
+                ->all(),
+        ]);
 
         if (PostNamespace::query()->where('slug', $namespace->slug)->count() === 1) {
             $backupPaths = $backupPaths->merge(

--- a/app/Support/NamespaceBackupArchive.php
+++ b/app/Support/NamespaceBackupArchive.php
@@ -26,6 +26,22 @@ class NamespaceBackupArchive
             return 'namespace-'.$namespace->id;
         }
 
-        return 'namespace-'.$namespace->id.'-'.str_replace('/', '--', $path);
+        return str_replace('/', '--', $path);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function legacyLookupPatterns(PostNamespace $namespace): array
+    {
+        $path = trim($namespace->full_path, '/');
+
+        if ($path === '') {
+            return [];
+        }
+
+        return [
+            'namespace-*-'.str_replace('/', '--', $path),
+        ];
     }
 }

--- a/resources/js/components/content-nav-tree.tsx
+++ b/resources/js/components/content-nav-tree.tsx
@@ -7,10 +7,12 @@ import { path as contentPath } from '@/routes/posts';
 export type ContentNavNode = {
     name: string;
     full_path: string;
+    href?: string;
     children: ContentNavNode[];
     posts: Array<{
         title: string;
         full_path: string;
+        href?: string;
     }>;
 };
 
@@ -75,7 +77,7 @@ function TreeNode({
                         </span>
                     )}
                     <Link
-                        href={contentPath.url(node.full_path)}
+                        href={node.href ?? contentPath.url(node.full_path)}
                         onClick={() => onNavigate?.()}
                         data-active={
                             currentPath === node.full_path ? 'true' : undefined
@@ -117,7 +119,7 @@ function TreeNode({
                     {node.posts.map((post) => (
                         <Link
                             key={post.full_path}
-                            href={contentPath.url(post.full_path)}
+                            href={post.href ?? contentPath.url(post.full_path)}
                             onClick={() => onNavigate?.()}
                             data-active={
                                 currentPath === post.full_path

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -210,11 +210,7 @@ export default function Show({
             <div className="space-y-4 p-4">
                 <PostHeader namespace={namespace} post={post} />
 
-                <div
-                    className={
-                        gridCols ? `lg:grid lg:gap-8 ${gridCols}` : ''
-                    }
-                >
+                <div className={gridCols ? `lg:grid lg:gap-8 ${gridCols}` : ''}>
                     {hasNav && (
                         <aside className="hidden self-start lg:sticky lg:top-20 lg:block">
                             {navVisible ? (

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -2,16 +2,20 @@ import { Head, router, setLayoutProps } from '@inertiajs/react';
 import {
     AlertTriangle,
     ExternalLink,
+    PanelLeftClose,
+    PanelLeftOpen,
     PanelRightClose,
     PanelRightOpen,
 } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import type { ContentNavNode } from '@/components/content-nav-tree';
+import ContentNavTree from '@/components/content-nav-tree';
 import MarkdownContent from '@/components/markdown-content';
 import PostHeader from '@/components/post-header';
 import TableOfContents from '@/components/table-of-contents';
+import { useBelowDesktop } from '@/hooks/use-below-desktop';
 import { useCurrentUrl } from '@/hooks/use-current-url';
 import { useMarkdownToc } from '@/hooks/use-markdown-toc';
-import { useIsMobile } from '@/hooks/use-mobile';
 import { normalizeMarkdownHeadingText } from '@/lib/markdown-heading-text';
 import { dashboard } from '@/routes';
 import {
@@ -111,14 +115,17 @@ type Post = {
 
 export default function Show({
     namespace,
+    navRoot,
     post,
 }: {
     namespace: Namespace;
+    navRoot: ContentNavNode;
     post: Post;
 }) {
     const { currentUrl } = useCurrentUrl();
-    const isMobile = useIsMobile();
+    const isBelowDesktop = useBelowDesktop();
     const [tocOverride, setTocOverride] = useState<boolean | null>(null);
+    const [navOverride, setNavOverride] = useState<boolean | null>(null);
     const tocPosts = useMemo(
         () => [{ slug: post.slug, content: post.content }],
         [post.content, post.slug],
@@ -163,7 +170,27 @@ export default function Show({
     });
     const entry = toc.get(post.slug);
     const hasHeadings = (entry?.headings.length ?? 0) > 0;
-    const tocVisible = tocOverride ?? !isMobile;
+    const hasNav = navRoot.children.length > 0 || navRoot.posts.length > 0;
+    const navVisible = navOverride ?? true;
+    const tocVisible = tocOverride ?? true;
+    const showDesktopSidebars = !isBelowDesktop;
+    const showDesktopNav = showDesktopSidebars && hasNav;
+    const showDesktopToc = showDesktopSidebars && tocVisible && hasHeadings;
+
+    let gridCols = '';
+
+    if (showDesktopNav && navVisible && showDesktopToc) {
+        gridCols = 'lg:grid-cols-[240px_1fr_240px]';
+    } else if (showDesktopNav && navVisible) {
+        gridCols = 'lg:grid-cols-[240px_1fr]';
+    } else if (showDesktopNav && !navVisible && showDesktopToc) {
+        gridCols = 'lg:grid-cols-[40px_1fr_240px]';
+    } else if (showDesktopNav && !navVisible) {
+        gridCols = 'lg:grid-cols-[40px_1fr]';
+    } else if (showDesktopToc) {
+        gridCols = 'lg:grid-cols-[1fr_240px]';
+    }
+
     setLayoutProps({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
@@ -180,73 +207,114 @@ export default function Show({
         <>
             <Head title={post.title} />
 
-            <div className="space-y-6 p-4">
+            <div className="space-y-4 p-4">
                 <PostHeader namespace={namespace} post={post} />
 
-                <section className="space-y-4">
-                    <div className="flex items-center justify-between gap-4 rounded-xl border bg-card px-5 py-4">
-                        <div className="flex items-center gap-3">
-                            <div>
-                                <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
-                                    Preview
-                                </p>
-                                <p className="mt-1 text-sm text-muted-foreground">
-                                    Canonical rendering inside the admin
-                                    workflow.
-                                </p>
-                            </div>
-                            <a
-                                href={`/${post.full_path}`}
-                                target="_blank"
-                                rel="noreferrer"
-                                className="text-muted-foreground transition-colors hover:text-foreground"
-                                title="Open canonical URL"
-                            >
-                                <ExternalLink className="size-4" />
-                            </a>
-                        </div>
-                        {hasHeadings && (
-                            <button
-                                type="button"
-                                onClick={() =>
-                                    setTocOverride(
-                                        (prev) => !(prev ?? !isMobile),
-                                    )
-                                }
-                                className="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
-                            >
-                                {tocVisible ? (
-                                    <PanelRightClose size={16} />
-                                ) : (
-                                    <PanelRightOpen size={16} />
-                                )}
-                                TOC
-                            </button>
-                        )}
-                    </div>
-
-                    {tocVisible && hasHeadings && (
-                        <div className="xl:hidden">
-                            <TableOfContents
-                                posts={[
-                                    {
-                                        id: post.id,
-                                        title: post.title,
-                                        slug: post.slug,
-                                        headings: entry!.headings,
-                                    },
-                                ]}
-                            />
-                        </div>
+                <div
+                    className={
+                        gridCols ? `lg:grid lg:gap-8 ${gridCols}` : ''
+                    }
+                >
+                    {hasNav && (
+                        <aside className="hidden self-start lg:sticky lg:top-20 lg:block">
+                            {navVisible ? (
+                                <div className="flex max-h-[calc(100vh-6rem)] flex-col text-sm">
+                                    <div className="shrink-0 pb-4">
+                                        <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                                            {navRoot.name}
+                                        </p>
+                                    </div>
+                                    <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain pr-3">
+                                        <ContentNavTree
+                                            currentPath={post.full_path}
+                                            root={navRoot}
+                                        />
+                                    </div>
+                                    <div className="mt-6 shrink-0 border-t border-border/60 pt-4">
+                                        <button
+                                            type="button"
+                                            onClick={() =>
+                                                setNavOverride(false)
+                                            }
+                                            className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                                        >
+                                            <PanelLeftClose size={14} />
+                                            Close
+                                        </button>
+                                    </div>
+                                </div>
+                            ) : (
+                                <div className="flex justify-center">
+                                    <button
+                                        type="button"
+                                        onClick={() => setNavOverride(true)}
+                                        className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                                        title="Open nav"
+                                    >
+                                        <PanelLeftOpen size={16} />
+                                    </button>
+                                </div>
+                            )}
+                        </aside>
                     )}
 
-                    <div
-                        className={
-                            tocVisible && hasHeadings
-                                ? 'xl:grid xl:grid-cols-[1fr_240px] xl:gap-8'
-                                : ''
-                        }
-                    >
+                    <section className="min-w-0 space-y-4">
+                        <div className="flex items-center justify-between gap-4 rounded-xl border bg-card px-5 py-4">
+                            <div className="flex items-center gap-3">
+                                <div>
+                                    <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                                        Preview
+                                    </p>
+                                    <p className="mt-1 text-sm text-muted-foreground">
+                                        Canonical rendering inside the admin
+                                        workflow.
+                                    </p>
+                                </div>
+                                <a
+                                    href={`/${post.full_path}`}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="text-muted-foreground transition-colors hover:text-foreground"
+                                    title="Open canonical URL"
+                                >
+                                    <ExternalLink className="size-4" />
+                                </a>
+                            </div>
+                            {hasHeadings && (
+                                <button
+                                    type="button"
+                                    onClick={() =>
+                                        setTocOverride(
+                                            (prev) => !(prev ?? true),
+                                        )
+                                    }
+                                    className="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                                >
+                                    {tocVisible ? (
+                                        <PanelRightClose size={16} />
+                                    ) : (
+                                        <PanelRightOpen size={16} />
+                                    )}
+                                    TOC
+                                </button>
+                            )}
+                        </div>
+
+                        {tocVisible && hasHeadings && (
+                            <div className="lg:hidden">
+                                <TableOfContents
+                                    posts={[
+                                        {
+                                            id: post.id,
+                                            title: post.title,
+                                            slug: post.slug,
+                                            headings: entry!.headings,
+                                        },
+                                    ]}
+                                />
+                            </div>
+                        )}
+
                         <div className="min-w-0 rounded-xl border bg-card p-6">
                             {post.reference_url && (
                                 <div className="mb-6 flex justify-end">
@@ -317,24 +385,24 @@ export default function Show({
                                 />
                             </div>
                         </div>
+                    </section>
 
-                        {tocVisible && hasHeadings && (
-                            <aside className="hidden xl:block">
-                                <TableOfContents
-                                    sticky
-                                    posts={[
-                                        {
-                                            id: post.id,
-                                            title: post.title,
-                                            slug: post.slug,
-                                            headings: entry!.headings,
-                                        },
-                                    ]}
-                                />
-                            </aside>
-                        )}
-                    </div>
-                </section>
+                    {showDesktopToc && (
+                        <aside className="hidden self-start lg:sticky lg:top-20 lg:block">
+                            <TableOfContents
+                                sticky
+                                posts={[
+                                    {
+                                        id: post.id,
+                                        title: post.title,
+                                        slug: post.slug,
+                                        headings: entry!.headings,
+                                    },
+                                ]}
+                            />
+                        </aside>
+                    )}
+                </div>
             </div>
         </>
     );

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -508,6 +508,45 @@ test('namespace backup management separates namespaces that share the same slug'
     }
 });
 
+test('namespace backup management includes legacy id-prefixed backups', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides-legacy-backup',
+        'full_path' => 'guides-legacy-backup',
+        'name' => 'Guides Legacy Backup',
+    ]);
+
+    $backupDirectory = NamespaceBackupArchive::directory();
+    $backupPrefix = NamespaceBackupArchive::currentPrefix($namespace);
+    $legacyPrefix = 'namespace-'.$namespace->id.'-'.$backupPrefix;
+    File::ensureDirectoryExists($backupDirectory);
+    File::delete([
+        ...File::glob($backupDirectory.'/'.$backupPrefix.'-*.zip'),
+        ...File::glob($backupDirectory.'/'.$legacyPrefix.'-*.zip'),
+    ]);
+
+    $legacyBackup = $backupDirectory.'/'.$legacyPrefix.'-20260421-040506.zip';
+    File::put($legacyBackup, 'legacy');
+
+    try {
+        $this->actingAs($user)
+            ->get(route('admin.posts.backups', $namespace))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('admin/posts/backups')
+                ->where('namespace.id', $namespace->id)
+                ->where('namespace.backup_count', 1)
+                ->has('backups', 1)
+                ->where('backups.0.filename', basename($legacyBackup))
+            );
+    } finally {
+        File::delete([
+            ...File::glob($backupDirectory.'/'.$backupPrefix.'-*.zip'),
+            ...File::glob($backupDirectory.'/'.$legacyPrefix.'-*.zip'),
+        ]);
+    }
+});
+
 test('authenticated users can create a namespace backup from backup management', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create([
@@ -1131,6 +1170,40 @@ test('authenticated users can view a post details page', function () {
             ->where('post.page_views', 27)
             ->where('post.reference_title', 'Release Notes Source')
             ->where('post.reference_url', 'https://example.com/release-notes')
+        );
+});
+
+test('admin post details page includes admin navigation rooted at the top namespace', function () {
+    $user = User::factory()->create();
+    $root = PostNamespace::factory()->create([
+        'slug' => 'guides-admin-nav',
+        'full_path' => 'guides-admin-nav',
+        'name' => 'Guides Admin Nav',
+    ]);
+    $child = PostNamespace::factory()->create([
+        'parent_id' => $root->id,
+        'slug' => 'laravel',
+        'full_path' => 'guides-admin-nav/laravel',
+        'name' => 'Laravel',
+    ]);
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $child->id,
+        'slug' => 'routing',
+        'full_path' => 'guides-admin-nav/laravel/routing',
+        'title' => 'Routing',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.show', [$child, $post]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/show')
+            ->where('navRoot.full_path', $root->full_path)
+            ->where('navRoot.href', route('admin.posts.namespace', $root, false))
+            ->where('navRoot.children.0.full_path', $child->full_path)
+            ->where('navRoot.children.0.href', route('admin.posts.namespace', $child, false))
+            ->where('navRoot.children.0.posts.0.full_path', $post->full_path)
+            ->where('navRoot.children.0.posts.0.href', route('admin.posts.show', [$child, $post], false))
         );
 });
 


### PR DESCRIPTION
## Summary
- keep admin post show sidebar navigation inside the admin flow by passing admin hrefs into the shared content nav tree
- keep namespace backup management compatible with legacy id-prefixed backup archives while using the new readable prefix
- build the admin navigation tree from preloaded namespace/post collections and cover the new behavior with feature tests