### PR TITLE
Refine admin post editor UX

### DIFF
--- a/resources/js/components/markdown-editor.tsx
+++ b/resources/js/components/markdown-editor.tsx
@@ -1,4 +1,5 @@
 import { router, usePage } from '@inertiajs/react';
+import { Code2, Eye } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import InputError from '@/components/input-error';
 import MarkdownContent from '@/components/markdown-content';
@@ -26,6 +27,7 @@ export default function MarkdownEditor({
     jumpTo,
 }: Props) {
     const [value, setValue] = useState(defaultValue);
+    const [activeTab, setActiveTab] = useState<'write' | 'preview'>('write');
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const previewRef = useRef<HTMLDivElement>(null);
     const { props } = usePage<{ imageUrl?: string }>();
@@ -153,54 +155,117 @@ export default function MarkdownEditor({
     return (
         <div className="grid gap-2">
             {label && <Label htmlFor={name}>{label}</Label>}
-            <div className="grid grid-cols-2 gap-4">
-                <div className="grid gap-1">
-                    <p className="text-xs text-muted-foreground">Markdown</p>
-                    <textarea
-                        ref={textareaRef}
-                        id={name}
-                        name={name}
-                        value={value}
-                        onChange={(e) => setValue(e.target.value)}
-                        onDrop={uploadUrl ? handleDrop : undefined}
-                        onDragOver={
-                            uploadUrl ? (e) => e.preventDefault() : undefined
-                        }
-                        onPaste={uploadUrl ? handlePaste : undefined}
-                        className={cn(
-                            'h-[600px] w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 font-mono text-sm shadow-xs outline-none placeholder:text-muted-foreground',
-                            'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
-                            error && 'border-destructive',
-                        )}
-                        placeholder="Write markdown here..."
-                    />
+
+            <div
+                data-test="markdown-editor"
+                className="overflow-hidden rounded-xl border border-border bg-card shadow-sm"
+            >
+                {/* Tab header */}
+                <div className="flex items-center justify-between border-b border-border px-4 py-2">
+                    <div className="flex gap-1 rounded-lg bg-muted/50 p-0.5">
+                        <button
+                            type="button"
+                            data-test="markdown-editor-write-tab"
+                            aria-pressed={activeTab === 'write'}
+                            onClick={() => setActiveTab('write')}
+                            className={cn(
+                                'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all',
+                                activeTab === 'write'
+                                    ? 'bg-card text-foreground shadow-sm'
+                                    : 'text-muted-foreground hover:text-foreground',
+                            )}
+                        >
+                            <Code2 className="size-3.5" />
+                            <span className="hidden sm:inline">Markdown</span>
+                        </button>
+                        <button
+                            type="button"
+                            data-test="markdown-editor-preview-tab"
+                            aria-pressed={activeTab === 'preview'}
+                            onClick={() => setActiveTab('preview')}
+                            className={cn(
+                                'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all',
+                                activeTab === 'preview'
+                                    ? 'bg-card text-foreground shadow-sm'
+                                    : 'text-muted-foreground hover:text-foreground',
+                            )}
+                        >
+                            <Eye className="size-3.5" />
+                            <span className="hidden sm:inline">Preview</span>
+                        </button>
+                    </div>
                     {uploadUrl && (
-                        <p className="text-xs text-muted-foreground">
-                            Tip: Drag & drop or paste images to upload
+                        <p className="hidden text-xs text-muted-foreground lg:block">
+                            Drag &amp; drop or paste images to upload
                         </p>
                     )}
                 </div>
-                <div className="grid gap-1">
-                    <p className="text-xs text-muted-foreground">Preview</p>
+
+                <div className="grid lg:grid-cols-2">
+                    {/* Write column */}
                     <div
-                        ref={previewRef}
-                        className="h-[600px] overflow-y-auto rounded-md border border-input bg-transparent px-3 py-2 text-sm"
-                    >
-                        {value ? (
-                            <div className="prose prose-sm max-w-none dark:prose-invert">
-                                <MarkdownContent
-                                    content={value}
-                                    components={createMarkdownComponents()}
-                                />
-                            </div>
-                        ) : (
-                            <p className="text-muted-foreground">
-                                Nothing to preview
-                            </p>
+                        data-test="markdown-editor-write-panel"
+                        className={cn(
+                            'border-border lg:border-r',
+                            activeTab !== 'write' && 'hidden lg:block',
                         )}
+                    >
+                        <p className="px-4 pt-3 text-xs text-muted-foreground">
+                            Markdown
+                        </p>
+                        <textarea
+                            ref={textareaRef}
+                            id={name}
+                            name={name}
+                            value={value}
+                            onChange={(e) => setValue(e.target.value)}
+                            onDrop={uploadUrl ? handleDrop : undefined}
+                            onDragOver={
+                                uploadUrl
+                                    ? (e) => e.preventDefault()
+                                    : undefined
+                            }
+                            onPaste={uploadUrl ? handlePaste : undefined}
+                            placeholder="Write markdown here..."
+                            className={cn(
+                                'h-[50vh] w-full resize-none border-0 bg-transparent px-4 pb-4 font-mono text-sm shadow-none outline-none placeholder:text-muted-foreground/60 lg:h-[65vh]',
+                                error && 'border-b border-destructive',
+                            )}
+                        />
+                    </div>
+
+                    {/* Preview column */}
+                    <div
+                        data-test="markdown-editor-preview-panel"
+                        className={cn(
+                            'bg-muted/20',
+                            activeTab !== 'preview' && 'hidden lg:block',
+                        )}
+                    >
+                        <p className="px-4 pt-3 text-xs text-muted-foreground">
+                            Preview
+                        </p>
+                        <div
+                            ref={previewRef}
+                            className="h-[50vh] overflow-y-auto px-4 pb-4 text-sm lg:h-[65vh]"
+                        >
+                            {value ? (
+                                <div className="prose prose-sm max-w-none dark:prose-invert">
+                                    <MarkdownContent
+                                        content={value}
+                                        components={createMarkdownComponents()}
+                                    />
+                                </div>
+                            ) : (
+                                <p className="text-muted-foreground">
+                                    Nothing to preview
+                                </p>
+                            )}
+                        </div>
                     </div>
                 </div>
             </div>
+
             <InputError message={error} />
         </div>
     );

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -1,15 +1,25 @@
-import { Form, Head, setLayoutProps } from '@inertiajs/react';
-import { Check, Save } from 'lucide-react';
+import { Form, Head, Link, setLayoutProps } from '@inertiajs/react';
+import {
+    ArrowLeft,
+    Calendar,
+    Check,
+    Eye,
+    EyeOff,
+    Link2,
+    Maximize2,
+    Minimize2,
+    Save,
+    Tag,
+} from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import InputError from '@/components/input-error';
 import MarkdownEditor from '@/components/markdown-editor';
-import PostHeader from '@/components/post-header';
 import TagInput from '@/components/tag-input';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
+import ViewContextBadge from '@/components/view-context-badge';
 import { cn } from '@/lib/utils';
 import { dashboard } from '@/routes';
 import {
@@ -74,6 +84,9 @@ export default function Edit({
             returnTo: params.get('return_to'),
         };
     }, []);
+
+    const [metaPanelOpen, setMetaPanelOpen] = useState(true);
+    const [slug, setSlug] = useState(post.slug);
 
     const [saved, setSaved] = useState(false);
     const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
@@ -147,18 +160,21 @@ export default function Edit({
         };
     }, [hasUnsavedChanges]);
 
+    function confirmNavigation(): boolean {
+        if (!hasUnsavedChanges) {
+            return true;
+        }
+
+        return window.confirm(
+            'You have unsaved changes. Leave this page without saving?',
+        );
+    }
+
     return (
         <>
             <Head title={`Edit: ${post.title}`} />
 
-            <div className="space-y-6 p-4">
-                <PostHeader
-                    namespace={namespace}
-                    post={post}
-                    mode="edit"
-                    hasUnsavedChanges={hasUnsavedChanges}
-                />
-
+            <div>
                 <Form
                     {...update.form({
                         namespace: namespace.id,
@@ -178,7 +194,7 @@ export default function Edit({
                             2500,
                         );
                     }}
-                    className="space-y-6"
+                    className=""
                     onInputCapture={() => setHasUnsavedChanges(true)}
                     onChangeCapture={() => setHasUnsavedChanges(true)}
                 >
@@ -198,193 +214,382 @@ export default function Edit({
                                     value={returnTo}
                                 />
                             )}
-                            <div className="grid gap-2">
-                                <Label htmlFor="title">Title</Label>
-                                <Input
-                                    id="title"
-                                    name="title"
-                                    defaultValue={post.title}
-                                    placeholder="Post title"
-                                    required
-                                />
-                                <InputError message={errors.title} />
-                            </div>
 
-                            <div className="grid gap-2">
-                                <Label htmlFor="slug">Slug</Label>
-                                <div className="flex rounded-md border border-input bg-transparent shadow-xs transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50">
-                                    <span className="inline-flex items-center border-r border-input bg-muted/30 px-3 text-sm whitespace-nowrap text-muted-foreground">
-                                        {slugPrefix}
-                                    </span>
-                                    <Input
-                                        id="slug"
-                                        name="slug"
-                                        defaultValue={post.slug}
-                                        placeholder="my-post-slug"
-                                        className={cn(
-                                            'rounded-l-none border-0 shadow-none focus-visible:border-0 focus-visible:ring-0',
-                                        )}
-                                        required
-                                    />
-                                </div>
-                                <p className="text-xs text-muted-foreground">
-                                    Lowercase letters, numbers, and hyphens
-                                    only.
-                                </p>
-                                <p className="text-xs text-muted-foreground">
-                                    Must be unique among pages and child
-                                    namespaces under /{namespace.full_path}.
-                                </p>
-                                <p className="text-xs text-muted-foreground">
-                                    Path preview: /{slugPrefix}
-                                    {post.slug}
-                                </p>
-                                <InputError message={errors.slug} />
-                            </div>
-
-                            <MarkdownEditor
-                                name="content"
-                                defaultValue={post.content}
-                                error={errors.content}
-                                uploadUrl={uploadImage.url({
-                                    namespace: namespace.id,
-                                    post: post.slug,
-                                })}
-                                jumpTo={jumpTo}
-                            />
-
-                            <div className="grid gap-4 rounded-lg border border-dashed p-4">
-                                <p className="text-sm font-medium text-muted-foreground">
-                                    Reference (optional)
-                                </p>
-                                <div className="grid gap-2">
-                                    <Label htmlFor="reference_title">
-                                        Title
-                                    </Label>
-                                    <Input
-                                        id="reference_title"
-                                        name="reference_title"
-                                        placeholder="Reference title"
-                                        defaultValue={
-                                            post.reference_title ?? ''
-                                        }
-                                    />
-                                    <InputError
-                                        message={errors.reference_title}
-                                    />
-                                </div>
-                                <div className="grid gap-2">
-                                    <Label htmlFor="reference_url">URL</Label>
-                                    <Input
-                                        id="reference_url"
-                                        name="reference_url"
-                                        type="url"
-                                        placeholder="https://example.com"
-                                        defaultValue={post.reference_url ?? ''}
-                                    />
-                                    <InputError
-                                        message={errors.reference_url}
-                                    />
-                                </div>
-                            </div>
-
-                            <div className="grid gap-2">
-                                <Label>Tags</Label>
-                                <TagInput
-                                    tags={currentTags}
-                                    onChange={(next) => {
-                                        setCurrentTags(next);
-                                        setHasUnsavedChanges(true);
-                                    }}
-                                    availableTags={availableTags}
-                                />
-                                <p className="text-xs text-muted-foreground">
-                                    Lowercase letters, numbers, and hyphens
-                                    only. Press Enter or comma to add.
-                                </p>
-                                <InputError
-                                    message={errors['tags'] ?? errors['tags.0']}
-                                />
-                            </div>
-
-                            <div className="flex items-center gap-2">
-                                <input
-                                    type="hidden"
-                                    name="is_draft"
-                                    value={isDraft ? '1' : '0'}
-                                />
-                                <Checkbox
-                                    id="is_draft"
-                                    checked={isDraft}
-                                    onCheckedChange={(checked) => {
-                                        const nextIsDraft = checked === true;
-
-                                        setIsDraft(nextIsDraft);
-
-                                        if (nextIsDraft) {
-                                            setRelativeTimeHint(null);
-                                        }
-                                    }}
-                                />
-                                <Label htmlFor="is_draft">Save as draft</Label>
-                            </div>
-
-                            <div className="grid gap-3">
-                                <div className="flex items-center gap-3">
-                                    <Switch
-                                        id="schedule_toggle"
-                                        checked={scheduleEnabled && !isDraft}
-                                        onCheckedChange={(checked) => {
-                                            setScheduleEnabled(checked);
-
-                                            if (!checked) {
-                                                setPublishedAt('');
-                                                setRelativeTimeHint(null);
+                            <div className="flex flex-col xl:flex-row">
+                                {/* Main content */}
+                                <main className="min-w-0 flex-1 px-4 py-6 lg:px-8 lg:py-8">
+                                    <div className="mb-4 flex items-center justify-between gap-3">
+                                        <div className="flex items-center gap-3">
+                                            <Button variant="outline" asChild>
+                                                <Link
+                                                    data-test="view-post-link"
+                                                    href={show.url({
+                                                        namespace: namespace.id,
+                                                        post: post.slug,
+                                                    })}
+                                                    onClick={(event) => {
+                                                        if (
+                                                            !confirmNavigation()
+                                                        ) {
+                                                            event.preventDefault();
+                                                        }
+                                                    }}
+                                                >
+                                                    <ArrowLeft className="size-4" />
+                                                    View Post
+                                                </Link>
+                                            </Button>
+                                            <ViewContextBadge
+                                                label="Admin View"
+                                                variant="admin"
+                                            />
+                                        </div>
+                                        <Button
+                                            type="button"
+                                            variant="ghost"
+                                            size="icon"
+                                            data-test="edit-meta-panel-toggle"
+                                            aria-expanded={metaPanelOpen}
+                                            onClick={() =>
+                                                setMetaPanelOpen((value) => !value)
                                             }
-                                        }}
-                                        disabled={isDraft}
-                                    />
-                                    <Label htmlFor="schedule_toggle">
-                                        Enable scheduled publishing
-                                    </Label>
-                                </div>
-                                <input
-                                    type="hidden"
-                                    name="published_at"
-                                    value={
-                                        scheduleEnabled && !isDraft
-                                            ? publishedAt
-                                            : ''
-                                    }
-                                />
-                                {scheduleEnabled && !isDraft && (
-                                    <div className="flex flex-wrap items-center gap-3">
-                                        <Input
-                                            id="published_at"
-                                            type="datetime-local"
-                                            className="w-fit"
-                                            value={publishedAt}
-                                            onChange={(e) => {
-                                                const nextValue =
-                                                    e.target.value;
-
-                                                setPublishedAt(nextValue);
-                                                setRelativeTimeHint(
-                                                    getRelativeTimeHint(
-                                                        nextValue,
-                                                        Date.now(),
-                                                    ),
-                                                );
-                                            }}
-                                        />
-                                        {relativeTimeHint && (
-                                            <p className="text-sm text-muted-foreground">
-                                                {relativeTimeHint}
-                                            </p>
-                                        )}
+                                            title={
+                                                metaPanelOpen
+                                                    ? 'Hide metadata panel'
+                                                    : 'Show metadata panel'
+                                            }
+                                        >
+                                            {metaPanelOpen ? (
+                                                <Minimize2 className="size-4" />
+                                            ) : (
+                                                <Maximize2 className="size-4" />
+                                            )}
+                                        </Button>
                                     </div>
-                                )}
-                                <InputError message={errors.published_at} />
+
+                                    {/* Borderless title */}
+                                    <div className="mb-4">
+                                        <input
+                                            type="text"
+                                            id="title"
+                                            name="title"
+                                            defaultValue={post.title}
+                                            placeholder="Post title..."
+                                            className="w-full border-0 bg-transparent text-2xl font-bold tracking-tight text-foreground placeholder:text-muted-foreground/40 focus:outline-none sm:text-3xl lg:text-4xl"
+                                            required
+                                        />
+                                        <InputError message={errors.title} />
+                                    </div>
+
+                                    {/* Inline monospace slug */}
+                                    <div className="mb-2 flex flex-wrap items-center gap-1 font-mono text-sm">
+                                        <span className="text-muted-foreground/50">
+                                            /{slugPrefix}
+                                        </span>
+                                        <Input
+                                            id="slug"
+                                            name="slug"
+                                            value={slug}
+                                            onChange={(event) =>
+                                                setSlug(event.target.value)
+                                            }
+                                            placeholder="slug"
+                                            required
+                                            className="w-auto min-w-0 border-0 border-b-2 border-dashed border-input bg-transparent px-1 py-0.5 shadow-none focus-visible:border-ring focus-visible:ring-0"
+                                        />
+                                        <InputError message={errors.slug} />
+                                    </div>
+                                    <div className="mb-8 space-y-0.5">
+                                        <p className="text-xs text-muted-foreground">
+                                            Lowercase letters, numbers, and
+                                            hyphens only.
+                                        </p>
+                                        <p className="text-xs text-muted-foreground">
+                                            Must be unique among pages and child
+                                            namespaces under /
+                                            {namespace.full_path}.
+                                        </p>
+                                        <p className="text-xs text-muted-foreground">
+                                            Path preview: /{slugPrefix}
+                                            {slug || 'slug'}
+                                        </p>
+                                    </div>
+
+                                    <MarkdownEditor
+                                        name="content"
+                                        defaultValue={post.content}
+                                        error={errors.content}
+                                        uploadUrl={uploadImage.url({
+                                            namespace: namespace.id,
+                                            post: post.slug,
+                                        })}
+                                        jumpTo={jumpTo}
+                                    />
+                                </main>
+
+                                {/* Sidebar */}
+                                <aside
+                                    data-test="edit-meta-panel"
+                                    className={cn(
+                                        'w-full shrink-0 border-t border-border px-4 py-6 xl:w-80 xl:border-t-0 xl:border-l xl:py-8 xl:pr-6',
+                                        !metaPanelOpen && 'hidden',
+                                    )}
+                                >
+                                    <div className="sticky top-20 space-y-5">
+                                        {/* Status card */}
+                                        <div className="overflow-hidden rounded-xl border border-border bg-card">
+                                            <div className="border-b border-border px-4 py-3">
+                                                <h3 className="text-sm font-semibold">
+                                                    Status
+                                                </h3>
+                                            </div>
+                                            <div className="p-4">
+                                                <input
+                                                    type="hidden"
+                                                    name="is_draft"
+                                                    value={isDraft ? '1' : '0'}
+                                                />
+                                                <div className="flex items-center justify-between">
+                                                    <div className="flex items-center gap-3">
+                                                        <div
+                                                            className={cn(
+                                                                'flex size-9 items-center justify-center rounded-lg',
+                                                                isDraft
+                                                                    ? 'bg-amber-100 dark:bg-amber-900/30'
+                                                                    : 'bg-green-100 dark:bg-green-900/30',
+                                                            )}
+                                                        >
+                                                            {isDraft ? (
+                                                                <EyeOff className="size-4 text-amber-700 dark:text-amber-400" />
+                                                            ) : (
+                                                                <Eye className="size-4 text-green-700 dark:text-green-400" />
+                                                            )}
+                                                        </div>
+                                                        <div>
+                                                            <p className="text-sm font-medium">
+                                                                {isDraft
+                                                                    ? 'Draft'
+                                                                    : 'Published'}
+                                                            </p>
+                                                            <p className="text-xs text-muted-foreground">
+                                                                {isDraft
+                                                                    ? 'Not visible'
+                                                                    : 'Visible to everyone'}
+                                                            </p>
+                                                        </div>
+                                                    </div>
+                                                    <Switch
+                                                        checked={!isDraft}
+                                                        onCheckedChange={(
+                                                            checked,
+                                                        ) => {
+                                                            setIsDraft(
+                                                                !checked,
+                                                            );
+
+                                                            if (!checked) {
+                                                                setRelativeTimeHint(
+                                                                    null,
+                                                                );
+                                                            }
+                                                        }}
+                                                    />
+                                                </div>
+
+                                                {!isDraft && (
+                                                    <div className="mt-4 border-t border-border pt-4">
+                                                        <div className="flex items-center justify-between">
+                                                            <div className="flex items-center gap-2">
+                                                                <Calendar className="size-4 text-muted-foreground" />
+                                                                <Label className="text-sm font-normal">
+                                                                    Schedule
+                                                                </Label>
+                                                            </div>
+                                                            <Switch
+                                                                id="schedule_toggle"
+                                                                checked={
+                                                                    scheduleEnabled
+                                                                }
+                                                                onCheckedChange={(
+                                                                    checked,
+                                                                ) => {
+                                                                    setScheduleEnabled(
+                                                                        checked,
+                                                                    );
+
+                                                                    if (
+                                                                        !checked
+                                                                    ) {
+                                                                        setPublishedAt(
+                                                                            '',
+                                                                        );
+                                                                        setRelativeTimeHint(
+                                                                            null,
+                                                                        );
+                                                                    }
+                                                                }}
+                                                            />
+                                                        </div>
+                                                        <input
+                                                            type="hidden"
+                                                            name="published_at"
+                                                            value={
+                                                                scheduleEnabled
+                                                                    ? publishedAt
+                                                                    : ''
+                                                            }
+                                                        />
+                                                        {scheduleEnabled && (
+                                                            <div className="mt-3 space-y-2">
+                                                                <Input
+                                                                    id="published_at"
+                                                                    type="datetime-local"
+                                                                    className="text-sm"
+                                                                    value={
+                                                                        publishedAt
+                                                                    }
+                                                                    onChange={(
+                                                                        e,
+                                                                    ) => {
+                                                                        const nextValue =
+                                                                            e
+                                                                                .target
+                                                                                .value;
+                                                                        setPublishedAt(
+                                                                            nextValue,
+                                                                        );
+                                                                        setRelativeTimeHint(
+                                                                            getRelativeTimeHint(
+                                                                                nextValue,
+                                                                                Date.now(),
+                                                                            ),
+                                                                        );
+                                                                    }}
+                                                                />
+                                                                {relativeTimeHint && (
+                                                                    <p className="text-xs text-muted-foreground">
+                                                                        {
+                                                                            relativeTimeHint
+                                                                        }
+                                                                    </p>
+                                                                )}
+                                                            </div>
+                                                        )}
+                                                        <InputError
+                                                            message={
+                                                                errors.published_at
+                                                            }
+                                                        />
+                                                    </div>
+                                                )}
+                                                {isDraft && (
+                                                    <input
+                                                        type="hidden"
+                                                        name="published_at"
+                                                        value=""
+                                                    />
+                                                )}
+                                            </div>
+                                        </div>
+
+                                        {/* Tags card */}
+                                        <div className="overflow-hidden rounded-xl border border-border bg-card">
+                                            <div className="flex items-center justify-between border-b border-border px-4 py-3">
+                                                <h3 className="text-sm font-semibold">
+                                                    Tags
+                                                </h3>
+                                                <Tag className="size-3.5 text-muted-foreground" />
+                                            </div>
+                                            <div className="p-4">
+                                                <TagInput
+                                                    tags={currentTags}
+                                                    onChange={(next) => {
+                                                        setCurrentTags(next);
+                                                        setHasUnsavedChanges(
+                                                            true,
+                                                        );
+                                                    }}
+                                                    availableTags={
+                                                        availableTags
+                                                    }
+                                                />
+                                                <p className="mt-2 text-xs text-muted-foreground">
+                                                    Lowercase letters, numbers,
+                                                    and hyphens only. Press
+                                                    Enter or comma to add.
+                                                </p>
+                                                <InputError
+                                                    message={
+                                                        errors['tags'] ??
+                                                        errors['tags.0']
+                                                    }
+                                                />
+                                            </div>
+                                        </div>
+
+                                        {/* Reference card */}
+                                        <div className="overflow-hidden rounded-xl border border-dashed border-border bg-muted/20">
+                                            <div className="flex items-center justify-between border-b border-dashed border-border px-4 py-3">
+                                                <div className="flex items-center gap-2">
+                                                    <h3 className="text-sm font-semibold">
+                                                        Reference
+                                                    </h3>
+                                                    <span className="text-xs text-muted-foreground">
+                                                        (optional)
+                                                    </span>
+                                                </div>
+                                                <Link2 className="size-3.5 text-muted-foreground" />
+                                            </div>
+                                            <div className="space-y-4 p-4">
+                                                <div className="space-y-1.5">
+                                                    <Label
+                                                        htmlFor="reference_title"
+                                                        className="text-xs text-muted-foreground"
+                                                    >
+                                                        Title
+                                                    </Label>
+                                                    <Input
+                                                        id="reference_title"
+                                                        name="reference_title"
+                                                        placeholder="Reference title"
+                                                        defaultValue={
+                                                            post.reference_title ??
+                                                            ''
+                                                        }
+                                                    />
+                                                    <InputError
+                                                        message={
+                                                            errors.reference_title
+                                                        }
+                                                    />
+                                                </div>
+                                                <div className="space-y-1.5">
+                                                    <Label
+                                                        htmlFor="reference_url"
+                                                        className="text-xs text-muted-foreground"
+                                                    >
+                                                        URL
+                                                    </Label>
+                                                    <Input
+                                                        id="reference_url"
+                                                        name="reference_url"
+                                                        type="url"
+                                                        placeholder="https://example.com"
+                                                        defaultValue={
+                                                            post.reference_url ??
+                                                            ''
+                                                        }
+                                                    />
+                                                    <InputError
+                                                        message={
+                                                            errors.reference_url
+                                                        }
+                                                    />
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </aside>
                             </div>
 
                             <div className="fixed right-6 bottom-6 z-50">

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -251,7 +251,9 @@ export default function Edit({
                                             data-test="edit-meta-panel-toggle"
                                             aria-expanded={metaPanelOpen}
                                             onClick={() =>
-                                                setMetaPanelOpen((value) => !value)
+                                                setMetaPanelOpen(
+                                                    (value) => !value,
+                                                )
                                             }
                                             title={
                                                 metaPanelOpen

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -1052,6 +1052,150 @@ test('admin post edit warns before leaving with unsaved changes', function () {
     ]);
 });
 
+test('admin post edit can collapse the metadata panel', function () {
+    $user = User::factory()->create([
+        'email' => 'test@example.com',
+    ]);
+
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+    ]);
+
+    $post = Post::factory()->for($namespace, 'namespace')->create([
+        'slug' => 'todo',
+        'title' => 'Todo',
+        'content' => '# Todo',
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.posts.edit', [
+        'namespace' => $namespace->id,
+        'post' => $post->slug,
+    ], absolute: false))->resize(1440, 900);
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="edit-meta-panel"]')
+        ->assertPresent('[data-test="edit-meta-panel-toggle"]');
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const panel = document.querySelector('[data-test="edit-meta-panel"]');
+            const toggle = document.querySelector('[data-test="edit-meta-panel-toggle"]');
+
+            if (! panel || ! toggle) {
+                return null;
+            }
+
+            return {
+                hidden: panel.classList.contains('hidden'),
+                expanded: toggle.getAttribute('aria-expanded'),
+            };
+        })()
+    JS))->toBe([
+        'hidden' => false,
+        'expanded' => 'true',
+    ]);
+
+    $page->click('[data-test="edit-meta-panel-toggle"]')->wait(0.2);
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const panel = document.querySelector('[data-test="edit-meta-panel"]');
+            const toggle = document.querySelector('[data-test="edit-meta-panel-toggle"]');
+
+            if (! panel || ! toggle) {
+                return null;
+            }
+
+            return {
+                hidden: panel.classList.contains('hidden'),
+                expanded: toggle.getAttribute('aria-expanded'),
+            };
+        })()
+    JS))->toBe([
+        'hidden' => true,
+        'expanded' => 'false',
+    ]);
+});
+
+test('admin post edit switches markdown editor tabs on mobile', function () {
+    $user = User::factory()->create([
+        'email' => 'test@example.com',
+    ]);
+
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+    ]);
+
+    $post = Post::factory()->for($namespace, 'namespace')->create([
+        'slug' => 'todo',
+        'title' => 'Todo',
+        'content' => "# Todo\n\nPreview body.",
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.posts.edit', [
+        'namespace' => $namespace->id,
+        'post' => $post->slug,
+    ], absolute: false))->resize(390, 844);
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="markdown-editor-write-tab"]')
+        ->assertPresent('[data-test="markdown-editor-preview-tab"]');
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const writePanel = document.querySelector('[data-test="markdown-editor-write-panel"]');
+            const previewPanel = document.querySelector('[data-test="markdown-editor-preview-panel"]');
+
+            if (! writePanel || ! previewPanel) {
+                return null;
+            }
+
+            return {
+                writeHidden: writePanel.classList.contains('hidden'),
+                previewHidden: previewPanel.classList.contains('hidden'),
+            };
+        })()
+    JS))->toBe([
+        'writeHidden' => false,
+        'previewHidden' => true,
+    ]);
+
+    $page->click('[data-test="markdown-editor-preview-tab"]')->wait(0.2);
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const writePanel = document.querySelector('[data-test="markdown-editor-write-panel"]');
+            const previewPanel = document.querySelector('[data-test="markdown-editor-preview-panel"]');
+            const previewText = previewPanel
+                ?.querySelector('.prose')
+                ?.textContent?.replace(/\s+/g, ' ')
+                .trim() ?? null;
+
+            if (! writePanel || ! previewPanel) {
+                return null;
+            }
+
+            return {
+                writeHidden: writePanel.classList.contains('hidden'),
+                previewHidden: previewPanel.classList.contains('hidden'),
+                previewText,
+            };
+        })()
+    JS))->toBe([
+        'writeHidden' => true,
+        'previewHidden' => false,
+        'previewText' => 'Todo Preview body.',
+    ]);
+});
+
 test('admin post header shows revisions and delete as labeled actions', function () {
     $user = User::factory()->create([
         'email' => 'test@example.com',


### PR DESCRIPTION
## Summary
- preserve the redesigned admin edit layout while restoring the in-page view-post navigation and unsaved-change confirmation
- add stable test selectors plus live slug preview and metadata panel toggle polish
- cover the new edit-screen behaviors with browser tests for the metadata panel and mobile markdown tabs

## Testing
- vendor/bin/sail npm run types:check
- vendor/bin/sail npx eslint resources/js/components/markdown-editor.tsx resources/js/pages/admin/posts/edit.tsx
- vendor/bin/sail npm run build
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail artisan test --compact tests/Feature/Admin/PostControllerTest.php tests/Feature/Admin/PostRevisionTest.php
- vendor/bin/sail bash -lc 'PHPUNIT_RESULT_CACHE=/tmp/.phpunit.result.cache php artisan test --compact tests/Browser/SmokeTest.php --filter="admin post edit|admin post header"'