### PR TITLE
Fix markdown port links and namespace ordering

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -86,7 +86,7 @@ class PostController extends Controller
 
     public function namespaceIndex(PostNamespace $namespace, NamespaceBackupIndex $backupIndex): Response
     {
-        $posts = $namespace->sortPosts($namespace->posts()->with('tags')->latest()->get([
+        $posts = $namespace->sortPosts($namespace->posts()->with('tags')->orderBy('published_at')->orderBy('id')->get([
             'id',
             'title',
             'slug',

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -43,6 +43,7 @@ import { remarkTabsDirective } from '@/lib/remark-tabs-directive';
 import { remarkTooltipDirective } from '@/lib/remark-tooltip-directive';
 import { remarkTreeDirective } from '@/lib/remark-tree-directive';
 import { remarkUpdateDirective } from '@/lib/remark-update-directive';
+import { remarkFixUrlPorts } from '@/lib/remark-fix-url-ports';
 import { remarkZennDirective } from '@/lib/remark-zenn-directive';
 import { cn } from '@/lib/utils';
 
@@ -259,6 +260,7 @@ export default function MarkdownContent({
                     [remarkGfm, { singleTilde: false }],
                     remarkCodeMeta,
                     remarkDirective,
+                    remarkFixUrlPorts,
                     remarkZennDirective,
                     remarkTabsDirective,
                     remarkCardDirective,

--- a/resources/js/lib/remark-fix-url-ports.ts
+++ b/resources/js/lib/remark-fix-url-ports.ts
@@ -12,28 +12,24 @@ import { visit } from 'unist-util-visit';
 
 export function remarkFixUrlPorts() {
     return (tree: Root) => {
-        visit(
-            tree,
-            'textDirective',
-            (node: TextDirective, index, parent) => {
-                if (
-                    parent === undefined ||
-                    index === undefined ||
-                    !/^\d+$/.test(node.name) ||
-                    node.children.length !== 0
-                ) {
-                    return;
-                }
+        visit(tree, 'textDirective', (node: TextDirective, index, parent) => {
+            if (
+                parent === undefined ||
+                index === undefined ||
+                !/^\d+$/.test(node.name) ||
+                node.children.length !== 0
+            ) {
+                return;
+            }
 
-                const text: Text = {
-                    type: 'text',
-                    value: ':' + node.name,
-                };
+            const text: Text = {
+                type: 'text',
+                value: ':' + node.name,
+            };
 
-                parent.children.splice(index, 1, text);
+            parent.children.splice(index, 1, text);
 
-                return index;
-            },
-        );
+            return index;
+        });
     };
 }

--- a/resources/js/lib/remark-fix-url-ports.ts
+++ b/resources/js/lib/remark-fix-url-ports.ts
@@ -1,0 +1,39 @@
+/**
+ * Reverts digit-only textDirective nodes back to plain text.
+ *
+ * remark-directive does not require directive names to start with a letter,
+ * so `:8000` inside a link text (e.g. `[http://localhost:8000](...)`) is
+ * incorrectly parsed as a textDirective named "8000". This plugin detects
+ * that case and restores the colon + digits as a plain text node.
+ */
+import type { Root, Text } from 'mdast';
+import type { TextDirective } from 'mdast-util-directive';
+import { visit } from 'unist-util-visit';
+
+export function remarkFixUrlPorts() {
+    return (tree: Root) => {
+        visit(
+            tree,
+            'textDirective',
+            (node: TextDirective, index, parent) => {
+                if (
+                    parent === undefined ||
+                    index === undefined ||
+                    !/^\d+$/.test(node.name) ||
+                    node.children.length !== 0
+                ) {
+                    return;
+                }
+
+                const text: Text = {
+                    type: 'text',
+                    value: ':' + node.name,
+                };
+
+                parent.children.splice(index, 1, text);
+
+                return index;
+            },
+        );
+    };
+}

--- a/tests-node/markdown/remark-fix-url-ports.test.ts
+++ b/tests-node/markdown/remark-fix-url-ports.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { remarkFixUrlPorts } from '../../resources/js/lib/remark-fix-url-ports.ts';
+
+test('remarkFixUrlPorts restores port-like text directives to plain text', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'paragraph',
+                children: [
+                    { type: 'text', value: 'http://localhost' },
+                    { type: 'textDirective', name: '8000', attributes: {}, children: [] },
+                    { type: 'text', value: '/docs' },
+                ],
+            },
+        ],
+    };
+
+    remarkFixUrlPorts()(tree as never);
+
+    assert.deepEqual(tree.children[0], {
+        type: 'paragraph',
+        children: [
+            { type: 'text', value: 'http://localhost' },
+            { type: 'text', value: ':8000' },
+            { type: 'text', value: '/docs' },
+        ],
+    });
+});
+
+test('remarkFixUrlPorts leaves non-port directives unchanged', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'paragraph',
+                children: [
+                    { type: 'textDirective', name: 'note', attributes: {}, children: [] },
+                    { type: 'textDirective', name: '8080', attributes: {}, children: [{ type: 'text', value: 'x' }] },
+                ],
+            },
+        ],
+    };
+
+    remarkFixUrlPorts()(tree as never);
+
+    assert.deepEqual(tree.children[0], {
+        type: 'paragraph',
+        children: [
+            { type: 'textDirective', name: 'note', attributes: {}, children: [] },
+            { type: 'textDirective', name: '8080', attributes: {}, children: [{ type: 'text', value: 'x' }] },
+        ],
+    });
+});

--- a/tests/Browser/ZennMarkdownRenderingTest.php
+++ b/tests/Browser/ZennMarkdownRenderingTest.php
@@ -157,6 +157,22 @@ MARKDOWN,
 
 });
 
+test('link text containing a URL with port renders the full URL including port', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => '[http://localhost:8000](http://localhost:8000) です',
+    ]);
+
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
+
+    $linkText = $page->script(<<<'JS'
+        (() => document.querySelector('.prose a')?.textContent)()
+    JS);
+
+    $page->assertNoJavaScriptErrors();
+    expect($linkText)->toBe('http://localhost:8000');
+});
+
 test('@[github](URL) directive renders as github embed', function () {
     $namespace = PostNamespace::factory()->create(['is_published' => true]);
     $post = Post::factory()->for($namespace, 'namespace')->published()->create([

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -307,23 +307,23 @@ test('namespace post list includes child namespaces', function () {
         );
 });
 
-test('namespace post list defaults to latest posts when no custom order exists', function () {
+test('namespace post list orders by published_at ascending when no custom order exists', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create();
-    $olderPost = Post::factory()->for($user)->create([
+    $laterPost = Post::factory()->for($user)->create([
         'namespace_id' => $namespace->id,
-        'created_at' => now()->subDay(),
+        'published_at' => now(),
     ]);
-    $newerPost = Post::factory()->for($user)->create([
+    $earlierPost = Post::factory()->for($user)->create([
         'namespace_id' => $namespace->id,
-        'created_at' => now(),
+        'published_at' => now()->subDay(),
     ]);
 
     $this->actingAs($user)
         ->get(route('admin.posts.namespace', $namespace))
         ->assertInertia(fn ($page) => $page
-            ->where('posts.0.id', $newerPost->id)
-            ->where('posts.1.id', $olderPost->id)
+            ->where('posts.0.id', $earlierPost->id)
+            ->where('posts.1.id', $laterPost->id)
         );
 });
 

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -148,6 +148,36 @@ test('published namespace sorts child namespaces by post order', function () {
         );
 });
 
+test('navigation sorts posts by published_at ascending when no custom order exists', function () {
+    $namespace = PostNamespace::factory()->create([
+        'is_published' => true,
+        'slug' => 'guides',
+        'full_path' => 'guides',
+    ]);
+    $user = User::factory()->create();
+    $laterPost = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'later-post',
+        'full_path' => 'guides/later-post',
+        'is_draft' => false,
+        'published_at' => now(),
+    ]);
+    $earlierPost = Post::factory()->for($user)->create([
+        'namespace_id' => $namespace->id,
+        'slug' => 'earlier-post',
+        'full_path' => 'guides/earlier-post',
+        'is_draft' => false,
+        'published_at' => now()->subDay(),
+    ]);
+
+    $this->get(route('posts.path', ['path' => $namespace->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->where('navRoot.posts.0.full_path', $earlierPost->full_path)
+            ->where('navRoot.posts.1.full_path', $laterPost->full_path)
+        );
+});
+
 test('unpublished ancestor returns 404 on post show page', function () {
     $root = PostNamespace::factory()->create([
         'slug' => 'guides',


### PR DESCRIPTION
## Summary
- preserve port numbers in markdown link text when remark-directive parses `:8000` as a directive
- align admin namespace post ordering with the public controller
- add focused browser, feature, and node markdown coverage

## Testing
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build
- vendor/bin/sail artisan test --compact tests/Feature/Admin/PostControllerTest.php tests/Feature/PostControllerTest.php
- vendor/bin/sail artisan test --compact tests/Browser/ZennMarkdownRenderingTest.php --filter="link text containing a URL with port renders the full URL including port"