### PR TITLE
Prefetch empty-root admin post navigation

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -395,13 +395,15 @@ class PostController extends Controller
     {
         $rootPath = trim($rootNamespace->full_path, '/');
 
-        if ($rootPath === '') {
-            return $this->buildNavigationNodeRecursively($rootNamespace);
+        $namespaceQuery = PostNamespace::query();
+
+        if ($rootPath !== '') {
+            $namespaceQuery
+                ->whereKey($rootNamespace->id)
+                ->orWhere('full_path', 'like', $rootPath.'/%');
         }
 
-        $namespaces = PostNamespace::query()
-            ->whereKey($rootNamespace->id)
-            ->orWhere('full_path', 'like', $rootPath.'/%')
+        $namespaces = $namespaceQuery
             ->get(['id', 'parent_id', 'slug', 'full_path', 'name', 'post_order'])
             ->keyBy('id');
 
@@ -409,8 +411,12 @@ class PostController extends Controller
             ->groupBy(fn (PostNamespace $namespace): int => $namespace->parent_id ?? 0)
             ->map(fn ($group) => $group->values());
 
+        $namespaceIds = $rootPath === ''
+            ? $this->navigationSubtreeNamespaceIds($rootNamespace->id, $namespacesByParent->all())
+            : $namespaces->keys()->all();
+
         $postsByNamespace = Post::query()
-            ->whereIn('namespace_id', $namespaces->keys())
+            ->whereIn('namespace_id', $namespaceIds)
             ->orderBy('published_at')
             ->orderBy('id')
             ->get(['namespace_id', 'title', 'full_path', 'slug'])
@@ -420,30 +426,29 @@ class PostController extends Controller
         return $this->buildNavigationNode($rootNamespace, $namespacesByParent->all(), $postsByNamespace->all());
     }
 
-    private function buildNavigationNodeRecursively(PostNamespace $namespace): array
+    /**
+     * @param  array<int, Collection<int, PostNamespace>>  $namespacesByParent
+     * @return array<int, int>
+     */
+    private function navigationSubtreeNamespaceIds(int $rootNamespaceId, array $namespacesByParent): array
     {
-        $children = $namespace->children()->get(['id', 'slug', 'full_path', 'name', 'post_order']);
-        $posts = $namespace->sortPosts(
-            $namespace->posts()
-                ->orderBy('published_at')
-                ->orderBy('id')
-                ->get(['namespace_id', 'title', 'full_path', 'slug'])
-        );
+        $namespaceIds = [$rootNamespaceId];
+        $pendingParentIds = [$rootNamespaceId];
 
-        return [
-            'name' => $namespace->name,
-            'full_path' => $namespace->full_path,
-            'href' => route('admin.posts.namespace', ['namespace' => $namespace], absolute: false),
-            'children' => $namespace->sortNamespaces($children)
-                ->map(fn (PostNamespace $child) => $this->buildNavigationNodeRecursively($child))
-                ->values()
-                ->all(),
-            'posts' => $posts->map(fn (Post $post) => [
-                'title' => $post->title,
-                'full_path' => $post->full_path,
-                'href' => route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug], absolute: false),
-            ])->values()->all(),
-        ];
+        while ($pendingParentIds !== []) {
+            $parentId = array_pop($pendingParentIds);
+
+            if ($parentId === null) {
+                continue;
+            }
+
+            foreach ($namespacesByParent[$parentId] ?? [] as $childNamespace) {
+                $namespaceIds[] = $childNamespace->id;
+                $pendingParentIds[] = $childNamespace->id;
+            }
+        }
+
+        return $namespaceIds;
     }
 
     /**

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -67,7 +67,7 @@ export default [
                 'error',
                 {
                     prefer: 'type-imports',
-                    fixStyle: 'separate-type-imports',
+                    fixStyle: 'inline-type-imports',
                 },
             ],
             'import/order': [
@@ -89,8 +89,9 @@ export default [
             ],
             'import/consistent-type-specifier-style': [
                 'error',
-                'prefer-top-level',
+                'prefer-inline',
             ],
+            'import/no-duplicates': ['error', { 'prefer-inline': true }],
         },
     },
     {

--- a/resources/js/components/app-content.tsx
+++ b/resources/js/components/app-content.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SidebarInset } from '@/components/ui/sidebar';
-import type { AppVariant } from '@/types';
+import { type AppVariant } from '@/types';
 
 type Props = React.ComponentProps<'main'> & {
     variant?: AppVariant;

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -35,7 +35,7 @@ import { useCurrentUrl } from '@/hooks/use-current-url';
 import { useInitials } from '@/hooks/use-initials';
 import { cn, toUrl } from '@/lib/utils';
 import { dashboard, home } from '@/routes';
-import type { BreadcrumbItem, NavItem } from '@/types';
+import { type BreadcrumbItem, type NavItem } from '@/types';
 
 type Props = {
     breadcrumbs?: BreadcrumbItem[];

--- a/resources/js/components/app-logo-icon.tsx
+++ b/resources/js/components/app-logo-icon.tsx
@@ -1,4 +1,4 @@
-import type { ImgHTMLAttributes } from 'react';
+import { type ImgHTMLAttributes } from 'react';
 
 export default function AppLogoIcon(
     props: ImgHTMLAttributes<HTMLImageElement>,

--- a/resources/js/components/app-shell.tsx
+++ b/resources/js/components/app-shell.tsx
@@ -1,7 +1,7 @@
 import { usePage } from '@inertiajs/react';
-import type { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { SidebarProvider } from '@/components/ui/sidebar';
-import type { AppVariant } from '@/types';
+import { type AppVariant } from '@/types';
 
 type Props = {
     children: ReactNode;

--- a/resources/js/components/app-sidebar-header.tsx
+++ b/resources/js/components/app-sidebar-header.tsx
@@ -1,6 +1,6 @@
 import { Breadcrumbs } from '@/components/breadcrumbs';
 import { SidebarTrigger } from '@/components/ui/sidebar';
-import type { BreadcrumbItem as BreadcrumbItemType } from '@/types';
+import { type BreadcrumbItem as BreadcrumbItemType } from '@/types';
 
 export function AppSidebarHeader({
     breadcrumbs = [],

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/components/ui/sidebar';
 import { useCurrentUrl } from '@/hooks/use-current-url';
 import { dashboard, home } from '@/routes';
-import type { NavItem } from '@/types';
+import { type NavItem } from '@/types';
 
 const mainNavItems: NavItem[] = [
     {

--- a/resources/js/components/appearance-tabs.tsx
+++ b/resources/js/components/appearance-tabs.tsx
@@ -1,8 +1,6 @@
-import type { LucideIcon } from 'lucide-react';
-import { Monitor, Moon, Sun } from 'lucide-react';
-import type { HTMLAttributes } from 'react';
-import type { Appearance } from '@/hooks/use-appearance';
-import { useAppearance } from '@/hooks/use-appearance';
+import { type LucideIcon, Monitor, Moon, Sun } from 'lucide-react';
+import { type HTMLAttributes } from 'react';
+import { type Appearance, useAppearance } from '@/hooks/use-appearance';
 import { cn } from '@/lib/utils';
 
 export default function AppearanceToggleTab({

--- a/resources/js/components/breadcrumbs.tsx
+++ b/resources/js/components/breadcrumbs.tsx
@@ -8,7 +8,7 @@ import {
     BreadcrumbPage,
     BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
-import type { BreadcrumbItem as BreadcrumbItemType } from '@/types';
+import { type BreadcrumbItem as BreadcrumbItemType } from '@/types';
 
 export function Breadcrumbs({
     breadcrumbs,

--- a/resources/js/components/code-block.tsx
+++ b/resources/js/components/code-block.tsx
@@ -1,7 +1,6 @@
 import { Check, Copy, MoveHorizontal, WrapText } from 'lucide-react';
-import type { ComponentPropsWithoutRef } from 'react';
-import { useEffect, useState } from 'react';
-import type { ExtraProps } from 'react-markdown';
+import { type ComponentPropsWithoutRef, useEffect, useState } from 'react';
+import { type ExtraProps } from 'react-markdown';
 import { MermaidBlock } from '@/components/mermaid-block';
 import { useClipboard } from '@/hooks/use-clipboard';
 import Prism, { ensurePrismLoaded } from '@/lib/prism';

--- a/resources/js/components/cover-image-dropzone.tsx
+++ b/resources/js/components/cover-image-dropzone.tsx
@@ -1,6 +1,5 @@
 import { ImageMinus, ImagePlus, ImageUp, Pencil, X } from 'lucide-react';
-import type { CSSProperties } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { type CSSProperties, useEffect, useRef, useState } from 'react';
 import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
 import {

--- a/resources/js/components/input-error.tsx
+++ b/resources/js/components/input-error.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes } from 'react';
+import { type HTMLAttributes } from 'react';
 import { cn } from '@/lib/utils';
 
 export default function InputError({

--- a/resources/js/components/markdown-api-fields.tsx
+++ b/resources/js/components/markdown-api-fields.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
 interface ApiFieldBaseProps {

--- a/resources/js/components/markdown-badge.tsx
+++ b/resources/js/components/markdown-badge.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { getLucideIcon, SimpleIconSvg } from '@/components/markdown-card-group';
 import { Badge } from '@/components/ui/badge';
 import { Icon } from '@/components/ui/icon';

--- a/resources/js/components/markdown-card-group.tsx
+++ b/resources/js/components/markdown-card-group.tsx
@@ -47,13 +47,12 @@ import {
     Users,
     XCircle,
     Zap,
+    type LucideIcon,
 } from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Icon } from '@/components/ui/icon';
 import { sanitizeMarkdownCardHref } from '@/lib/markdown-card-href';
-import type { SimpleIcon } from '@/lib/simple-icon-lookup';
-import { getSimpleIcon } from '@/lib/simple-icon-lookup';
+import { type SimpleIcon, getSimpleIcon } from '@/lib/simple-icon-lookup';
 import { cn } from '@/lib/utils';
 
 const ICON_MAP: Record<string, LucideIcon> = {

--- a/resources/js/components/markdown-code-group.tsx
+++ b/resources/js/components/markdown-code-group.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode } from 'react';
-import { useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { CodeBlock } from '@/components/code-block';
 import { SimpleIconSvg } from '@/components/markdown-card-group';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -1,6 +1,5 @@
 import { AlertTriangle, CircleCheck, Info, Lightbulb } from 'lucide-react';
-import type { Components } from 'react-markdown';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import {
     defListHastHandlers,
     remarkDefinitionList,

--- a/resources/js/components/markdown-image.tsx
+++ b/resources/js/components/markdown-image.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithoutRef } from 'react';
+import { type ComponentPropsWithoutRef } from 'react';
 import { parseMarkdownImageMetadata } from '@/lib/markdown-syntax';
 import { cn } from '@/lib/utils';
 

--- a/resources/js/components/markdown-steps.tsx
+++ b/resources/js/components/markdown-steps.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
 interface MarkdownStepsProps {
     children?: ReactNode;

--- a/resources/js/components/markdown-tabs.tsx
+++ b/resources/js/components/markdown-tabs.tsx
@@ -1,5 +1,11 @@
-import type { ReactNode } from 'react';
-import { Children, isValidElement, useEffect, useMemo, useState } from 'react';
+import {
+    type ReactNode,
+    Children,
+    isValidElement,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 

--- a/resources/js/components/markdown-tooltip.tsx
+++ b/resources/js/components/markdown-tooltip.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import {
     Tooltip,
     TooltipContent,

--- a/resources/js/components/markdown-update.tsx
+++ b/resources/js/components/markdown-update.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
 interface MarkdownUpdateProps {
     'data-update-label'?: string;

--- a/resources/js/components/nav-footer.tsx
+++ b/resources/js/components/nav-footer.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithoutRef } from 'react';
+import { type ComponentPropsWithoutRef } from 'react';
 import {
     SidebarGroup,
     SidebarGroupContent,
@@ -7,7 +7,7 @@ import {
     SidebarMenuItem,
 } from '@/components/ui/sidebar';
 import { toUrl } from '@/lib/utils';
-import type { NavItem } from '@/types';
+import { type NavItem } from '@/types';
 
 export function NavFooter({
     items,

--- a/resources/js/components/nav-main.tsx
+++ b/resources/js/components/nav-main.tsx
@@ -7,7 +7,7 @@ import {
     SidebarMenuItem,
 } from '@/components/ui/sidebar';
 import { useCurrentUrl } from '@/hooks/use-current-url';
-import type { NavItem } from '@/types';
+import { type NavItem } from '@/types';
 
 export function NavMain({ items = [] }: { items: NavItem[] }) {
     const { isCurrentUrl } = useCurrentUrl();

--- a/resources/js/components/password-input.tsx
+++ b/resources/js/components/password-input.tsx
@@ -1,6 +1,5 @@
 import { Eye, EyeOff } from 'lucide-react';
-import type { ComponentProps, Ref } from 'react';
-import { useState } from 'react';
+import { type ComponentProps, type Ref, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 

--- a/resources/js/components/table-of-contents.tsx
+++ b/resources/js/components/table-of-contents.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { Heading } from '@/hooks/use-markdown-toc';
+import { type Heading } from '@/hooks/use-markdown-toc';
 import { cn } from '@/lib/utils';
 
 type TocPost = {

--- a/resources/js/components/text-link.tsx
+++ b/resources/js/components/text-link.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@inertiajs/react';
-import type { ComponentProps } from 'react';
+import { type ComponentProps } from 'react';
 import { cn } from '@/lib/utils';
 
 type Props = ComponentProps<typeof Link>;

--- a/resources/js/components/user-info.tsx
+++ b/resources/js/components/user-info.tsx
@@ -1,6 +1,6 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { useInitials } from '@/hooks/use-initials';
-import type { User } from '@/types';
+import { type User } from '@/types';
 
 export function UserInfo({
     user,

--- a/resources/js/components/user-menu-content.tsx
+++ b/resources/js/components/user-menu-content.tsx
@@ -10,7 +10,7 @@ import { UserInfo } from '@/components/user-info';
 import { useMobileNavigation } from '@/hooks/use-mobile-navigation';
 import { logout } from '@/routes';
 import { edit } from '@/routes/profile';
-import type { User } from '@/types';
+import { type User } from '@/types';
 
 type Props = {
     user: User;

--- a/resources/js/hooks/use-current-url.ts
+++ b/resources/js/hooks/use-current-url.ts
@@ -1,5 +1,4 @@
-import type { InertiaLinkProps } from '@inertiajs/react';
-import { usePage } from '@inertiajs/react';
+import { usePage, type InertiaLinkProps } from '@inertiajs/react';
 import { toUrl } from '@/lib/utils';
 
 export type IsCurrentUrlFn = (

--- a/resources/js/hooks/use-flash-toast.ts
+++ b/resources/js/hooks/use-flash-toast.ts
@@ -1,7 +1,7 @@
 import { router } from '@inertiajs/react';
 import { useEffect } from 'react';
 import { toast } from 'sonner';
-import type { FlashToast } from '@/types/ui';
+import { type FlashToast } from '@/types/ui';
 
 export function useFlashToast(): void {
     useEffect(() => {

--- a/resources/js/hooks/use-markdown-toc.tsx
+++ b/resources/js/hooks/use-markdown-toc.tsx
@@ -1,9 +1,13 @@
 import { useMemo } from 'react';
-import type { Components } from 'react-markdown';
-import { createMarkdownComponents } from '@/lib/markdown-components';
-import type { MarkdownComponentOptions } from '@/lib/markdown-components';
-import { extractMarkdownHeadings } from '@/lib/markdown-headings';
-import type { MarkdownHeading } from '@/lib/markdown-headings';
+import { type Components } from 'react-markdown';
+import {
+    createMarkdownComponents,
+    type MarkdownComponentOptions,
+} from '@/lib/markdown-components';
+import {
+    extractMarkdownHeadings,
+    type MarkdownHeading,
+} from '@/lib/markdown-headings';
 
 export type Heading = MarkdownHeading;
 

--- a/resources/js/layouts/app-layout.tsx
+++ b/resources/js/layouts/app-layout.tsx
@@ -1,5 +1,5 @@
 import AppLayoutTemplate from '@/layouts/app/app-header-layout';
-import type { BreadcrumbItem } from '@/types';
+import { type BreadcrumbItem } from '@/types';
 
 export default function AppLayout({
     breadcrumbs = [],

--- a/resources/js/layouts/app/app-header-layout.tsx
+++ b/resources/js/layouts/app/app-header-layout.tsx
@@ -1,7 +1,7 @@
 import { AppContent } from '@/components/app-content';
 import { AppHeader } from '@/components/app-header';
 import { AppShell } from '@/components/app-shell';
-import type { AppLayoutProps } from '@/types';
+import { type AppLayoutProps } from '@/types';
 
 export default function AppHeaderLayout({
     children,

--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -2,7 +2,7 @@ import { AppContent } from '@/components/app-content';
 import { AppShell } from '@/components/app-shell';
 import { AppSidebar } from '@/components/app-sidebar';
 import { AppSidebarHeader } from '@/components/app-sidebar-header';
-import type { AppLayoutProps } from '@/types';
+import { type AppLayoutProps } from '@/types';
 
 export default function AppSidebarLayout({
     children,

--- a/resources/js/layouts/auth/auth-card-layout.tsx
+++ b/resources/js/layouts/auth/auth-card-layout.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@inertiajs/react';
-import type { PropsWithChildren } from 'react';
+import { type PropsWithChildren } from 'react';
 import AppLogoIcon from '@/components/app-logo-icon';
 import {
     Card,

--- a/resources/js/layouts/auth/auth-simple-layout.tsx
+++ b/resources/js/layouts/auth/auth-simple-layout.tsx
@@ -1,7 +1,7 @@
 import { Link } from '@inertiajs/react';
 import AppLogoIcon from '@/components/app-logo-icon';
 import { home } from '@/routes';
-import type { AuthLayoutProps } from '@/types';
+import { type AuthLayoutProps } from '@/types';
 
 export default function AuthSimpleLayout({
     children,

--- a/resources/js/layouts/auth/auth-split-layout.tsx
+++ b/resources/js/layouts/auth/auth-split-layout.tsx
@@ -1,7 +1,7 @@
 import { Link, usePage } from '@inertiajs/react';
 import AppLogoIcon from '@/components/app-logo-icon';
 import { home } from '@/routes';
-import type { AuthLayoutProps } from '@/types';
+import { type AuthLayoutProps } from '@/types';
 
 export default function AuthSplitLayout({
     children,

--- a/resources/js/layouts/settings/layout.tsx
+++ b/resources/js/layouts/settings/layout.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@inertiajs/react';
-import type { PropsWithChildren } from 'react';
+import { type PropsWithChildren } from 'react';
 import Heading from '@/components/heading';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
@@ -8,7 +8,7 @@ import { cn, toUrl } from '@/lib/utils';
 import { edit as editAppearance } from '@/routes/appearance';
 import { edit } from '@/routes/profile';
 import { edit as editSecurity } from '@/routes/security';
-import type { NavItem } from '@/types';
+import { type NavItem } from '@/types';
 
 const sidebarNavItems: NavItem[] = [
     {

--- a/resources/js/lib/markdown-components.tsx
+++ b/resources/js/lib/markdown-components.tsx
@@ -5,9 +5,10 @@ import {
     isValidElement,
     useContext,
     useRef,
+    type ComponentPropsWithoutRef,
+    type ReactNode,
 } from 'react';
-import type { ComponentPropsWithoutRef, ReactNode } from 'react';
-import type { Components } from 'react-markdown';
+import { type Components } from 'react-markdown';
 import { CodeBlock } from '@/components/code-block';
 import { MarkdownImage } from '@/components/markdown-image';
 import { extractRenderedHeadingText } from '@/lib/markdown-heading-text';

--- a/resources/js/lib/markdown-heading-text.ts
+++ b/resources/js/lib/markdown-heading-text.ts
@@ -1,5 +1,4 @@
-import { Children, isValidElement } from 'react';
-import type { ReactNode } from 'react';
+import { Children, isValidElement, type ReactNode } from 'react';
 
 export function normalizeMarkdownHeadingText(text: string): string {
     return text

--- a/resources/js/lib/remark-api-fields-directive.ts
+++ b/resources/js/lib/remark-api-fields-directive.ts
@@ -1,5 +1,5 @@
-import type { Root } from 'mdast';
-import type { Node } from 'unist';
+import { type Root } from 'mdast';
+import { type Node } from 'unist';
 import { visit } from 'unist-util-visit';
 
 interface ContainerDirectiveNode extends Node {

--- a/resources/js/lib/remark-badge-directive.ts
+++ b/resources/js/lib/remark-badge-directive.ts
@@ -1,5 +1,5 @@
-import type { Root } from 'mdast';
-import type { Node } from 'unist';
+import { type Root } from 'mdast';
+import { type Node } from 'unist';
 import { visit } from 'unist-util-visit';
 
 interface TextDirectiveNode extends Node {

--- a/resources/js/lib/remark-card-directive.ts
+++ b/resources/js/lib/remark-card-directive.ts
@@ -1,5 +1,5 @@
-import type { Root } from 'mdast';
-import type { Node } from 'unist';
+import { type Root } from 'mdast';
+import { type Node } from 'unist';
 import { visit } from 'unist-util-visit';
 
 interface ContainerDirectiveNode extends Node {

--- a/resources/js/lib/remark-code-group-directive.ts
+++ b/resources/js/lib/remark-code-group-directive.ts
@@ -1,5 +1,5 @@
-import type { Code, Root } from 'mdast';
-import type { Node } from 'unist';
+import { type Code, type Root } from 'mdast';
+import { type Node } from 'unist';
 import { visit } from 'unist-util-visit';
 
 interface ContainerDirectiveNode extends Node {

--- a/resources/js/lib/remark-code-meta.ts
+++ b/resources/js/lib/remark-code-meta.ts
@@ -1,4 +1,4 @@
-import type { Code, Root } from 'mdast';
+import { type Code, type Root } from 'mdast';
 import { visit } from 'unist-util-visit';
 
 /**

--- a/resources/js/lib/remark-linkify-to-card.ts
+++ b/resources/js/lib/remark-linkify-to-card.ts
@@ -5,7 +5,7 @@
  * whitespace), the paragraph node is converted to a <div> via data.hName and
  * data.hProperties — no rehype-raw required.
  */
-import type { Link, Paragraph, Root, Text } from 'mdast';
+import { type Link, type Paragraph, type Root, type Text } from 'mdast';
 import { visit } from 'unist-util-visit';
 import { isGithubUrl, isYoutubeUrl } from './url-matcher';
 

--- a/resources/js/lib/remark-mark.ts
+++ b/resources/js/lib/remark-mark.ts
@@ -3,7 +3,7 @@ import { pandocMarkFromMarkdown } from 'mdast-util-mark';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 import { pandocMark } from 'micromark-extension-mark';
-import type { Processor } from 'unified';
+import { type Processor } from 'unified';
 
 /**
  * Remark plugin to support ==highlight== syntax, rendered as <mark>.

--- a/resources/js/lib/remark-steps-directive.ts
+++ b/resources/js/lib/remark-steps-directive.ts
@@ -1,5 +1,5 @@
-import type { Root } from 'mdast';
-import type { Node } from 'unist';
+import { type Root } from 'mdast';
+import { type Node } from 'unist';
 import { visit } from 'unist-util-visit';
 
 interface ContainerDirectiveNode extends Node {

--- a/resources/js/lib/remark-tabs-directive.ts
+++ b/resources/js/lib/remark-tabs-directive.ts
@@ -1,5 +1,5 @@
-import type { Root } from 'mdast';
-import type { Node } from 'unist';
+import { type Root } from 'mdast';
+import { type Node } from 'unist';
 import { visit } from 'unist-util-visit';
 
 interface ContainerDirectiveNode extends Node {

--- a/resources/js/lib/remark-tooltip-directive.ts
+++ b/resources/js/lib/remark-tooltip-directive.ts
@@ -1,5 +1,5 @@
-import type { Root } from 'mdast';
-import type { Node } from 'unist';
+import { type Root } from 'mdast';
+import { type Node } from 'unist';
 import { visit } from 'unist-util-visit';
 
 interface TextDirectiveNode extends Node {

--- a/resources/js/lib/remark-tree-directive.ts
+++ b/resources/js/lib/remark-tree-directive.ts
@@ -1,5 +1,5 @@
-import type { Code, Root } from 'mdast';
-import type { Node } from 'unist';
+import { type Code, type Root } from 'mdast';
+import { type Node } from 'unist';
 import { visit } from 'unist-util-visit';
 
 interface ContainerDirectiveNode extends Node {

--- a/resources/js/lib/remark-update-directive.ts
+++ b/resources/js/lib/remark-update-directive.ts
@@ -1,5 +1,5 @@
-import type { Root } from 'mdast';
-import type { Node } from 'unist';
+import { type Root } from 'mdast';
+import { type Node } from 'unist';
 import { visit } from 'unist-util-visit';
 
 interface ContainerDirectiveNode extends Node {

--- a/resources/js/lib/remark-zenn-directive.ts
+++ b/resources/js/lib/remark-zenn-directive.ts
@@ -1,5 +1,5 @@
-import type { Paragraph, Root, Text } from 'mdast';
-import type { Node } from 'unist';
+import { type Paragraph, type Root, type Text } from 'mdast';
+import { type Node } from 'unist';
 import { visit } from 'unist-util-visit';
 
 interface ContainerDirectiveNode extends Node {

--- a/resources/js/lib/simple-icon-lookup.ts
+++ b/resources/js/lib/simple-icon-lookup.ts
@@ -33,8 +33,8 @@ import {
     siVercel,
     siVite,
     siVuedotjs,
+    type SimpleIcon,
 } from 'simple-icons';
-import type { SimpleIcon } from 'simple-icons';
 
 export type { SimpleIcon };
 

--- a/resources/js/lib/utils.ts
+++ b/resources/js/lib/utils.ts
@@ -1,6 +1,5 @@
-import type { InertiaLinkProps } from '@inertiajs/react';
-import { clsx } from 'clsx';
-import type { ClassValue } from 'clsx';
+import { type InertiaLinkProps } from '@inertiajs/react';
+import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {

--- a/resources/js/pages/admin/namespaces/create.tsx
+++ b/resources/js/pages/admin/namespaces/create.tsx
@@ -8,8 +8,10 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { dashboard } from '@/routes';
 import { create } from '@/routes/admin/namespaces';
-import { namespace as namespaceRoute } from '@/routes/admin/posts';
-import { index as postsIndex } from '@/routes/admin/posts';
+import {
+    namespace as namespaceRoute,
+    index as postsIndex,
+} from '@/routes/admin/posts';
 
 function toSlug(value: string): string {
     return value

--- a/resources/js/pages/admin/namespaces/index.tsx
+++ b/resources/js/pages/admin/namespaces/index.tsx
@@ -1,5 +1,4 @@
-import { Head, Link } from '@inertiajs/react';
-import { Form } from '@inertiajs/react';
+import { Form, Head, Link } from '@inertiajs/react';
 import { FolderPlus } from 'lucide-react';
 import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import { Button } from '@/components/ui/button';

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -1,5 +1,5 @@
-import type { DragEndEvent } from '@dnd-kit/core';
 import {
+    type DragEndEvent,
     DndContext,
     KeyboardSensor,
     PointerSensor,
@@ -15,8 +15,7 @@ import {
     arrayMove,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Form } from '@inertiajs/react';
-import { Head, Link, router, useForm } from '@inertiajs/react';
+import { Form, Head, Link, router, useForm } from '@inertiajs/react';
 import {
     ArrowUpDown,
     Check,

--- a/resources/js/pages/admin/posts/namespace.tsx
+++ b/resources/js/pages/admin/posts/namespace.tsx
@@ -1,5 +1,5 @@
-import type { DragEndEvent } from '@dnd-kit/core';
 import {
+    type DragEndEvent,
     DndContext,
     KeyboardSensor,
     PointerSensor,
@@ -32,6 +32,7 @@ import {
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import NamespaceHeader from '@/components/namespace-header';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -43,7 +44,6 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
-import { Badge } from '@/components/ui/badge';
 import { timeAgo } from '@/lib/time';
 import { dashboard } from '@/routes';
 import { create as namespaceCreate } from '@/routes/admin/namespaces';

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -8,8 +8,9 @@ import {
     PanelRightOpen,
 } from 'lucide-react';
 import { useMemo, useState } from 'react';
-import type { ContentNavNode } from '@/components/content-nav-tree';
-import ContentNavTree from '@/components/content-nav-tree';
+import ContentNavTree, {
+    type ContentNavNode,
+} from '@/components/content-nav-tree';
 import MarkdownContent from '@/components/markdown-content';
 import PostHeader from '@/components/post-header';
 import TableOfContents from '@/components/table-of-contents';

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -1,8 +1,9 @@
 import { Head, Link, usePage } from '@inertiajs/react';
 import { AlertTriangle, ChevronRight, ImageOff } from 'lucide-react';
 import { useState } from 'react';
-import type { ContentNavNode } from '@/components/content-nav-tree';
-import ContentNavTree from '@/components/content-nav-tree';
+import ContentNavTree, {
+    type ContentNavNode,
+} from '@/components/content-nav-tree';
 import DocsHeaderActions from '@/components/docs-header-actions';
 import MarkdownPageActions from '@/components/markdown-page-actions';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -11,8 +11,9 @@ import {
 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { siX } from 'simple-icons';
-import type { ContentNavNode } from '@/components/content-nav-tree';
-import ContentNavTree from '@/components/content-nav-tree';
+import ContentNavTree, {
+    type ContentNavNode,
+} from '@/components/content-nav-tree';
 import DocsHeaderActions from '@/components/docs-header-actions';
 import MarkdownContent from '@/components/markdown-content';
 import MarkdownPageActions from '@/components/markdown-page-actions';

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -1,4 +1,4 @@
-import type { Auth } from '@/types/auth';
+import { type Auth } from '@/types/auth';
 
 declare module '@inertiajs/core' {
     export interface InertiaConfig {

--- a/resources/js/types/navigation.ts
+++ b/resources/js/types/navigation.ts
@@ -1,5 +1,5 @@
-import type { InertiaLinkProps } from '@inertiajs/react';
-import type { LucideIcon } from 'lucide-react';
+import { type InertiaLinkProps } from '@inertiajs/react';
+import { type LucideIcon } from 'lucide-react';
 
 export type BreadcrumbItem = {
     title: string;

--- a/resources/js/types/ui.ts
+++ b/resources/js/types/ui.ts
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
-import type { BreadcrumbItem } from '@/types/navigation';
+import { type ReactNode } from 'react';
+import { type BreadcrumbItem } from '@/types/navigation';
 
 export type AppLayoutProps = {
     children: ReactNode;

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -1207,6 +1207,86 @@ test('admin post details page includes admin navigation rooted at the top namesp
         );
 });
 
+test('admin post details page builds empty-root navigation without including other top-level trees', function () {
+    $user = User::factory()->create();
+    $root = PostNamespace::factory()->create([
+        'slug' => 'docs-root',
+        'full_path' => '',
+        'name' => 'Docs Root',
+    ]);
+    PostNamespace::query()
+        ->whereKey($root->id)
+        ->update(['full_path' => '']);
+    $root->refresh();
+    $child = PostNamespace::factory()->create([
+        'parent_id' => $root->id,
+        'slug' => 'laravel',
+        'full_path' => 'laravel',
+        'name' => 'Laravel',
+    ]);
+    $grandchild = PostNamespace::factory()->create([
+        'parent_id' => $child->id,
+        'slug' => 'routing',
+        'full_path' => 'laravel/routing',
+        'name' => 'Routing',
+    ]);
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $grandchild->id,
+        'slug' => 'controllers',
+        'full_path' => 'laravel/routing/controllers',
+        'title' => 'Controllers',
+    ]);
+    $foreignRoot = PostNamespace::factory()->create([
+        'slug' => 'other-root',
+        'full_path' => 'other-root',
+        'name' => 'Other Root',
+    ]);
+    $foreignChild = PostNamespace::factory()->create([
+        'parent_id' => $foreignRoot->id,
+        'slug' => 'ignored-child',
+        'full_path' => 'other-root/ignored-child',
+        'name' => 'Ignored Child',
+    ]);
+    Post::factory()->for($user)->create([
+        'namespace_id' => $foreignChild->id,
+        'slug' => 'ignored-post',
+        'full_path' => 'other-root/ignored-child/ignored-post',
+        'title' => 'Ignored Post',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.show', [$grandchild, $post]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/show')
+            ->where('navRoot.full_path', '')
+            ->where('navRoot.href', route('admin.posts.namespace', $root, false))
+            ->where('navRoot.children', [
+                [
+                    'name' => 'Laravel',
+                    'full_path' => 'laravel',
+                    'href' => route('admin.posts.namespace', $child, false),
+                    'children' => [
+                        [
+                            'name' => 'Routing',
+                            'full_path' => 'laravel/routing',
+                            'href' => route('admin.posts.namespace', $grandchild, false),
+                            'children' => [],
+                            'posts' => [
+                                [
+                                    'title' => 'Controllers',
+                                    'full_path' => 'laravel/routing/controllers',
+                                    'href' => route('admin.posts.show', [$grandchild, $post], false),
+                                ],
+                            ],
+                        ],
+                    ],
+                    'posts' => [],
+                ],
+            ])
+        );
+});
+
 test('admin post details page does not increment page views', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create();


### PR DESCRIPTION
## Summary\n- avoid recursive per-node queries when the top admin navigation namespace has an empty full_path\n- build the empty-root subtree from prefetched namespace and post collections\n- add regression coverage to keep unrelated top-level trees out of the admin post navigation\n\n## Testing\n- vendor/bin/sail artisan test --compact tests/Feature/Admin/PostControllerTest.php\n