### PR TITLE
Add post referer backup support

### DIFF
--- a/app/Console/Commands/NamespaceBackupCommand.php
+++ b/app/Console/Commands/NamespaceBackupCommand.php
@@ -95,6 +95,7 @@ class NamespaceBackupCommand extends Command
                 'slug' => $post->slug,
                 'full_path' => $post->full_path,
                 'page_views' => $post->page_views,
+                'http_referer' => $post->http_referer,
                 'is_draft' => $post->is_draft,
                 'published_at' => $post->published_at?->toIso8601String(),
                 'reference_title' => $post->reference_title,

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -375,12 +375,31 @@ class PostController extends Controller
                     'published_at',
                     'created_at',
                     'page_views',
+                    'http_referer',
                     'reference_title',
                     'reference_url',
                 ]),
+                'http_referer_url' => $this->safeExternalUrl($post->http_referer),
                 'tags' => $post->tags->pluck('name')->values()->all(),
             ],
         ]);
+    }
+
+    private function safeExternalUrl(?string $url): ?string
+    {
+        $candidate = trim((string) $url);
+
+        if ($candidate === '' || filter_var($candidate, FILTER_VALIDATE_URL) === false) {
+            return null;
+        }
+
+        $scheme = parse_url($candidate, PHP_URL_SCHEME);
+
+        if (! is_string($scheme) || ! in_array(strtolower($scheme), ['http', 'https'], true)) {
+            return null;
+        }
+
+        return $candidate;
     }
 
     private function rootNamespace(PostNamespace $namespace): PostNamespace

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -183,7 +183,16 @@ class PostController extends Controller
             && ! $this->isBotRequest($request)
             && ! $request->hasCookie($this->pageViewCookieName($post))
         ) {
-            $post->increment('page_views');
+            $referer = $this->resolveHttpReferer($request);
+
+            if ($referer !== null) {
+                $post->increment('page_views', 1, [
+                    'http_referer' => $referer,
+                ]);
+            } else {
+                $post->increment('page_views');
+            }
+
             $pageViews++;
 
             Cookie::queue($this->pageViewCookieName($post), '1', self::PAGE_VIEW_COOKIE_TTL_MINUTES);
@@ -211,6 +220,16 @@ class PostController extends Controller
     private function pageViewCookieName(Post $post): string
     {
         return 'post_viewed_'.$post->id;
+    }
+
+    private function resolveHttpReferer(Request $request): ?string
+    {
+        $referer = Str::of((string) $request->headers->get('referer', ''))
+            ->trim()
+            ->substr(0, 2048)
+            ->value();
+
+        return $referer === '' ? null : $referer;
     }
 
     private function isBotRequest(Request $request): bool

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -23,6 +23,7 @@ class Post extends Model
         'full_path',
         'content',
         'page_views',
+        'http_referer',
         'user_id',
         'is_draft',
         'published_at',

--- a/app/Support/NamespaceRestoreArchive.php
+++ b/app/Support/NamespaceRestoreArchive.php
@@ -273,6 +273,7 @@ class NamespaceRestoreArchive
             $post->slug = (string) $frontmatter['slug'];
             $post->content = $body;
             $post->page_views = (int) ($frontmatter['page_views'] ?? 0);
+            $post->http_referer = $frontmatter['http_referer'] ?? null;
             $post->is_draft = (bool) ($frontmatter['is_draft'] ?? false);
             $post->published_at = $frontmatter['published_at'] ?? null;
             $post->reference_title = $frontmatter['reference_title'] ?? null;

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -24,6 +24,7 @@ class PostFactory extends Factory
             'slug' => Str::slug($title),
             'content' => implode("\n\n", fake()->paragraphs(3)),
             'page_views' => 0,
+            'http_referer' => null,
             'is_draft' => false,
             'published_at' => now(),
         ];

--- a/database/migrations/2026_04_26_043539_add_http_referer_to_posts_table.php
+++ b/database/migrations/2026_04_26_043539_add_http_referer_to_posts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('http_referer', 2048)->nullable()->after('page_views');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('http_referer');
+        });
+    }
+};

--- a/database/seeders/SyntaxSeeder.php
+++ b/database/seeders/SyntaxSeeder.php
@@ -1516,13 +1516,5 @@ MD),
                 'published_at' => now(),
             ]);
 
-        $metaNamespace = PostNamespace::updateOrCreate(
-            ['slug' => 'meta'],
-            [
-                'name' => 'Meta',
-                'description' => 'Internal notes about Thinkstream architecture, implementation status, and operational decisions.',
-                'post_order' => [],
-            ],
-        );
     }
 }

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -123,6 +123,8 @@ type Post = {
     full_path: string;
     content: string;
     page_views: number;
+    http_referer: string | null;
+    http_referer_url: string | null;
     is_draft: boolean;
     published_at: string | null;
     created_at: string;
@@ -536,6 +538,30 @@ export default function Show({
                                         <span className="max-w-32 truncate font-mono text-xs text-muted-foreground">
                                             /{post.full_path}
                                         </span>
+                                    </div>
+                                    <div className="flex items-center justify-between gap-3 px-4 py-3">
+                                        <span className="text-sm text-muted-foreground">
+                                            Referer
+                                        </span>
+                                        {post.http_referer &&
+                                        post.http_referer_url ? (
+                                            <a
+                                                href={post.http_referer_url}
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                className="max-w-32 truncate text-right text-xs text-muted-foreground underline-offset-4 hover:underline"
+                                            >
+                                                {post.http_referer}
+                                            </a>
+                                        ) : post.http_referer ? (
+                                            <span className="max-w-32 truncate text-right text-xs text-muted-foreground">
+                                                {post.http_referer}
+                                            </span>
+                                        ) : (
+                                            <span className="text-sm font-medium">
+                                                -
+                                            </span>
+                                        )}
                                     </div>
                                 </div>
                             </div>

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -51,6 +51,10 @@ function addAdminNamespaceBackupTreeToZip(ZipArchive $zip, array $tree, string $
             $frontmatter['page_views'] = $post['page_views'];
         }
 
+        if (array_key_exists('http_referer', $post)) {
+            $frontmatter['http_referer'] = $post['http_referer'];
+        }
+
         if (array_key_exists('tags', $post)) {
             $frontmatter['tags'] = $post['tags'];
         }
@@ -1153,6 +1157,7 @@ test('authenticated users can view a post details page', function () {
         'title' => 'Release Notes',
         'slug' => 'release-notes',
         'page_views' => 27,
+        'http_referer' => 'https://example.com/changelog',
         'is_draft' => false,
         'reference_title' => 'Release Notes Source',
         'reference_url' => 'https://example.com/release-notes',
@@ -1168,8 +1173,28 @@ test('authenticated users can view a post details page', function () {
             ->where('post.slug', 'release-notes')
             ->where('post.title', 'Release Notes')
             ->where('post.page_views', 27)
+            ->where('post.http_referer', 'https://example.com/changelog')
+            ->where('post.http_referer_url', 'https://example.com/changelog')
             ->where('post.reference_title', 'Release Notes Source')
             ->where('post.reference_url', 'https://example.com/release-notes')
+        );
+});
+
+test('admin post details page does not expose unsafe referer links', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'http_referer' => 'javascript:alert(1)',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.show', [$namespace, $post]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/show')
+            ->where('post.http_referer', 'javascript:alert(1)')
+            ->where('post.http_referer_url', null)
         );
 });
 

--- a/tests/Feature/NamespaceBackupCommandTest.php
+++ b/tests/Feature/NamespaceBackupCommandTest.php
@@ -52,6 +52,10 @@ function addNamespaceBackupTreeToZip(ZipArchive $zip, array $tree, string $prefi
             $frontmatter['page_views'] = $post['page_views'];
         }
 
+        if (array_key_exists('http_referer', $post)) {
+            $frontmatter['http_referer'] = $post['http_referer'];
+        }
+
         if (array_key_exists('reference_title', $post)) {
             $frontmatter['reference_title'] = $post['reference_title'];
         }
@@ -105,6 +109,7 @@ test('namespace backup command exports namespace metadata and markdown posts', f
         'slug' => 'routing',
         'full_path' => 'guides/routing',
         'page_views' => 42,
+        'http_referer' => 'https://example.com/search?q=routing',
         'reference_title' => 'Laravel Routing Docs',
         'reference_url' => 'https://laravel.com/docs/routing',
         'content' => "# Routing\n\n![Diagram](/images/posts/123/diagram.png)\n\nBackup me.",
@@ -142,6 +147,8 @@ test('namespace backup command exports namespace metadata and markdown posts', f
         ->toContain('slug: routing')
         ->toContain('full_path: guides/routing')
         ->toContain('page_views: 42')
+        ->toContain('http_referer:')
+        ->toContain('https://example.com/search?q=routing')
         ->toContain("reference_title: 'Laravel Routing Docs'")
         ->toContain("reference_url: 'https://laravel.com/docs/routing'")
         ->toContain('![Diagram](/images/posts/123/diagram.png)')
@@ -168,6 +175,7 @@ test('namespace restore command imports a namespace backup zip', function () {
                 'title' => 'Laravel AI SDK',
                 'slug' => 'laravel-ai-sdk',
                 'page_views' => 11,
+                'http_referer' => 'https://example.com/docs/ai',
                 'reference_title' => 'Laravel AI SDK Docs',
                 'reference_url' => 'https://laravel.com/docs/ai',
                 'content' => "# Laravel AI SDK\n\n![Diagram](/images/posts/legacy-id/ai-sdk.png)\n\nIntro.",
@@ -210,9 +218,11 @@ test('namespace restore command imports a namespace backup zip', function () {
                 'upgrade-12-to-13',
             ])
             ->and($posts->firstWhere('slug', 'laravel-ai-sdk')?->page_views)->toBe(11)
+            ->and($posts->firstWhere('slug', 'laravel-ai-sdk')?->http_referer)->toBe('https://example.com/docs/ai')
             ->and($posts->firstWhere('slug', 'laravel-ai-sdk')?->reference_title)->toBe('Laravel AI SDK Docs')
             ->and($posts->firstWhere('slug', 'laravel-ai-sdk')?->reference_url)->toBe('https://laravel.com/docs/ai')
             ->and($posts->firstWhere('slug', 'upgrade-12-to-13')?->page_views)->toBe(0)
+            ->and($posts->firstWhere('slug', 'upgrade-12-to-13')?->http_referer)->toBeNull()
             ->and($posts->pluck('user_id')->unique()->all())->toBe([$user->id]);
 
         Storage::disk('public')->assertExists('namespaces/laravel-13-cover.jpg');
@@ -326,7 +336,8 @@ test('namespace restore command defaults page views to zero for older backups', 
 
         expect($post)->not->toBeNull()
             ->and($post->user_id)->toBe($user->id)
-            ->and($post->page_views)->toBe(0);
+            ->and($post->page_views)->toBe(0)
+            ->and($post->http_referer)->toBeNull();
     } finally {
         File::delete($zipPath);
     }

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -210,7 +210,9 @@ test('published post increments page views and queues a tracking cookie', functi
         'page_views' => 4,
     ]);
 
-    $response = $this->get(route('posts.path', ['path' => $post->full_path]));
+    $response = $this
+        ->withHeader('Referer', 'https://example.com/search?q=laravel')
+        ->get(route('posts.path', ['path' => $post->full_path]));
 
     $response->assertSuccessful()
         ->assertCookie('post_viewed_'.$post->id, '1')
@@ -220,7 +222,8 @@ test('published post increments page views and queues a tracking cookie', functi
             ->where('post.page_views', 5)
         );
 
-    expect($post->fresh()->page_views)->toBe(5);
+    expect($post->fresh()->page_views)->toBe(5)
+        ->and($post->fresh()->http_referer)->toBe('https://example.com/search?q=laravel');
 });
 
 test('published post does not increment page views again while tracking cookie exists', function () {
@@ -243,6 +246,23 @@ test('published post does not increment page views again while tracking cookie e
         );
 
     expect($post->fresh()->page_views)->toBe(9);
+});
+
+test('published post keeps the previous referer when the request has no referer header', function () {
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'is_published' => true,
+    ]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'slug' => 'routing',
+        'page_views' => 1,
+        'http_referer' => 'https://old.example.com/article',
+    ]);
+
+    $this->get(route('posts.path', ['path' => $post->full_path]))->assertSuccessful();
+
+    expect($post->fresh()->page_views)->toBe(2)
+        ->and($post->fresh()->http_referer)->toBe('https://old.example.com/article');
 });
 
 test('published post does not increment page views for bot user agents', function () {

--- a/tests/Feature/SyntaxSeederTest.php
+++ b/tests/Feature/SyntaxSeederTest.php
@@ -122,22 +122,12 @@ test('routing check seeder creates wildcard routing lookalike namespaces', funct
     expect($administratorPost->content)->toContain('/admin/*');
 });
 
-test('syntax seeder keeps the meta namespace without the content url handoff article', function () {
+test('syntax seeder does not create the meta namespace', function () {
     $this->seed(SyntaxSeeder::class);
 
     $namespace = PostNamespace::query()
         ->where('slug', 'meta')
         ->first();
 
-    expect($namespace)->not->toBeNull();
-    expect($namespace->name)->toBe('Meta');
-    expect($namespace->description)->toBe('Internal notes about Thinkstream architecture, implementation status, and operational decisions.');
-    expect($namespace->post_order)->toBe([]);
-
-    $post = Post::query()
-        ->where('namespace_id', $namespace->id)
-        ->where('slug', 'content-url-unification-handoff')
-        ->first();
-
-    expect($post)->toBeNull();
+    expect($namespace)->toBeNull();
 });


### PR DESCRIPTION
## Summary
- persist and restore post http referers through backup and restore flows
- surface referer data safely in the admin post detail view
- stop creating the meta syntax namespace and add focused regression coverage