### PR TITLE
Prefetch empty-root admin post navigation

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -395,13 +395,15 @@ class PostController extends Controller
     {
         $rootPath = trim($rootNamespace->full_path, '/');
 
-        if ($rootPath === '') {
-            return $this->buildNavigationNodeRecursively($rootNamespace);
+        $namespaceQuery = PostNamespace::query();
+
+        if ($rootPath !== '') {
+            $namespaceQuery
+                ->whereKey($rootNamespace->id)
+                ->orWhere('full_path', 'like', $rootPath.'/%');
         }
 
-        $namespaces = PostNamespace::query()
-            ->whereKey($rootNamespace->id)
-            ->orWhere('full_path', 'like', $rootPath.'/%')
+        $namespaces = $namespaceQuery
             ->get(['id', 'parent_id', 'slug', 'full_path', 'name', 'post_order'])
             ->keyBy('id');
 
@@ -409,8 +411,12 @@ class PostController extends Controller
             ->groupBy(fn (PostNamespace $namespace): int => $namespace->parent_id ?? 0)
             ->map(fn ($group) => $group->values());
 
+        $namespaceIds = $rootPath === ''
+            ? $this->navigationSubtreeNamespaceIds($rootNamespace->id, $namespacesByParent->all())
+            : $namespaces->keys()->all();
+
         $postsByNamespace = Post::query()
-            ->whereIn('namespace_id', $namespaces->keys())
+            ->whereIn('namespace_id', $namespaceIds)
             ->orderBy('published_at')
             ->orderBy('id')
             ->get(['namespace_id', 'title', 'full_path', 'slug'])
@@ -420,30 +426,29 @@ class PostController extends Controller
         return $this->buildNavigationNode($rootNamespace, $namespacesByParent->all(), $postsByNamespace->all());
     }
 
-    private function buildNavigationNodeRecursively(PostNamespace $namespace): array
+    /**
+     * @param  array<int, \Illuminate\Support\Collection<int, PostNamespace>>  $namespacesByParent
+     * @return array<int, int>
+     */
+    private function navigationSubtreeNamespaceIds(int $rootNamespaceId, array $namespacesByParent): array
     {
-        $children = $namespace->children()->get(['id', 'slug', 'full_path', 'name', 'post_order']);
-        $posts = $namespace->sortPosts(
-            $namespace->posts()
-                ->orderBy('published_at')
-                ->orderBy('id')
-                ->get(['namespace_id', 'title', 'full_path', 'slug'])
-        );
+        $namespaceIds = [$rootNamespaceId];
+        $pendingParentIds = [$rootNamespaceId];
 
-        return [
-            'name' => $namespace->name,
-            'full_path' => $namespace->full_path,
-            'href' => route('admin.posts.namespace', ['namespace' => $namespace], absolute: false),
-            'children' => $namespace->sortNamespaces($children)
-                ->map(fn (PostNamespace $child) => $this->buildNavigationNodeRecursively($child))
-                ->values()
-                ->all(),
-            'posts' => $posts->map(fn (Post $post) => [
-                'title' => $post->title,
-                'full_path' => $post->full_path,
-                'href' => route('admin.posts.show', ['namespace' => $namespace, 'post' => $post->slug], absolute: false),
-            ])->values()->all(),
-        ];
+        while ($pendingParentIds !== []) {
+            $parentId = array_pop($pendingParentIds);
+
+            if ($parentId === null) {
+                continue;
+            }
+
+            foreach ($namespacesByParent[$parentId] ?? [] as $childNamespace) {
+                $namespaceIds[] = $childNamespace->id;
+                $pendingParentIds[] = $childNamespace->id;
+            }
+        }
+
+        return $namespaceIds;
     }
 
     /**

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -1207,6 +1207,82 @@ test('admin post details page includes admin navigation rooted at the top namesp
         );
 });
 
+test('admin post details page builds empty-root navigation without including other top-level trees', function () {
+    $user = User::factory()->create();
+    $root = PostNamespace::factory()->create([
+        'slug' => 'docs-root',
+        'full_path' => '',
+        'name' => 'Docs Root',
+    ]);
+    $child = PostNamespace::factory()->create([
+        'parent_id' => $root->id,
+        'slug' => 'laravel',
+        'full_path' => 'laravel',
+        'name' => 'Laravel',
+    ]);
+    $grandchild = PostNamespace::factory()->create([
+        'parent_id' => $child->id,
+        'slug' => 'routing',
+        'full_path' => 'laravel/routing',
+        'name' => 'Routing',
+    ]);
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $grandchild->id,
+        'slug' => 'controllers',
+        'full_path' => 'laravel/routing/controllers',
+        'title' => 'Controllers',
+    ]);
+    $foreignRoot = PostNamespace::factory()->create([
+        'slug' => 'other-root',
+        'full_path' => 'other-root',
+        'name' => 'Other Root',
+    ]);
+    $foreignChild = PostNamespace::factory()->create([
+        'parent_id' => $foreignRoot->id,
+        'slug' => 'ignored-child',
+        'full_path' => 'other-root/ignored-child',
+        'name' => 'Ignored Child',
+    ]);
+    Post::factory()->for($user)->create([
+        'namespace_id' => $foreignChild->id,
+        'slug' => 'ignored-post',
+        'full_path' => 'other-root/ignored-child/ignored-post',
+        'title' => 'Ignored Post',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.show', [$grandchild, $post]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/show')
+            ->where('navRoot.full_path', '')
+            ->where('navRoot.href', route('admin.posts.namespace', $root, false))
+            ->where('navRoot.children', [
+                [
+                    'name' => 'Laravel',
+                    'full_path' => 'laravel',
+                    'href' => route('admin.posts.namespace', $child, false),
+                    'children' => [
+                        [
+                            'name' => 'Routing',
+                            'full_path' => 'laravel/routing',
+                            'href' => route('admin.posts.namespace', $grandchild, false),
+                            'children' => [],
+                            'posts' => [
+                                [
+                                    'title' => 'Controllers',
+                                    'full_path' => 'laravel/routing/controllers',
+                                    'href' => route('admin.posts.show', [$grandchild, $post], false),
+                                ],
+                            ],
+                        ],
+                    ],
+                    'posts' => [],
+                ],
+            ])
+        );
+});
+
 test('admin post details page does not increment page views', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create();

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -1214,6 +1214,10 @@ test('admin post details page builds empty-root navigation without including oth
         'full_path' => '',
         'name' => 'Docs Root',
     ]);
+    PostNamespace::query()
+        ->whereKey($root->id)
+        ->update(['full_path' => '']);
+    $root->refresh();
     $child = PostNamespace::factory()->create([
         'parent_id' => $root->id,
         'slug' => 'laravel',


### PR DESCRIPTION
## Summary\n- avoid recursive per-node queries when the top admin navigation namespace has an empty full_path\n- build the empty-root subtree from prefetched namespace and post collections\n- add regression coverage to keep unrelated top-level trees out of the admin post navigation\n\n## Testing\n- vendor/bin/sail artisan test --compact tests/Feature/Admin/PostControllerTest.php\n