### PR TITLE
Fix admin namespace UI regressions

### DIFF
--- a/resources/js/components/namespace-header.tsx
+++ b/resources/js/components/namespace-header.tsx
@@ -10,6 +10,7 @@ import {
     Pencil,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -17,6 +18,7 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import ViewContextBadge from '@/components/view-context-badge';
+import { cn } from '@/lib/utils';
 import {
     create as namespaceCreate,
     edit as editNamespace,
@@ -40,127 +42,278 @@ type Namespace = {
 
 export default function NamespaceHeader({
     namespace,
+    childNamespacesCount,
+    postsCount,
+    namespacesReorderMode = false,
+    postsReorderMode = false,
 }: {
     namespace: Namespace;
+    childNamespacesCount: number;
+    postsCount: number;
+    namespacesReorderMode?: boolean;
+    postsReorderMode?: boolean;
 }) {
     const childNamespaceCreateUrl = `${namespaceCreate.url()}?${new URLSearchParams({ parent: String(namespace.id) }).toString()}`;
     const siteUrl = `/${namespace.full_path}`;
+    const statusLabel = namespace.is_published ? 'Published' : 'Draft';
+    const activeModes = [
+        namespacesReorderMode ? 'Child namespace reorder active' : null,
+        postsReorderMode ? 'Post reorder active' : null,
+    ].filter(Boolean);
+
+    const metrics = [
+        {
+            label: 'Child namespaces',
+            value: childNamespacesCount.toLocaleString(),
+            hint:
+                childNamespacesCount === 0
+                    ? 'No nested namespaces yet'
+                    : 'Nested beneath this namespace',
+        },
+        {
+            label: 'Posts',
+            value: postsCount.toLocaleString(),
+            hint:
+                postsCount === 0
+                    ? 'No posts in this namespace yet'
+                    : 'Managed from the post table below',
+        },
+        {
+            label: 'Backups',
+            value: (namespace.backup_count ?? 0).toLocaleString(),
+            hint: namespace.backup_management_url
+                ? 'Backup management available'
+                : 'No backups available yet',
+        },
+    ];
 
     return (
-        <div className="rounded-xl border border-amber-200/80 bg-amber-50/70 p-5 dark:border-amber-900/80 dark:bg-amber-950/20">
-            <div className="flex flex-wrap items-start justify-between gap-4">
-                <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-start gap-4">
-                        {namespace.cover_image_url && (
-                            <div className="order-2 sm:order-1 sm:flex-none">
-                                <img
-                                    data-test="manage-namespace-cover-image"
-                                    src={namespace.cover_image_url}
-                                    alt={`${namespace.name} cover`}
-                                    className="h-20 w-32 rounded-lg border border-amber-200/80 object-cover shadow-sm dark:border-amber-900/80"
-                                />
-                            </div>
-                        )}
-                        <div className="order-1 min-w-0 flex-1 sm:order-2">
-                            <p className="text-xs font-semibold tracking-wider text-amber-700 uppercase dark:text-amber-300">
-                                Manage Namespace
-                            </p>
-                            <div className="mt-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
-                                <h1 className="flex items-center gap-2 text-2xl font-semibold">
-                                    <FolderOpen className="size-5 shrink-0 text-amber-700 dark:text-amber-300" />
-                                    <Link
-                                        href={namespaceRoute.url(namespace.id)}
-                                        className="hover:underline"
-                                    >
-                                        {namespace.name}
-                                    </Link>
-                                </h1>
-                                <div className="flex items-center gap-2">
-                                    <p className="text-sm text-amber-800/70 dark:text-amber-200/70">
-                                        /{namespace.full_path}
-                                    </p>
+        <section className="relative overflow-hidden rounded-[1.75rem] border border-amber-200/70 bg-gradient-to-br from-amber-50 via-background to-orange-50 p-6 shadow-sm sm:p-7 dark:border-amber-900/70 dark:from-amber-950/20 dark:via-background dark:to-orange-950/10">
+            <div className="pointer-events-none absolute inset-0">
+                <div className="absolute top-0 right-0 h-40 w-40 rounded-full bg-amber-200/35 blur-3xl dark:bg-amber-500/10" />
+                <div className="absolute bottom-0 left-0 h-36 w-36 rounded-full bg-orange-200/25 blur-3xl dark:bg-orange-500/10" />
+            </div>
+
+            <div className="relative flex flex-col gap-6">
+                <div className="flex flex-col gap-6 xl:flex-row xl:items-start xl:justify-between">
+                    <div className="max-w-3xl min-w-0 space-y-4">
+                        <div className="inline-flex w-fit items-center rounded-full border border-amber-200/70 bg-background/80 px-3 py-1 text-xs font-medium text-amber-700 shadow-sm dark:border-amber-900/70 dark:text-amber-300">
+                            Manage Namespace
+                        </div>
+
+                        <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+                            {namespace.cover_image_url && (
+                                <div className="shrink-0">
+                                    <img
+                                        data-test="manage-namespace-cover-image"
+                                        src={namespace.cover_image_url}
+                                        alt={`${namespace.name} cover`}
+                                        className="h-24 w-36 rounded-2xl border border-amber-200/80 object-cover shadow-sm dark:border-amber-900/80"
+                                    />
                                 </div>
-                            </div>
-                            <div className="mt-2">
-                                {namespace.is_published ? (
-                                    <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
-                                        <CheckCircle2 className="size-3" />
-                                        Published
-                                    </span>
+                            )}
+
+                            <div className="min-w-0 flex-1 space-y-3">
+                                <div className="space-y-3">
+                                    <div className="flex flex-wrap items-center gap-3">
+                                        <h1 className="flex min-w-0 items-center gap-2 text-3xl font-semibold tracking-tight sm:text-4xl">
+                                            <FolderOpen className="size-6 shrink-0 text-amber-700 dark:text-amber-300" />
+                                            <Link
+                                                href={namespaceRoute.url(
+                                                    namespace.id,
+                                                )}
+                                                className="truncate hover:underline"
+                                            >
+                                                {namespace.name}
+                                            </Link>
+                                        </h1>
+
+                                        <span
+                                            className={cn(
+                                                'inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium',
+                                                namespace.is_published
+                                                    ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                                                    : 'bg-muted text-muted-foreground',
+                                            )}
+                                        >
+                                            {namespace.is_published ? (
+                                                <CheckCircle2 className="size-3.5" />
+                                            ) : (
+                                                <FilePen className="size-3.5" />
+                                            )}
+                                            {statusLabel}
+                                        </span>
+                                    </div>
+
+                                    <div className="flex flex-wrap items-center gap-2 text-sm text-amber-900/70 dark:text-amber-100/70">
+                                        <span className="rounded-full bg-background/80 px-3 py-1 ring-1 ring-border/60">
+                                            /{namespace.full_path}
+                                        </span>
+                                        <ViewContextBadge
+                                            label="Admin View"
+                                            variant="admin"
+                                        />
+                                    </div>
+                                </div>
+
+                                {namespace.description ? (
+                                    <p className="max-w-2xl text-sm leading-6 whitespace-pre-line text-amber-950/80 dark:text-amber-100/80">
+                                        {namespace.description}
+                                    </p>
                                 ) : (
-                                    <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                                        <FilePen className="size-3" />
-                                        Draft
-                                    </span>
+                                    <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+                                        This namespace groups related posts and
+                                        nested namespaces. Use the controls on
+                                        the right to expand the structure or
+                                        update its metadata.
+                                    </p>
+                                )}
+
+                                {activeModes.length > 0 && (
+                                    <div className="flex flex-wrap gap-2">
+                                        {activeModes.map((mode) => (
+                                            <span
+                                                key={mode}
+                                                className="inline-flex items-center rounded-full bg-foreground px-3 py-1 text-xs font-medium text-background"
+                                            >
+                                                {mode}
+                                            </span>
+                                        ))}
+                                    </div>
                                 )}
                             </div>
-                            {namespace.description && (
-                                <p className="mt-3 max-w-2xl text-sm leading-6 whitespace-pre-line text-amber-900/80 dark:text-amber-100/80">
-                                    {namespace.description}
-                                </p>
-                            )}
                         </div>
-                    </div>
-                </div>
-                <div className="flex flex-col items-start gap-2 sm:items-end">
-                    <div className="flex flex-wrap items-center gap-2">
-                        <Button asChild>
-                            <Link href={siteUrl}>
-                                <ArrowRightLeft className="size-4" />
-                                View Site
-                            </Link>
-                        </Button>
-                        <ViewContextBadge label="Admin View" variant="admin" />
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                        <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                                <Button>
-                                    <FilePen className="size-4" />
-                                    Create
-                                    <ChevronDown className="size-4" />
-                                </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end" className="w-52">
-                                <DropdownMenuItem asChild>
-                                    <Link href={createPost.url(namespace.id)}>
-                                        <FilePen className="size-4" />
-                                        Post
-                                    </Link>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem asChild>
-                                    <Link href={childNamespaceCreateUrl}>
-                                        <FolderPlus className="size-4" />
-                                        Child Namespace
-                                    </Link>
-                                </DropdownMenuItem>
-                            </DropdownMenuContent>
-                        </DropdownMenu>
-                        <Button variant="outline" asChild>
-                            <Link href={editNamespace.url(namespace.id)}>
-                                <Pencil className="size-4" />
-                                Edit Namespace
-                            </Link>
-                        </Button>
-                    </div>
-                    {namespace.backup_management_url && (
-                        <div className="flex flex-wrap items-center gap-2">
-                            <Button variant="outline" asChild>
-                                <Link
-                                    href={namespace.backup_management_url}
-                                    data-test="manage-namespace-backups-link"
+
+                        <div className="grid gap-3 sm:grid-cols-3">
+                            {metrics.map((metric) => (
+                                <Card
+                                    key={metric.label}
+                                    className="gap-0 border-border/60 bg-background/80 py-0 shadow-none backdrop-blur"
                                 >
-                                    <Archive className="size-4" />
-                                    {namespace.backup_count ?? 0} backups
-                                    <span className="hidden sm:inline">
-                                        · Backup Management
-                                    </span>
-                                </Link>
-                            </Button>
+                                    <CardContent className="space-y-1 px-4 py-4">
+                                        <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                                            {metric.label}
+                                        </p>
+                                        <p className="text-2xl font-semibold tracking-tight">
+                                            {metric.value}
+                                        </p>
+                                        <p className="text-xs text-muted-foreground">
+                                            {metric.hint}
+                                        </p>
+                                    </CardContent>
+                                </Card>
+                            ))}
                         </div>
-                    )}
+                    </div>
+
+                    <Card className="w-full max-w-xl gap-0 border-border/70 bg-background/88 py-0 shadow-lg shadow-black/5 backdrop-blur xl:w-[23rem]">
+                        <CardContent className="space-y-4 px-5 py-5">
+                            <div className="space-y-1">
+                                <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                                    Controls
+                                </p>
+                                <h2 className="text-lg font-semibold">
+                                    Namespace actions
+                                </h2>
+                                <p className="text-sm leading-6 text-muted-foreground">
+                                    Open the public page, create content inside
+                                    this namespace, or update its settings and
+                                    backups.
+                                </p>
+                            </div>
+
+                            <div className="flex flex-col gap-3">
+                                <Button asChild size="lg" className="w-full">
+                                    <Link href={siteUrl}>
+                                        <ArrowRightLeft className="size-4" />
+                                        View Site
+                                    </Link>
+                                </Button>
+
+                                <div className="grid gap-3 sm:grid-cols-2">
+                                    <DropdownMenu>
+                                        <DropdownMenuTrigger asChild>
+                                            <Button
+                                                size="lg"
+                                                className="w-full"
+                                            >
+                                                <FilePen className="size-4" />
+                                                Create
+                                                <ChevronDown className="size-4" />
+                                            </Button>
+                                        </DropdownMenuTrigger>
+                                        <DropdownMenuContent
+                                            align="end"
+                                            className="w-56"
+                                        >
+                                            <DropdownMenuItem asChild>
+                                                <Link
+                                                    href={createPost.url(
+                                                        namespace.id,
+                                                    )}
+                                                >
+                                                    <FilePen className="size-4" />
+                                                    Post
+                                                </Link>
+                                            </DropdownMenuItem>
+                                            <DropdownMenuItem asChild>
+                                                <Link
+                                                    href={
+                                                        childNamespaceCreateUrl
+                                                    }
+                                                >
+                                                    <FolderPlus className="size-4" />
+                                                    Child Namespace
+                                                </Link>
+                                            </DropdownMenuItem>
+                                        </DropdownMenuContent>
+                                    </DropdownMenu>
+
+                                    <Button
+                                        variant="outline"
+                                        size="lg"
+                                        className="w-full"
+                                        asChild
+                                    >
+                                        <Link
+                                            href={editNamespace.url(
+                                                namespace.id,
+                                            )}
+                                        >
+                                            <Pencil className="size-4" />
+                                            Edit Namespace
+                                        </Link>
+                                    </Button>
+                                </div>
+                            </div>
+
+                            {namespace.backup_management_url ? (
+                                <Button
+                                    variant="outline"
+                                    className="w-full justify-start"
+                                    asChild
+                                >
+                                    <Link
+                                        href={namespace.backup_management_url}
+                                        data-test="manage-namespace-backups-link"
+                                    >
+                                        <Archive className="size-4" />
+                                        {namespace.backup_count ?? 0} backups
+                                        <span className="text-muted-foreground">
+                                            · Backup Management
+                                        </span>
+                                    </Link>
+                                </Button>
+                            ) : (
+                                <div className="rounded-2xl border border-dashed border-border/70 bg-muted/40 p-4 text-sm text-muted-foreground">
+                                    No backups yet. Once backups exist,
+                                    management links will appear here.
+                                </div>
+                            )}
+                        </CardContent>
+                    </Card>
                 </div>
             </div>
-        </div>
+        </section>
     );
 }

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -38,6 +38,7 @@ import { startTransition, useEffect, useRef, useState } from 'react';
 import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
 import {
     Dialog,
     DialogClose,
@@ -102,6 +103,67 @@ type RestoreLog = {
     type: 'info' | 'success' | 'error';
     message: string;
 };
+
+type NamespaceSummary = {
+    childCount: number;
+    draftCount: number;
+    publishedCount: number;
+    rootCount: number;
+    totalCount: number;
+    totalPosts: number;
+};
+
+function summarizeNamespaces(namespaces: Namespace[]): NamespaceSummary {
+    let totalCount = 0;
+    let childCount = 0;
+    let totalPosts = 0;
+    let publishedCount = 0;
+    let draftCount = 0;
+
+    function visit(nodes: Namespace[], depth = 0): void {
+        nodes.forEach((namespace) => {
+            totalCount += 1;
+            totalPosts += namespace.posts_count;
+
+            if (depth > 0) {
+                childCount += 1;
+            }
+
+            if (namespace.is_published) {
+                publishedCount += 1;
+            } else {
+                draftCount += 1;
+            }
+
+            visit(namespace.children, depth + 1);
+        });
+    }
+
+    visit(namespaces);
+
+    return {
+        childCount,
+        draftCount,
+        publishedCount,
+        rootCount: namespaces.length,
+        totalCount,
+        totalPosts,
+    };
+}
+
+function sortLabel(sort: Sort): string {
+    const columnLabels: Record<string, string> = {
+        is_published: 'Status',
+        name: 'Name',
+        posts_count: 'Post count',
+        sort_order: 'Manual order',
+    };
+
+    const label = columnLabels[sort.column] ?? sort.column;
+    const direction = sort.direction === 'asc' ? 'ascending' : 'descending';
+
+    return `${label}, ${direction}`;
+}
 
 function DeleteNamespaceDialog({ namespace }: { namespace: Namespace }) {
     const [confirmation, setConfirmation] = useState('');
@@ -384,9 +446,11 @@ function RestorePreviewPanel({
 function RestoreNamespacesDialog({
     restoreUploadUrl,
     restorePreview,
+    triggerClassName,
 }: {
     restoreUploadUrl: string;
     restorePreview: RestorePreview | null;
+    triggerClassName?: string;
 }) {
     const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false);
     const [isDraggingBackup, setIsDraggingBackup] = useState(false);
@@ -472,7 +536,7 @@ function RestoreNamespacesDialog({
     return (
         <Dialog open={open} onOpenChange={handleOpenChange}>
             <DialogTrigger asChild>
-                <Button variant="outline">
+                <Button variant="outline" className={triggerClassName}>
                     <Upload className="size-4" />
                     Restore Zip
                 </Button>
@@ -600,6 +664,209 @@ function RestoreNamespacesDialog({
                 )}
             </DialogContent>
         </Dialog>
+    );
+}
+
+function NamespacesHeaderPanel({
+    namespaces,
+    reorderMode,
+    restoreUploadUrl,
+    restorePreview,
+    sort,
+    onToggleReorder,
+}: {
+    namespaces: Namespace[];
+    reorderMode: boolean;
+    restoreUploadUrl: string;
+    restorePreview: RestorePreview | null;
+    sort: Sort;
+    onToggleReorder: () => void;
+}) {
+    const summary = summarizeNamespaces(namespaces);
+    const hasNamespaces = namespaces.length > 0;
+
+    const metrics = [
+        {
+            label: 'Root namespaces',
+            value: summary.rootCount.toLocaleString(),
+            hint: `${summary.childCount.toLocaleString()} nested`,
+        },
+        {
+            label: 'All namespaces',
+            value: summary.totalCount.toLocaleString(),
+            hint: `${summary.publishedCount.toLocaleString()} published`,
+        },
+        {
+            label: 'Posts in tree',
+            value: summary.totalPosts.toLocaleString(),
+            hint: hasNamespaces
+                ? 'Across all visible namespaces'
+                : 'No content yet',
+        },
+        {
+            label: 'Needs attention',
+            value: summary.draftCount.toLocaleString(),
+            hint:
+                summary.draftCount === 0
+                    ? 'All namespaces published'
+                    : 'Draft namespaces remaining',
+        },
+    ];
+
+    return (
+        <section className="relative overflow-hidden rounded-[1.75rem] border border-border/70 bg-gradient-to-br from-amber-50 via-background to-sky-50 p-6 shadow-sm sm:p-7 dark:from-amber-950/20 dark:via-background dark:to-sky-950/20">
+            <div className="pointer-events-none absolute inset-0">
+                <div className="absolute top-0 right-0 h-40 w-40 rounded-full bg-amber-200/30 blur-3xl dark:bg-amber-500/10" />
+                <div className="absolute bottom-0 left-0 h-40 w-40 rounded-full bg-sky-200/30 blur-3xl dark:bg-sky-500/10" />
+            </div>
+
+            <div className="relative flex flex-col gap-6">
+                <div className="flex flex-col gap-6 xl:flex-row xl:items-start xl:justify-between">
+                    <div className="max-w-3xl space-y-4">
+                        <div className="inline-flex w-fit items-center rounded-full border border-amber-200/70 bg-background/80 px-3 py-1 text-xs font-medium text-amber-700 shadow-sm dark:border-amber-900/70 dark:text-amber-300">
+                            Admin content structure
+                        </div>
+
+                        <div className="space-y-3">
+                            <div className="flex flex-wrap items-center gap-3">
+                                <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+                                    Namespaces
+                                </h1>
+                                <span
+                                    className={cn(
+                                        'inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium',
+                                        reorderMode
+                                            ? 'bg-foreground text-background'
+                                            : 'bg-background/80 text-muted-foreground ring-1 ring-border/70',
+                                    )}
+                                >
+                                    {reorderMode ? (
+                                        <>
+                                            <Check className="size-3.5" />
+                                            Reorder mode
+                                        </>
+                                    ) : (
+                                        <>
+                                            <ArrowUpDown className="size-3.5" />
+                                            Sorted by {sortLabel(sort)}
+                                        </>
+                                    )}
+                                </span>
+                            </div>
+
+                            <p className="max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+                                Root namespaces, child trees, and publishing
+                                state are managed from here. Keep the top-level
+                                structure readable, then drill into each
+                                namespace for post-level work.
+                            </p>
+                        </div>
+
+                        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                            {metrics.map((metric) => (
+                                <Card
+                                    key={metric.label}
+                                    className="gap-0 border-border/60 bg-background/80 py-0 shadow-none backdrop-blur"
+                                >
+                                    <CardContent className="space-y-1 px-4 py-4">
+                                        <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                                            {metric.label}
+                                        </p>
+                                        <p className="text-2xl font-semibold tracking-tight">
+                                            {metric.value}
+                                        </p>
+                                        <p className="text-xs text-muted-foreground">
+                                            {metric.hint}
+                                        </p>
+                                    </CardContent>
+                                </Card>
+                            ))}
+                        </div>
+                    </div>
+
+                    <Card className="w-full max-w-xl gap-0 border-border/70 bg-background/88 py-0 shadow-lg shadow-black/5 backdrop-blur xl:w-[24rem]">
+                        <CardContent className="space-y-4 px-5 py-5">
+                            <div className="space-y-1">
+                                <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                                    Controls
+                                </p>
+                                <h2 className="text-lg font-semibold">
+                                    Primary actions
+                                </h2>
+                                <p className="text-sm leading-6 text-muted-foreground">
+                                    Create a new root namespace, reorder the
+                                    current tree, or restore a zip backup into
+                                    the hierarchy.
+                                </p>
+                            </div>
+
+                            <div className="flex flex-col gap-3">
+                                <Button asChild size="lg" className="w-full">
+                                    <Link href={namespaceCreate.url()}>
+                                        <FolderPlus className="size-4" />
+                                        New Namespace
+                                    </Link>
+                                </Button>
+
+                                <div className="grid gap-3 sm:grid-cols-2">
+                                    <Button
+                                        variant={
+                                            reorderMode
+                                                ? 'secondary'
+                                                : 'outline'
+                                        }
+                                        size="lg"
+                                        onClick={onToggleReorder}
+                                        className="w-full"
+                                    >
+                                        {reorderMode ? (
+                                            <>
+                                                <Check className="size-4" />
+                                                Done
+                                            </>
+                                        ) : (
+                                            <>
+                                                <ArrowUpDown className="size-4" />
+                                                Reorder
+                                            </>
+                                        )}
+                                    </Button>
+
+                                    <RestoreNamespacesDialog
+                                        restoreUploadUrl={restoreUploadUrl}
+                                        restorePreview={restorePreview}
+                                        triggerClassName="w-full"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="rounded-2xl border border-dashed border-border/70 bg-muted/40 p-4 text-sm text-muted-foreground">
+                                {reorderMode ? (
+                                    <p>
+                                        Drag root namespaces to change their top
+                                        level order. Child namespaces keep their
+                                        local tree under each parent.
+                                    </p>
+                                ) : hasNamespaces ? (
+                                    <p>
+                                        Expand a row to inspect child
+                                        namespaces. Sorting changes the current
+                                        view, while reorder mode returns to the
+                                        manual structure.
+                                    </p>
+                                ) : (
+                                    <p>
+                                        Start with a single namespace for your
+                                        first content area, then branch into
+                                        child namespaces as the catalog grows.
+                                    </p>
+                                )}
+                            </div>
+                        </CardContent>
+                    </Card>
+                </div>
+            </div>
+        </section>
     );
 }
 
@@ -941,154 +1208,161 @@ export default function Index({
             <Head title="Namespaces" />
 
             <div className="space-y-6 p-4">
-                <div className="flex items-center justify-between">
-                    <div>
-                        <h1 className="text-2xl font-semibold">Namespaces</h1>
-                        <p className="text-sm text-muted-foreground">
-                            Manage namespaces and their posts
-                        </p>
-                    </div>
-                    <div className="flex items-center gap-2">
-                        <RestoreNamespacesDialog
-                            restoreUploadUrl={restore_upload_url}
-                            restorePreview={restore_preview}
-                        />
-                        <Button
-                            variant={reorderMode ? 'secondary' : 'outline'}
-                            onClick={handleReorderToggle}
-                        >
-                            {reorderMode ? (
-                                <>
-                                    <Check className="size-4" />
-                                    Done
-                                </>
-                            ) : (
-                                <>
-                                    <ArrowUpDown className="size-4" />
-                                    Reorder
-                                </>
-                            )}
-                        </Button>
-                        <Button asChild>
-                            <Link href={namespaceCreate.url()}>
-                                <FolderPlus className="size-4" />
-                                New Namespace
-                            </Link>
-                        </Button>
-                    </div>
-                </div>
+                <NamespacesHeaderPanel
+                    namespaces={namespaces}
+                    reorderMode={reorderMode}
+                    restoreUploadUrl={restore_upload_url}
+                    restorePreview={restore_preview}
+                    sort={sort}
+                    onToggleReorder={handleReorderToggle}
+                />
 
                 {namespaces.length === 0 ? (
-                    <div className="rounded-xl border border-dashed p-12 text-center">
-                        <p className="text-muted-foreground">
-                            No namespaces yet.
-                        </p>
-                        <p className="mt-1 text-sm text-muted-foreground">
-                            Create a namespace to start adding posts.
-                        </p>
-                        <Button asChild className="mt-4">
-                            <Link href={namespaceCreate.url()}>
-                                <FolderPlus className="size-4" />
-                                Create your first namespace
-                            </Link>
-                        </Button>
-                    </div>
+                    <Card className="border-dashed py-0 shadow-none">
+                        <CardContent className="flex flex-col items-center px-6 py-14 text-center">
+                            <div className="rounded-full border bg-muted/60 p-4">
+                                <FolderPlus className="size-6 text-muted-foreground" />
+                            </div>
+                            <h2 className="mt-5 text-xl font-semibold">
+                                No namespaces yet
+                            </h2>
+                            <p className="mt-2 max-w-md text-sm leading-6 text-muted-foreground">
+                                Create a root namespace to define your first
+                                content area, then branch into child namespaces
+                                when the structure becomes deeper.
+                            </p>
+                            <Button asChild className="mt-6">
+                                <Link href={namespaceCreate.url()}>
+                                    <FolderPlus className="size-4" />
+                                    Create your first namespace
+                                </Link>
+                            </Button>
+                        </CardContent>
+                    </Card>
                 ) : (
                     <DndContext
                         sensors={sensors}
                         collisionDetection={closestCenter}
                         onDragEnd={handleDragEnd}
                     >
-                        <div className="rounded-xl border">
-                            <table className="w-full text-sm">
-                                <thead>
-                                    <tr className="border-b bg-muted/50">
-                                        <th className="w-8 px-2 py-3" />
-                                        <th className="px-4 py-3 text-left">
-                                            {reorderMode ? (
-                                                <span className="font-medium">
-                                                    Namespace
-                                                </span>
-                                            ) : (
-                                                <SortableHeader
-                                                    column="name"
-                                                    label="Namespace"
-                                                    sort={sort}
-                                                />
-                                            )}
-                                        </th>
-                                        <th className="px-4 py-3 text-left font-medium">
-                                            Slug
-                                        </th>
-                                        <th className="px-4 py-3 text-left">
-                                            {reorderMode ? (
-                                                <span className="font-medium">
-                                                    Status
-                                                </span>
-                                            ) : (
-                                                <SortableHeader
-                                                    column="is_published"
-                                                    label="Status"
-                                                    sort={sort}
-                                                />
-                                            )}
-                                        </th>
-                                        <th className="px-4 py-3 text-left">
-                                            {reorderMode ? (
-                                                <span className="font-medium">
-                                                    Posts
-                                                </span>
-                                            ) : (
-                                                <SortableHeader
-                                                    column="posts_count"
-                                                    label="Posts"
-                                                    sort={sort}
-                                                />
-                                            )}
-                                        </th>
-                                        <th className="px-4 py-3 text-right font-medium">
-                                            Actions
-                                        </th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <SortableContext
-                                        items={namespaces.map((ns) => ns.id)}
-                                        strategy={verticalListSortingStrategy}
-                                    >
-                                        {namespaces.flatMap((ns) => [
-                                            <SortableRow
-                                                key={ns.id}
-                                                namespace={ns}
-                                                isDndActive={reorderMode}
-                                                isExpanded={expandedIds.has(
-                                                    ns.id,
+                        <Card className="gap-0 py-0 shadow-sm">
+                            <div className="flex flex-col gap-2 border-b px-5 py-4 sm:flex-row sm:items-start sm:justify-between">
+                                <div>
+                                    <h2 className="text-lg font-semibold">
+                                        Namespace tree
+                                    </h2>
+                                    <p className="text-sm text-muted-foreground">
+                                        {reorderMode
+                                            ? 'Drag and drop root namespaces to set the manual order.'
+                                            : 'Browse the top-level structure, expand children, and open a namespace for deeper editing.'}
+                                    </p>
+                                </div>
+                                <div className="rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground">
+                                    {reorderMode
+                                        ? 'Manual ordering active'
+                                        : `Current sort: ${sortLabel(sort)}`}
+                                </div>
+                            </div>
+
+                            <div className="overflow-x-auto">
+                                <table className="w-full text-sm">
+                                    <thead>
+                                        <tr className="border-b bg-muted/50">
+                                            <th className="w-8 px-2 py-3" />
+                                            <th className="px-4 py-3 text-left">
+                                                {reorderMode ? (
+                                                    <span className="font-medium">
+                                                        Namespace
+                                                    </span>
+                                                ) : (
+                                                    <SortableHeader
+                                                        column="name"
+                                                        label="Namespace"
+                                                        sort={sort}
+                                                    />
                                                 )}
-                                                onToggle={() =>
-                                                    toggleExpand(ns.id)
-                                                }
-                                            />,
-                                            ...(!reorderMode &&
-                                            expandedIds.has(ns.id)
-                                                ? ns.children.map((child) => (
-                                                      <ChildRow
-                                                          key={child.id}
-                                                          namespace={child}
-                                                          depth={1}
-                                                          expandedIds={
-                                                              expandedIds
-                                                          }
-                                                          onToggle={
-                                                              toggleExpand
-                                                          }
-                                                      />
-                                                  ))
-                                                : []),
-                                        ])}
-                                    </SortableContext>
-                                </tbody>
-                            </table>
-                        </div>
+                                            </th>
+                                            <th className="px-4 py-3 text-left font-medium">
+                                                Slug
+                                            </th>
+                                            <th className="px-4 py-3 text-left">
+                                                {reorderMode ? (
+                                                    <span className="font-medium">
+                                                        Status
+                                                    </span>
+                                                ) : (
+                                                    <SortableHeader
+                                                        column="is_published"
+                                                        label="Status"
+                                                        sort={sort}
+                                                    />
+                                                )}
+                                            </th>
+                                            <th className="px-4 py-3 text-left">
+                                                {reorderMode ? (
+                                                    <span className="font-medium">
+                                                        Posts
+                                                    </span>
+                                                ) : (
+                                                    <SortableHeader
+                                                        column="posts_count"
+                                                        label="Posts"
+                                                        sort={sort}
+                                                    />
+                                                )}
+                                            </th>
+                                            <th className="px-4 py-3 text-right font-medium">
+                                                Actions
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <SortableContext
+                                            items={namespaces.map(
+                                                (ns) => ns.id,
+                                            )}
+                                            strategy={
+                                                verticalListSortingStrategy
+                                            }
+                                        >
+                                            {namespaces.flatMap((ns) => [
+                                                <SortableRow
+                                                    key={ns.id}
+                                                    namespace={ns}
+                                                    isDndActive={reorderMode}
+                                                    isExpanded={expandedIds.has(
+                                                        ns.id,
+                                                    )}
+                                                    onToggle={() =>
+                                                        toggleExpand(ns.id)
+                                                    }
+                                                />,
+                                                ...(!reorderMode &&
+                                                expandedIds.has(ns.id)
+                                                    ? ns.children.map(
+                                                          (child) => (
+                                                              <ChildRow
+                                                                  key={child.id}
+                                                                  namespace={
+                                                                      child
+                                                                  }
+                                                                  depth={1}
+                                                                  expandedIds={
+                                                                      expandedIds
+                                                                  }
+                                                                  onToggle={
+                                                                      toggleExpand
+                                                                  }
+                                                              />
+                                                          ),
+                                                      )
+                                                    : []),
+                                            ])}
+                                        </SortableContext>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </Card>
                     </DndContext>
                 )}
             </div>

--- a/resources/js/pages/admin/posts/namespace.tsx
+++ b/resources/js/pages/admin/posts/namespace.tsx
@@ -32,7 +32,9 @@ import {
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import NamespaceHeader from '@/components/namespace-header';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
     Dialog,
@@ -43,7 +45,6 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
-import { Badge } from '@/components/ui/badge';
 import { timeAgo } from '@/lib/time';
 import { dashboard } from '@/routes';
 import { create as namespaceCreate } from '@/routes/admin/namespaces';
@@ -256,7 +257,7 @@ function SortablePostRow({
                         <FilePen className="size-3" />
                         Draft
                     </span>
-                ) : !post.published_at ||
+                ) : post.published_at &&
                   new Date(post.published_at) > new Date() ? (
                     <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
                         <Clock className="size-3" />
@@ -394,297 +395,338 @@ export default function Namespace({
             <Head title={`Posts — ${namespace.name}`} />
 
             <div className="space-y-6 p-4">
-                <NamespaceHeader namespace={namespace} />
+                <NamespaceHeader
+                    namespace={namespace}
+                    childNamespacesCount={children.length}
+                    postsCount={posts.length}
+                    namespacesReorderMode={namespacesReorderMode}
+                    postsReorderMode={postsReorderMode}
+                />
 
                 {children.length > 0 && (
-                    <div className="space-y-2">
-                        <div className="flex items-center justify-between">
-                            <h2 className="text-sm font-medium text-muted-foreground">
-                                Child Namespaces
-                            </h2>
-                            <Button
-                                variant={
-                                    namespacesReorderMode
-                                        ? 'secondary'
-                                        : 'outline'
-                                }
-                                size="sm"
-                                onClick={() =>
-                                    setNamespacesReorderMode((v) => !v)
-                                }
-                            >
-                                {namespacesReorderMode ? (
-                                    <>
-                                        <Check className="size-4" />
-                                        Done
-                                    </>
-                                ) : (
-                                    <>
-                                        <ArrowUpDown className="size-4" />
-                                        Reorder
-                                    </>
-                                )}
-                            </Button>
-                        </div>
+                    <div className="space-y-3">
                         <DndContext
                             sensors={sensors}
                             collisionDetection={closestCenter}
                             onDragEnd={handleNamespaceDragEnd}
                         >
-                            <div className="rounded-xl border">
-                                <table className="w-full text-sm">
-                                    <tbody>
-                                        <SortableContext
-                                            items={children.map((c) => c.id)}
-                                            strategy={
-                                                verticalListSortingStrategy
-                                            }
-                                        >
-                                            {children.map((child) => (
-                                                <SortableChildRow
-                                                    key={child.id}
-                                                    child={child}
-                                                    reorderMode={
-                                                        namespacesReorderMode
-                                                    }
-                                                />
-                                            ))}
-                                        </SortableContext>
-                                    </tbody>
-                                </table>
-                            </div>
+                            <Card className="gap-0 py-0 shadow-sm">
+                                <div className="flex flex-col gap-2 border-b px-5 py-4 sm:flex-row sm:items-start sm:justify-between">
+                                    <div>
+                                        <h2 className="text-lg font-semibold">
+                                            Child namespaces
+                                        </h2>
+                                        <p className="text-sm text-muted-foreground">
+                                            Reorder the local namespace tree or
+                                            open a child namespace for deeper
+                                            editing.
+                                        </p>
+                                    </div>
+                                    <Button
+                                        variant={
+                                            namespacesReorderMode
+                                                ? 'secondary'
+                                                : 'outline'
+                                        }
+                                        size="sm"
+                                        onClick={() =>
+                                            setNamespacesReorderMode((v) => !v)
+                                        }
+                                    >
+                                        {namespacesReorderMode ? (
+                                            <>
+                                                <Check className="size-4" />
+                                                Done
+                                            </>
+                                        ) : (
+                                            <>
+                                                <ArrowUpDown className="size-4" />
+                                                Reorder
+                                            </>
+                                        )}
+                                    </Button>
+                                </div>
+
+                                <div className="overflow-x-auto">
+                                    <table className="w-full text-sm">
+                                        <tbody>
+                                            <SortableContext
+                                                items={children.map(
+                                                    (c) => c.id,
+                                                )}
+                                                strategy={
+                                                    verticalListSortingStrategy
+                                                }
+                                            >
+                                                {children.map((child) => (
+                                                    <SortableChildRow
+                                                        key={child.id}
+                                                        child={child}
+                                                        reorderMode={
+                                                            namespacesReorderMode
+                                                        }
+                                                    />
+                                                ))}
+                                            </SortableContext>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </Card>
                         </DndContext>
                     </div>
                 )}
 
                 {posts.length === 0 ? (
-                    <div className="rounded-xl border border-dashed p-12 text-center">
-                        <p className="text-muted-foreground">
-                            No posts in this namespace yet.
-                        </p>
-                        <div className="mt-4 flex items-center justify-center gap-2">
-                            <Button variant="outline" asChild>
-                                <Link href={childNamespaceCreateUrl}>
-                                    <FolderPlus className="size-4" />
-                                    Create a child namespace
-                                </Link>
-                            </Button>
-                            <Button asChild>
-                                <Link href={create.url(namespace.id)}>
-                                    <FilePlus2 className="size-4" />
-                                    Create your first post
-                                </Link>
-                            </Button>
-                        </div>
-                    </div>
-                ) : (
-                    <div className="space-y-2">
-                        <div className="flex items-center justify-between">
-                            <div className="space-y-1">
-                                <h2 className="text-sm font-medium text-muted-foreground">
-                                    Posts
-                                </h2>
-                                {!postsReorderMode && (
-                                    <p className="text-xs text-muted-foreground">
-                                        {selectedPostIds.length} selected
-                                    </p>
-                                )}
-                            </div>
-                            <div className="flex items-center gap-2">
-                                {!postsReorderMode && (
-                                    <Dialog
-                                        open={isDeleteDialogOpen}
-                                        onOpenChange={setIsDeleteDialogOpen}
-                                    >
-                                        <DialogTrigger asChild>
-                                            <Button
-                                                variant="destructive"
-                                                size="sm"
-                                                disabled={
-                                                    selectedPostIds.length === 0
-                                                }
-                                            >
-                                                <Trash2 className="size-4" />
-                                                Delete Selected
-                                            </Button>
-                                        </DialogTrigger>
-                                        <DialogContent>
-                                            <DialogTitle>
-                                                Delete selected posts?
-                                            </DialogTitle>
-                                            <DialogDescription className="space-y-3">
-                                                <p>
-                                                    This will permanently delete
-                                                    the selected posts.
-                                                </p>
-                                                <p>
-                                                    {selectedPostIds.length}{' '}
-                                                    post
-                                                    {selectedPostIds.length ===
-                                                    1
-                                                        ? ''
-                                                        : 's'}{' '}
-                                                    will be deleted.
-                                                </p>
-                                            </DialogDescription>
-                                            <Form
-                                                action={delete_posts_url}
-                                                method="post"
-                                                onSuccess={() => {
-                                                    setIsDeleteDialogOpen(
-                                                        false,
-                                                    );
-                                                    setSelectedPostIds([]);
-                                                }}
-                                            >
-                                                {({ processing }) => (
-                                                    <div className="space-y-4">
-                                                        {selectedPostIds.map(
-                                                            (id) => (
-                                                                <input
-                                                                    key={id}
-                                                                    type="hidden"
-                                                                    name="ids[]"
-                                                                    value={id}
-                                                                />
-                                                            ),
-                                                        )}
-                                                        <DialogFooter className="gap-2">
-                                                            <DialogClose
-                                                                asChild
-                                                            >
-                                                                <Button variant="secondary">
-                                                                    Cancel
-                                                                </Button>
-                                                            </DialogClose>
-                                                            <Button
-                                                                variant="destructive"
-                                                                disabled={
-                                                                    processing
-                                                                }
-                                                                asChild
-                                                            >
-                                                                <button type="submit">
-                                                                    Delete
-                                                                    Selected
-                                                                </button>
-                                                            </Button>
-                                                        </DialogFooter>
-                                                    </div>
-                                                )}
-                                            </Form>
-                                        </DialogContent>
-                                    </Dialog>
-                                )}
-                                <Button
-                                    variant={
-                                        postsReorderMode
-                                            ? 'secondary'
-                                            : 'outline'
-                                    }
-                                    size="sm"
-                                    onClick={() =>
-                                        setPostsReorderMode((value) => {
-                                            const next = !value;
-
-                                            if (next) {
-                                                setSelectedPostIds([]);
-                                            }
-
-                                            return next;
-                                        })
-                                    }
-                                >
-                                    {postsReorderMode ? (
-                                        <>
-                                            <Check className="size-4" />
-                                            Done
-                                        </>
-                                    ) : (
-                                        <>
-                                            <ArrowUpDown className="size-4" />
-                                            Reorder
-                                        </>
-                                    )}
+                    <Card className="border-dashed py-0 shadow-none">
+                        <CardContent className="flex flex-col items-center px-6 py-14 text-center">
+                            <h2 className="text-xl font-semibold">
+                                No posts in this namespace yet
+                            </h2>
+                            <p className="mt-2 max-w-md text-sm leading-6 text-muted-foreground">
+                                Start with a post or branch this area into child
+                                namespaces if the content needs another layer.
+                            </p>
+                            <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+                                <Button variant="outline" asChild>
+                                    <Link href={childNamespaceCreateUrl}>
+                                        <FolderPlus className="size-4" />
+                                        Create a child namespace
+                                    </Link>
+                                </Button>
+                                <Button asChild>
+                                    <Link href={create.url(namespace.id)}>
+                                        <FilePlus2 className="size-4" />
+                                        Create your first post
+                                    </Link>
                                 </Button>
                             </div>
-                        </div>
+                        </CardContent>
+                    </Card>
+                ) : (
+                    <div className="space-y-3">
                         <DndContext
                             sensors={sensors}
                             collisionDetection={closestCenter}
                             onDragEnd={handlePostDragEnd}
                         >
-                            <div className="rounded-xl border">
-                                <table className="w-full text-sm">
-                                    <thead>
-                                        <tr className="border-b bg-muted/50">
-                                            <th className="w-8 px-2 py-3">
-                                                {!postsReorderMode && (
-                                                    <Checkbox
-                                                        checked={
-                                                            allPostsSelected
+                            <Card className="gap-0 py-0 shadow-sm">
+                                <div className="flex flex-col gap-3 border-b px-5 py-4 sm:flex-row sm:items-start sm:justify-between">
+                                    <div className="space-y-1">
+                                        <h2 className="text-lg font-semibold">
+                                            Posts
+                                        </h2>
+                                        <p className="text-sm text-muted-foreground">
+                                            {postsReorderMode
+                                                ? 'Drag posts to set the manual order inside this namespace.'
+                                                : `${selectedPostIds.length} selected. Open a post to edit it, or use bulk delete for cleanup.`}
+                                        </p>
+                                    </div>
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        {!postsReorderMode && (
+                                            <Dialog
+                                                open={isDeleteDialogOpen}
+                                                onOpenChange={
+                                                    setIsDeleteDialogOpen
+                                                }
+                                            >
+                                                <DialogTrigger asChild>
+                                                    <Button
+                                                        variant="destructive"
+                                                        size="sm"
+                                                        disabled={
+                                                            selectedPostIds.length ===
+                                                            0
                                                         }
-                                                        onCheckedChange={(
-                                                            checked,
-                                                        ) =>
-                                                            toggleAllPosts(
-                                                                Boolean(
-                                                                    checked,
-                                                                ),
-                                                            )
+                                                    >
+                                                        <Trash2 className="size-4" />
+                                                        Delete Selected
+                                                    </Button>
+                                                </DialogTrigger>
+                                                <DialogContent>
+                                                    <DialogTitle>
+                                                        Delete selected posts?
+                                                    </DialogTitle>
+                                                    <DialogDescription className="space-y-3">
+                                                        <p>
+                                                            This will
+                                                            permanently delete
+                                                            the selected posts.
+                                                        </p>
+                                                        <p>
+                                                            {
+                                                                selectedPostIds.length
+                                                            }{' '}
+                                                            post
+                                                            {selectedPostIds.length ===
+                                                            1
+                                                                ? ''
+                                                                : 's'}{' '}
+                                                            will be deleted.
+                                                        </p>
+                                                    </DialogDescription>
+                                                    <Form
+                                                        action={
+                                                            delete_posts_url
                                                         }
-                                                        aria-label="Select all posts"
-                                                    />
-                                                )}
-                                            </th>
-                                            <th className="px-4 py-3 text-left font-medium">
-                                                Title
-                                            </th>
-                                            <th className="px-4 py-3 text-left font-medium">
-                                                Slug
-                                            </th>
-                                            <th className="px-4 py-3 text-left font-medium">
-                                                Status
-                                            </th>
-                                            <th className="px-4 py-3 text-left font-medium">
-                                                Created
-                                            </th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <SortableContext
-                                            items={posts.map((p) => p.id)}
-                                            strategy={
-                                                verticalListSortingStrategy
+                                                        method="post"
+                                                        onSuccess={() => {
+                                                            setIsDeleteDialogOpen(
+                                                                false,
+                                                            );
+                                                            setSelectedPostIds(
+                                                                [],
+                                                            );
+                                                        }}
+                                                    >
+                                                        {({ processing }) => (
+                                                            <div className="space-y-4">
+                                                                {selectedPostIds.map(
+                                                                    (id) => (
+                                                                        <input
+                                                                            key={
+                                                                                id
+                                                                            }
+                                                                            type="hidden"
+                                                                            name="ids[]"
+                                                                            value={
+                                                                                id
+                                                                            }
+                                                                        />
+                                                                    ),
+                                                                )}
+                                                                <DialogFooter className="gap-2">
+                                                                    <DialogClose
+                                                                        asChild
+                                                                    >
+                                                                        <Button variant="secondary">
+                                                                            Cancel
+                                                                        </Button>
+                                                                    </DialogClose>
+                                                                    <Button
+                                                                        variant="destructive"
+                                                                        disabled={
+                                                                            processing
+                                                                        }
+                                                                        asChild
+                                                                    >
+                                                                        <button type="submit">
+                                                                            Delete
+                                                                            Selected
+                                                                        </button>
+                                                                    </Button>
+                                                                </DialogFooter>
+                                                            </div>
+                                                        )}
+                                                    </Form>
+                                                </DialogContent>
+                                            </Dialog>
+                                        )}
+                                        <Button
+                                            variant={
+                                                postsReorderMode
+                                                    ? 'secondary'
+                                                    : 'outline'
+                                            }
+                                            size="sm"
+                                            onClick={() =>
+                                                setPostsReorderMode((value) => {
+                                                    const next = !value;
+
+                                                    if (next) {
+                                                        setSelectedPostIds([]);
+                                                    }
+
+                                                    return next;
+                                                })
                                             }
                                         >
-                                            {posts.map((post) => (
-                                                <SortablePostRow
-                                                    key={post.id}
-                                                    post={post}
-                                                    namespaceFullPath={
-                                                        namespace.full_path
-                                                    }
-                                                    reorderMode={
-                                                        postsReorderMode
-                                                    }
-                                                    selected={selectedPostIds.includes(
-                                                        post.id,
+                                            {postsReorderMode ? (
+                                                <>
+                                                    <Check className="size-4" />
+                                                    Done
+                                                </>
+                                            ) : (
+                                                <>
+                                                    <ArrowUpDown className="size-4" />
+                                                    Reorder
+                                                </>
+                                            )}
+                                        </Button>
+                                    </div>
+                                </div>
+
+                                <div className="overflow-x-auto">
+                                    <table className="w-full text-sm">
+                                        <thead>
+                                            <tr className="border-b bg-muted/50">
+                                                <th className="w-8 px-2 py-3">
+                                                    {!postsReorderMode && (
+                                                        <Checkbox
+                                                            checked={
+                                                                allPostsSelected
+                                                            }
+                                                            onCheckedChange={(
+                                                                checked,
+                                                            ) =>
+                                                                toggleAllPosts(
+                                                                    Boolean(
+                                                                        checked,
+                                                                    ),
+                                                                )
+                                                            }
+                                                            aria-label="Select all posts"
+                                                        />
                                                     )}
-                                                    onSelectedChange={(
-                                                        checked,
-                                                    ) =>
-                                                        togglePostSelection(
+                                                </th>
+                                                <th className="px-4 py-3 text-left font-medium">
+                                                    Title
+                                                </th>
+                                                <th className="px-4 py-3 text-left font-medium">
+                                                    Slug
+                                                </th>
+                                                <th className="px-4 py-3 text-left font-medium">
+                                                    Status
+                                                </th>
+                                                <th className="px-4 py-3 text-left font-medium">
+                                                    Created
+                                                </th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <SortableContext
+                                                items={posts.map((p) => p.id)}
+                                                strategy={
+                                                    verticalListSortingStrategy
+                                                }
+                                            >
+                                                {posts.map((post) => (
+                                                    <SortablePostRow
+                                                        key={post.id}
+                                                        post={post}
+                                                        namespaceFullPath={
+                                                            namespace.full_path
+                                                        }
+                                                        reorderMode={
+                                                            postsReorderMode
+                                                        }
+                                                        selected={selectedPostIds.includes(
                                                             post.id,
+                                                        )}
+                                                        onSelectedChange={(
                                                             checked,
-                                                        )
-                                                    }
-                                                />
-                                            ))}
-                                        </SortableContext>
-                                    </tbody>
-                                </table>
-                            </div>
+                                                        ) =>
+                                                            togglePostSelection(
+                                                                post.id,
+                                                                checked,
+                                                            )
+                                                        }
+                                                    />
+                                                ))}
+                                            </SortableContext>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </Card>
                         </DndContext>
                     </div>
                 )}

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -999,6 +999,83 @@ test('admin namespace page shows backup count and backup management button when 
     }
 });
 
+test('admin namespaces index shows the management summary header', function () {
+    $user = User::factory()->create([
+        'email' => 'test@example.com',
+    ]);
+
+    $root = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+        'parent_id' => null,
+    ]);
+
+    PostNamespace::factory()->create([
+        'slug' => 'laravel',
+        'name' => 'Laravel',
+        'parent_id' => $root->id,
+        'is_published' => false,
+    ]);
+
+    Post::factory()->for($root, 'namespace')->create([
+        'slug' => 'intro',
+        'title' => 'Intro',
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.posts.index', absolute: false))->resize(1440, 900);
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertSee('Admin content structure')
+        ->assertSee('Namespaces')
+        ->assertSee('Root namespaces')
+        ->assertSee('All namespaces')
+        ->assertSee('Posts in tree')
+        ->assertSee('Needs attention')
+        ->assertSee('Restore Zip')
+        ->assertSee('New Namespace');
+});
+
+test('admin namespace page shows unscheduled published posts as published', function () {
+    $user = User::factory()->create([
+        'email' => 'test@example.com',
+    ]);
+
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+    ]);
+
+    Post::factory()->for($namespace, 'namespace')->create([
+        'slug' => 'published-post',
+        'title' => 'Published Post',
+        'is_draft' => false,
+        'published_at' => null,
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.posts.namespace', $namespace, absolute: false))->resize(1440, 900);
+
+    $page->assertNoJavaScriptErrors();
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const row = [...document.querySelectorAll('tbody tr')].find((element) =>
+                element.textContent?.includes('Published Post')
+            );
+
+            if (! row) {
+                return null;
+            }
+
+            return row.querySelectorAll('td')[3]?.textContent?.replace(/\s+/g, ' ').trim() ?? null;
+        })()
+    JS))->toBe('Published');
+});
+
 test('admin post edit warns before leaving with unsaved changes', function () {
     $user = User::factory()->create([
         'email' => 'test@example.com',


### PR DESCRIPTION
## Summary\n- fix the namespace page status badge so unscheduled published posts render as Published\n- keep the refreshed namespace management UI and add browser coverage for the new admin surfaces\n- cover the root namespace management summary header in smoke tests\n\n## Testing\n- vendor/bin/sail bin pint --dirty --format agent\n- rm -f public/hot\n- vendor/bin/sail npm run build\n- vendor/bin/sail npm run types:check\n- vendor/bin/sail artisan test --compact tests/Browser/SmokeTest.php --filter='admin namespaces index shows the management summary header|admin namespace page shows the namespace description in the manage header|admin namespace page shows a cover image thumbnail in the manage header|admin namespace page shows backup count and backup management button when backups exist|admin namespace page shows unscheduled published posts as published|admin post edit warns before leaving with unsaved changes|admin post edit can collapse the metadata panel'