### PR TITLE
Add AI-generated namespace cover image prompts

### DIFF
--- a/app/Ai/Agents/CoverImagePromptAgent.php
+++ b/app/Ai/Agents/CoverImagePromptAgent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Ai\Agents;
+
+use Laravel\Ai\Attributes\UseCheapestModel;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+use Stringable;
+
+#[UseCheapestModel]
+class CoverImagePromptAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): Stringable|string
+    {
+        return 'You are a documentation assistant. Given metadata about a documentation section (which may be in any language), write a concise English description in 1-2 sentences that captures the conceptual theme, suitable for use in an image generation prompt. Return only the description, nothing else.';
+    }
+}

--- a/app/Http/Controllers/Admin/NamespaceController.php
+++ b/app/Http/Controllers/Admin/NamespaceController.php
@@ -2,13 +2,16 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Ai\Agents\CoverImagePromptAgent;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\StoreNamespaceRequest;
 use App\Http\Requests\Admin\UpdateNamespaceRequest;
 use App\Models\PostNamespace;
+use App\Support\AiCostCalculator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\Rule;
 use Inertia\Inertia;
@@ -105,18 +108,22 @@ class NamespaceController extends Controller
 
         $postTitles = $namespace->posts()->limit(10)->pluck('title')->implode(', ');
 
-        $subject = $postTitles !== ''
-            ? "topics: {$postTitles}"
-            : "section: {$namespace->name}";
+        $metadata = "Section name: {$namespace->name}";
 
-        $description = $namespace->description !== null && $namespace->description !== ''
-            ? " It covers: {$namespace->description}."
-            : '';
+        if ($namespace->description !== null && $namespace->description !== '') {
+            $metadata .= "\nDescription: {$namespace->description}";
+        }
 
-        $prompt = "Wide landscape cover image for a documentation section called \"{$namespace->name}\".{$description} Visually represent these {$subject}. Professional, clean, abstract, suitable for a technical documentation website.";
+        if ($postTitles !== '') {
+            $metadata .= "\nPost titles: {$postTitles}";
+        }
 
-        $image = Image::of($prompt)->landscape()->generate();
-        $newCoverImage = $image->storePublicly('namespaces', 'public');
+        $agentResponse = (new CoverImagePromptAgent)->prompt($metadata);
+
+        $prompt = "Wide landscape cover image for a technical documentation website. {$agentResponse->text} Professional, clean, abstract. Do not include any text, letters, words, or characters in the image.";
+
+        $imageResponse = Image::of($prompt)->landscape()->generate();
+        $newCoverImage = $imageResponse->storePublicly('namespaces', 'public');
 
         if ($newCoverImage === false) {
             throw new RuntimeException('Failed to store the generated namespace cover image.');
@@ -131,6 +138,25 @@ class NamespaceController extends Controller
         if ($previousCoverImage) {
             Storage::disk('public')->delete($previousCoverImage);
         }
+
+        $cost = AiCostCalculator::sum(
+            AiCostCalculator::forText($agentResponse->meta, $agentResponse->usage),
+            AiCostCalculator::forImage($imageResponse->meta),
+        );
+
+        Log::info('Cover image generated', [
+            'namespace_id' => $namespace->id,
+            'agent_model' => $agentResponse->meta->model,
+            'agent_usage' => $agentResponse->usage->toArray(),
+            'image_model' => $imageResponse->meta->model,
+            'cost_usd' => $cost,
+        ]);
+
+        $message = $cost !== null
+            ? __('Cover image generated. (cost: $:cost)', ['cost' => number_format($cost, 4)])
+            : __('Cover image generated.');
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => $message]);
 
         return back();
     }

--- a/app/Support/AiCostCalculator.php
+++ b/app/Support/AiCostCalculator.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Support;
+
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+
+class AiCostCalculator
+{
+    /**
+     * Calculate the cost in USD for a text generation response.
+     * Returns null if no pricing is configured for the model.
+     */
+    public static function forText(Meta $meta, Usage $usage): ?float
+    {
+        $pricing = self::pricing($meta);
+
+        if ($pricing === null || ! isset($pricing['input_per_1m'], $pricing['output_per_1m'])) {
+            return null;
+        }
+
+        return ($usage->promptTokens / 1_000_000 * $pricing['input_per_1m'])
+            + ($usage->completionTokens / 1_000_000 * $pricing['output_per_1m']);
+    }
+
+    /**
+     * Calculate the cost in USD for an image generation response.
+     * Returns null if no pricing is configured for the model.
+     */
+    public static function forImage(Meta $meta, int $imageCount = 1): ?float
+    {
+        $pricing = self::pricing($meta);
+
+        if ($pricing === null || ! isset($pricing['per_image'])) {
+            return null;
+        }
+
+        return $pricing['per_image'] * $imageCount;
+    }
+
+    /**
+     * Sum multiple nullable costs, returning null if none are known.
+     */
+    public static function sum(?float ...$costs): ?float
+    {
+        $known = array_filter($costs, fn (?float $cost) => $cost !== null);
+
+        return $known !== [] ? array_sum($known) : null;
+    }
+
+    /**
+     * @return array<string, float>|null
+     */
+    private static function pricing(Meta $meta): ?array
+    {
+        if ($meta->provider === null || $meta->model === null) {
+            return null;
+        }
+
+        $pricing = config("ai.providers.{$meta->provider}.pricing");
+
+        return is_array($pricing) ? ($pricing[$meta->model] ?? null) : null;
+    }
+}

--- a/config/ai.php
+++ b/config/ai.php
@@ -58,6 +58,18 @@ return [
             'secret_access_key' => env('AWS_SECRET_ACCESS_KEY'),
             'session_token' => env('AWS_SESSION_TOKEN'),
             'use_default_credential_provider' => env('AWS_USE_DEFAULT_CREDENTIALS', true),
+            'models' => [
+                'text' => [
+                    'cheapest' => 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+                    'smartest' => 'us.anthropic.claude-opus-4-6-v1',
+                ],
+            ],
+            'pricing' => [
+                'us.anthropic.claude-haiku-4-5-20251001-v1:0' => ['input_per_1m' => 0.25, 'output_per_1m' => 1.25],
+                'us.anthropic.claude-sonnet-4-5-20250929-v1:0' => ['input_per_1m' => 3.00, 'output_per_1m' => 15.00],
+                'us.anthropic.claude-opus-4-6-v1' => ['input_per_1m' => 15.00, 'output_per_1m' => 75.00],
+                'amazon.nova-canvas-v1:0' => ['per_image' => 0.04],
+            ],
         ],
 
         'anthropic' => [

--- a/tests/Feature/Admin/NamespaceControllerTest.php
+++ b/tests/Feature/Admin/NamespaceControllerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Ai\Agents\CoverImagePromptAgent;
 use App\Models\Post;
 use App\Models\PostNamespace;
 use App\Models\User;
@@ -587,6 +588,7 @@ test('deleting a namespace removes the cover image file', function () {
 
 test('generating a namespace cover image is forbidden when ai is disabled', function () {
     Image::fake();
+    config()->set('thinkstream.ai.enabled', false);
 
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create();
@@ -601,6 +603,9 @@ test('generating a namespace cover image is forbidden when ai is disabled', func
 test('generating a namespace cover image stores a new image and replaces the old one', function () {
     Storage::fake('public');
     Image::fake();
+    CoverImagePromptAgent::fake([
+        'An abstract landscape illustration representing technical guides about routing and validation.',
+    ])->preventStrayPrompts();
     config()->set('thinkstream.ai.enabled', true);
 
     $user = User::factory()->create();
@@ -624,12 +629,21 @@ test('generating a namespace cover image stores a new image and replaces the old
     $this->actingAs($user)
         ->from(route('admin.namespaces.edit', $namespace))
         ->post(route('admin.namespaces.generate-cover-image', $namespace))
-        ->assertRedirect(route('admin.namespaces.edit', $namespace));
+        ->assertRedirect(route('admin.namespaces.edit', $namespace))
+        ->assertInertiaFlash('toast', [
+            'type' => 'success',
+            'message' => 'Cover image generated. (cost: $0.0400)',
+        ]);
 
-    Image::assertGenerated(fn ($prompt) => $prompt->contains('Guides')
-        && $prompt->contains('Step-by-step writing guides.')
-        && $prompt->contains('Routing')
-        && $prompt->contains('Validation')
+    CoverImagePromptAgent::assertPrompted(fn ($prompt) => str_contains($prompt->prompt, 'Section name: Guides')
+        && str_contains($prompt->prompt, 'Description: Step-by-step writing guides.')
+        && str_contains($prompt->prompt, 'Post titles:')
+        && str_contains($prompt->prompt, 'Routing')
+        && str_contains($prompt->prompt, 'Validation')
+    );
+
+    Image::assertGenerated(fn ($prompt) => $prompt->contains('An abstract landscape illustration representing technical guides about routing and validation.')
+        && $prompt->contains('Do not include any text, letters, words, or characters in the image.')
         && $prompt->isLandscape()
     );
 

--- a/tests/Unit/AiCostCalculatorTest.php
+++ b/tests/Unit/AiCostCalculatorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Support\AiCostCalculator;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+test('it calculates text costs from configured pricing', function () {
+    $cost = AiCostCalculator::forText(
+        new Meta('bedrock', 'us.anthropic.claude-haiku-4-5-20251001-v1:0'),
+        new Usage(promptTokens: 2_000, completionTokens: 1_000),
+    );
+
+    expect($cost)->toEqualWithDelta(0.00175, 0.000001);
+});
+
+test('it calculates image costs from configured pricing', function () {
+    $cost = AiCostCalculator::forImage(
+        new Meta('bedrock', 'amazon.nova-canvas-v1:0'),
+        imageCount: 3,
+    );
+
+    expect($cost)->toEqualWithDelta(0.12, 0.000001);
+});
+
+test('it returns null when pricing is unavailable and sums only known costs', function () {
+    $unknownTextCost = AiCostCalculator::forText(
+        new Meta('bedrock', 'unknown-model'),
+        new Usage(promptTokens: 1_000, completionTokens: 1_000),
+    );
+
+    $knownImageCost = AiCostCalculator::forImage(
+        new Meta('bedrock', 'amazon.nova-canvas-v1:0'),
+    );
+
+    expect($unknownTextCost)->toBeNull()
+        ->and(AiCostCalculator::sum($unknownTextCost, $knownImageCost))->toEqualWithDelta(0.04, 0.000001)
+        ->and(AiCostCalculator::sum(null, null))->toBeNull();
+});


### PR DESCRIPTION
## Summary
- add a dedicated AI agent to turn namespace metadata into image prompt text
- calculate and surface estimated AI/image generation cost for namespace cover images
- cover the new cost calculator and namespace cover image flow with focused Pest tests

## Testing
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail artisan test --compact tests/Unit/AiCostCalculatorTest.php tests/Feature/Admin/NamespaceControllerTest.php