### PR TITLE
Add AI markdown editing tools

### DIFF
--- a/app/Ai/Agents/MarkdownStructureAgent.php
+++ b/app/Ai/Agents/MarkdownStructureAgent.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Ai\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\UseSmartestModel;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Promptable;
+use Stringable;
+
+#[UseSmartestModel]
+class MarkdownStructureAgent implements Agent, HasStructuredOutput
+{
+    use Promptable;
+
+    public function instructions(): Stringable|string
+    {
+        return <<<'INSTRUCTIONS'
+You are a markdown formatting expert. Given raw text content, reformat it as clean, well-structured markdown.
+- Add appropriate headings (##, ###) based on the content's structure
+- Format code snippets in fenced code blocks with the correct language tag
+- Create bullet or numbered lists where appropriate
+- Ensure proper paragraph spacing
+- Preserve all the original information — do not add, remove, or summarize content
+- Return only the formatted markdown, nothing else
+INSTRUCTIONS;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'content' => $schema->string()->required(),
+        ];
+    }
+}

--- a/app/Ai/Agents/TranslateSelectionAgent.php
+++ b/app/Ai/Agents/TranslateSelectionAgent.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Ai\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\UseSmartestModel;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Promptable;
+use Stringable;
+
+#[UseSmartestModel]
+class TranslateSelectionAgent implements Agent, HasStructuredOutput
+{
+    use Promptable;
+
+    public function __construct(private readonly string $targetLanguage) {}
+
+    public function instructions(): Stringable|string
+    {
+        return "You are a professional translator. Translate the given markdown text to {$this->targetLanguage}, preserving all markdown formatting (headings, lists, code blocks, links, emphasis, etc.). Return only the translated markdown, nothing else.";
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'content' => $schema->string()->required(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Admin/NamespaceController.php
+++ b/app/Http/Controllers/Admin/NamespaceController.php
@@ -102,9 +102,13 @@ class NamespaceController extends Controller
         return to_route('admin.posts.namespace', $namespace);
     }
 
-    public function generateCoverImage(PostNamespace $namespace): RedirectResponse
+    public function generateCoverImage(Request $request, PostNamespace $namespace): RedirectResponse
     {
         abort_unless(config('thinkstream.ai.enabled'), 403);
+
+        $validated = $request->validate([
+            'additional_prompt' => ['nullable', 'string', 'max:500'],
+        ]);
 
         $postTitles = $namespace->posts()->limit(10)->pluck('title')->implode(', ');
 
@@ -116,6 +120,12 @@ class NamespaceController extends Controller
 
         if ($postTitles !== '') {
             $metadata .= "\nPost titles: {$postTitles}";
+        }
+
+        $additionalPrompt = trim($validated['additional_prompt'] ?? '');
+
+        if ($additionalPrompt !== '') {
+            $metadata .= "\nAdditional style guidance from user: {$additionalPrompt}";
         }
 
         $agentResponse = (new CoverImagePromptAgent)->prompt($metadata);

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Ai\Agents\MarkdownStructureAgent;
+use App\Ai\Agents\TranslateSelectionAgent;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\RestorePostRevisionRequest;
 use App\Http\Requests\Admin\StorePostRequest;
@@ -11,14 +13,17 @@ use App\Models\Post;
 use App\Models\PostNamespace;
 use App\Models\PostRevision;
 use App\Models\Tag;
+use App\Support\AiCostCalculator;
 use App\Support\NamespaceBackupIndex;
 use App\Support\NamespaceRestoreArchive;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\StreamedEvent;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Inertia\Inertia;
@@ -569,6 +574,7 @@ class PostController extends Controller
             ],
             'availableTags' => Tag::orderBy('name')->pluck('name')->all(),
             'slugPrefix' => trim($namespace->full_path, '/').'/',
+            'aiEnabled' => config('thinkstream.ai.enabled'),
         ]);
     }
 
@@ -665,6 +671,68 @@ class PostController extends Controller
         Inertia::flash('toast', ['type' => 'success', 'message' => 'Revision restored.']);
 
         return to_route('admin.posts.revisions', ['namespace' => $namespace, 'post' => $post->slug]);
+    }
+
+    public function structureMarkdown(Request $request, PostNamespace $namespace, Post $post): JsonResponse
+    {
+        abort_unless(config('thinkstream.ai.enabled'), 403);
+
+        $validated = $request->validate([
+            'content' => ['required', 'string', 'max:50000'],
+        ]);
+
+        $agentResponse = (new MarkdownStructureAgent)->prompt($validated['content']);
+
+        $cost = AiCostCalculator::forText($agentResponse->meta, $agentResponse->usage);
+
+        Log::info('Markdown structured with AI', [
+            'post_id' => $post->id,
+            'agent_model' => $agentResponse->meta->model,
+            'agent_usage' => $agentResponse->usage->toArray(),
+            'cost_usd' => $cost,
+        ]);
+
+        $message = $cost !== null
+            ? __('Content structured. (cost: $:cost)', ['cost' => number_format($cost, 4)])
+            : __('Content structured.');
+
+        return response()->json([
+            'content' => $agentResponse['content'],
+            'message' => $message,
+        ]);
+    }
+
+    public function translateMarkdown(Request $request, PostNamespace $namespace, Post $post): JsonResponse
+    {
+        abort_unless(config('thinkstream.ai.enabled'), 403);
+
+        $validated = $request->validate([
+            'content' => ['required', 'string', 'max:50000'],
+        ]);
+
+        $locale = (string) config('app.locale', 'en');
+        $targetLanguage = \Locale::getDisplayLanguage($locale, 'en') ?: $locale;
+
+        $agentResponse = (new TranslateSelectionAgent($targetLanguage))->prompt($validated['content']);
+
+        $cost = AiCostCalculator::forText($agentResponse->meta, $agentResponse->usage);
+
+        Log::info('Markdown translated with AI', [
+            'post_id' => $post->id,
+            'target_language' => $targetLanguage,
+            'agent_model' => $agentResponse->meta->model,
+            'agent_usage' => $agentResponse->usage->toArray(),
+            'cost_usd' => $cost,
+        ]);
+
+        $message = $cost !== null
+            ? __('Translated to :language. (cost: $:cost)', ['language' => $targetLanguage, 'cost' => number_format($cost, 4)])
+            : __('Translated to :language.', ['language' => $targetLanguage]);
+
+        return response()->json([
+            'content' => $agentResponse['content'],
+            'message' => $message,
+        ]);
     }
 
     public function uploadNamespaceImage(UploadPostImageRequest $request, PostNamespace $namespace): RedirectResponse

--- a/resources/js/components/markdown-editor.tsx
+++ b/resources/js/components/markdown-editor.tsx
@@ -1,6 +1,13 @@
 import { router, usePage } from '@inertiajs/react';
 import { ArrowLeft, ArrowRight, Code2, Eye } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import {
+    forwardRef,
+    useEffect,
+    useImperativeHandle,
+    useRef,
+    useState,
+} from 'react';
+import type React from 'react';
 import InputError from '@/components/input-error';
 import MarkdownContent from '@/components/markdown-content';
 import { Label } from '@/components/ui/label';
@@ -9,6 +16,13 @@ import { normalizeMarkdownHeadingText } from '@/lib/markdown-heading-text';
 import { slugify } from '@/lib/slugify';
 import { cn } from '@/lib/utils';
 
+export type MarkdownEditorRef = {
+    setContent: (content: string) => void;
+    getContent: () => string;
+    getSelection: () => { text: string; start: number; end: number } | null;
+    replaceRange: (start: number, end: number, newText: string) => void;
+};
+
 type Props = {
     name: string;
     label?: string;
@@ -16,317 +30,422 @@ type Props = {
     error?: string;
     uploadUrl?: string;
     jumpTo?: number;
+    onSelectionChange?: (hasSelection: boolean) => void;
+    toolbar?: React.ReactNode;
 };
 
-export default function MarkdownEditor({
-    name,
-    label = 'Content',
-    defaultValue = '',
-    error,
-    uploadUrl,
-    jumpTo,
-}: Props) {
-    const [value, setValue] = useState(defaultValue);
-    const [activeTab, setActiveTab] = useState<'write' | 'preview'>('write');
-    const textareaRef = useRef<HTMLTextAreaElement>(null);
-    const previewRef = useRef<HTMLDivElement>(null);
-    const { props } = usePage<{ imageUrl?: string }>();
-    const previousImageUrlRef = useRef<string | undefined>(undefined);
-    const hasJumpedRef = useRef(false);
+const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
+    function MarkdownEditor(
+        {
+            name,
+            label = 'Content',
+            defaultValue = '',
+            error,
+            uploadUrl,
+            jumpTo,
+            onSelectionChange,
+            toolbar,
+        }: Props,
+        ref,
+    ) {
+        const [value, setValue] = useState(defaultValue);
+        const [activeTab, setActiveTab] = useState<'write' | 'preview'>(
+            'write',
+        );
 
-    useEffect(() => {
-        if (
-            props.imageUrl &&
-            props.imageUrl !== previousImageUrlRef.current &&
-            textareaRef.current
-        ) {
-            previousImageUrlRef.current = props.imageUrl;
+        const lastSelectionRef = useRef<{
+            text: string;
+            start: number;
+            end: number;
+        } | null>(null);
+
+        useImperativeHandle(
+            ref,
+            () => ({
+                setContent: (content: string) => setValue(content),
+                getContent: () => value,
+                getSelection: () => lastSelectionRef.current,
+                replaceRange: (start: number, end: number, newText: string) => {
+                    lastSelectionRef.current = null;
+                    onSelectionChange?.(false);
+                    setValue(
+                        (prev) =>
+                            prev.slice(0, start) + newText + prev.slice(end),
+                    );
+                },
+            }),
+            [value, onSelectionChange],
+        );
+        const textareaRef = useRef<HTMLTextAreaElement>(null);
+        const previewRef = useRef<HTMLDivElement>(null);
+        const { props } = usePage<{ imageUrl?: string }>();
+        const previousImageUrlRef = useRef<string | undefined>(undefined);
+        const hasJumpedRef = useRef(false);
+
+        useEffect(() => {
+            if (
+                props.imageUrl &&
+                props.imageUrl !== previousImageUrlRef.current &&
+                textareaRef.current
+            ) {
+                previousImageUrlRef.current = props.imageUrl;
+
+                const textarea = textareaRef.current;
+                const { selectionStart, selectionEnd } = textarea;
+                const markdown = `![image](${props.imageUrl})`;
+
+                setValue((prevContent) => {
+                    const newContent =
+                        prevContent.substring(0, selectionStart) +
+                        markdown +
+                        prevContent.substring(selectionEnd);
+
+                    setTimeout(() => {
+                        const newPosition = selectionStart + markdown.length;
+                        textarea.setSelectionRange(newPosition, newPosition);
+                        textarea.focus();
+                    }, 0);
+
+                    return newContent;
+                });
+            }
+        }, [props.imageUrl]);
+
+        useEffect(() => {
+            if (hasJumpedRef.current || jumpTo === undefined) {
+                return;
+            }
 
             const textarea = textareaRef.current;
-            const { selectionStart, selectionEnd } = textarea;
-            const markdown = `![image](${props.imageUrl})`;
 
-            setValue((prevContent) => {
-                const newContent =
-                    prevContent.substring(0, selectionStart) +
-                    markdown +
-                    prevContent.substring(selectionEnd);
-
-                setTimeout(() => {
-                    const newPosition = selectionStart + markdown.length;
-                    textarea.setSelectionRange(newPosition, newPosition);
-                    textarea.focus();
-                }, 0);
-
-                return newContent;
-            });
-        }
-    }, [props.imageUrl]);
-
-    useEffect(() => {
-        if (hasJumpedRef.current || jumpTo === undefined) {
-            return;
-        }
-
-        const textarea = textareaRef.current;
-
-        if (!textarea) {
-            return;
-        }
-
-        const clamped = Math.max(0, Math.min(jumpTo, textarea.value.length));
-        const lineEnd = textarea.value.indexOf('\n', clamped);
-        const selectionEnd = lineEnd === -1 ? textarea.value.length : lineEnd;
-        textarea.focus();
-        textarea.setSelectionRange(clamped, selectionEnd);
-
-        const lineHeight =
-            Number.parseFloat(window.getComputedStyle(textarea).lineHeight) ||
-            20;
-        const lineIndex =
-            textarea.value.slice(0, clamped).split(/\r?\n/).length - 1;
-        textarea.scrollTop = Math.max(
-            0,
-            lineIndex * lineHeight - lineHeight * 2,
-        );
-
-        const line = textarea.value.slice(clamped, selectionEnd);
-        const headingMatch = /^(#{1,6})\s+(.+?)(?:\s+#+\s*)?$/.exec(line);
-
-        if (headingMatch && previewRef.current) {
-            const id = slugify(normalizeMarkdownHeadingText(headingMatch[2]));
-            const el = previewRef.current.querySelector(`#${CSS.escape(id)}`);
-
-            if (el) {
-                const containerTop =
-                    previewRef.current.getBoundingClientRect().top;
-                const elTop = el.getBoundingClientRect().top;
-                previewRef.current.scrollTop += elTop - containerTop - 16;
+            if (!textarea) {
+                return;
             }
-        }
 
-        hasJumpedRef.current = true;
-    }, [jumpTo]);
+            const clamped = Math.max(
+                0,
+                Math.min(jumpTo, textarea.value.length),
+            );
+            const lineEnd = textarea.value.indexOf('\n', clamped);
+            const selectionEnd =
+                lineEnd === -1 ? textarea.value.length : lineEnd;
+            textarea.focus();
+            textarea.setSelectionRange(clamped, selectionEnd);
 
-    const handleImageUpload = (file: File) => {
-        if (!uploadUrl || !file.type.startsWith('image/')) {
-            return;
-        }
+            const lineHeight =
+                Number.parseFloat(
+                    window.getComputedStyle(textarea).lineHeight,
+                ) || 20;
+            const lineIndex =
+                textarea.value.slice(0, clamped).split(/\r?\n/).length - 1;
+            textarea.scrollTop = Math.max(
+                0,
+                lineIndex * lineHeight - lineHeight * 2,
+            );
 
-        router.post(
-            uploadUrl,
-            { image: file },
-            {
-                preserveState: true,
-                preserveScroll: true,
-                onError: (errors) => {
-                    alert(errors.image ?? 'Image upload failed.');
+            const line = textarea.value.slice(clamped, selectionEnd);
+            const headingMatch = /^(#{1,6})\s+(.+?)(?:\s+#+\s*)?$/.exec(line);
+
+            if (headingMatch && previewRef.current) {
+                const id = slugify(
+                    normalizeMarkdownHeadingText(headingMatch[2]),
+                );
+                const el = previewRef.current.querySelector(
+                    `#${CSS.escape(id)}`,
+                );
+
+                if (el) {
+                    const containerTop =
+                        previewRef.current.getBoundingClientRect().top;
+                    const elTop = el.getBoundingClientRect().top;
+                    previewRef.current.scrollTop += elTop - containerTop - 16;
+                }
+            }
+
+            hasJumpedRef.current = true;
+        }, [jumpTo]);
+
+        const handleImageUpload = (file: File) => {
+            if (!uploadUrl || !file.type.startsWith('image/')) {
+                return;
+            }
+
+            router.post(
+                uploadUrl,
+                { image: file },
+                {
+                    preserveState: true,
+                    preserveScroll: true,
+                    onError: (errors) => {
+                        alert(errors.image ?? 'Image upload failed.');
+                    },
                 },
-            },
-        );
-    };
+            );
+        };
 
-    const handleDrop = (e: React.DragEvent<HTMLTextAreaElement>) => {
-        e.preventDefault();
-        const imageFile = Array.from(e.dataTransfer.files).find((file) =>
-            file.type.startsWith('image/'),
-        );
-
-        if (imageFile) {
-            handleImageUpload(imageFile);
-        }
-    };
-
-    const syncLeftToRight = () => {
-        const textarea = textareaRef.current;
-        const preview = previewRef.current;
-        if (!textarea || !preview) {
-            return;
-        }
-
-        const scrollableHeight = textarea.scrollHeight - textarea.clientHeight;
-
-        if (scrollableHeight <= 0) {
-            return;
-        }
-
-        const ratio = textarea.scrollTop / scrollableHeight;
-        preview.scrollTop =
-            ratio * (preview.scrollHeight - preview.clientHeight);
-    };
-
-    const syncRightToLeft = () => {
-        const textarea = textareaRef.current;
-        const preview = previewRef.current;
-        if (!textarea || !preview) {
-            return;
-        }
-
-        const scrollableHeight = preview.scrollHeight - preview.clientHeight;
-
-        if (scrollableHeight <= 0) {
-            return;
-        }
-
-        const ratio = preview.scrollTop / scrollableHeight;
-        textarea.scrollTop =
-            ratio * (textarea.scrollHeight - textarea.clientHeight);
-    };
-
-    const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
-        const imageItem = Array.from(e.clipboardData.items).find((item) =>
-            item.type.startsWith('image/'),
-        );
-
-        if (imageItem) {
+        const handleDrop = (e: React.DragEvent<HTMLTextAreaElement>) => {
             e.preventDefault();
-            const file = imageItem.getAsFile();
+            const imageFile = Array.from(e.dataTransfer.files).find((file) =>
+                file.type.startsWith('image/'),
+            );
 
-            if (file) {
-                handleImageUpload(file);
+            if (imageFile) {
+                handleImageUpload(imageFile);
             }
-        }
-    };
+        };
 
-    return (
-        <div className="grid gap-2">
-            {label && <Label htmlFor={name}>{label}</Label>}
+        const syncLeftToRight = () => {
+            const textarea = textareaRef.current;
+            const preview = previewRef.current;
 
-            <div
-                data-test="markdown-editor"
-                className="overflow-hidden rounded-xl border border-border bg-card shadow-sm"
-            >
-                {/* Tab header */}
-                <div className="flex items-center justify-between border-b border-border px-4 py-2">
-                    <div className="flex gap-1 rounded-lg bg-muted/50 p-0.5">
-                        <button
-                            type="button"
-                            data-test="markdown-editor-write-tab"
-                            aria-pressed={activeTab === 'write'}
-                            onClick={() => setActiveTab('write')}
-                            className={cn(
-                                'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all',
-                                activeTab === 'write'
-                                    ? 'bg-card text-foreground shadow-sm'
-                                    : 'text-muted-foreground hover:text-foreground',
-                            )}
-                        >
-                            <Code2 className="size-3.5" />
-                            <span className="hidden sm:inline">Markdown</span>
-                        </button>
-                        <button
-                            type="button"
-                            data-test="markdown-editor-preview-tab"
-                            aria-pressed={activeTab === 'preview'}
-                            onClick={() => setActiveTab('preview')}
-                            className={cn(
-                                'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all',
-                                activeTab === 'preview'
-                                    ? 'bg-card text-foreground shadow-sm'
-                                    : 'text-muted-foreground hover:text-foreground',
-                            )}
-                        >
-                            <Eye className="size-3.5" />
-                            <span className="hidden sm:inline">Preview</span>
-                        </button>
-                    </div>
-                    {uploadUrl && (
-                        <p className="hidden text-xs text-muted-foreground lg:block">
-                            Drag &amp; drop or paste images to upload
-                        </p>
-                    )}
-                </div>
+            if (!textarea || !preview) {
+                return;
+            }
 
-                <div className="grid lg:grid-cols-2">
-                    {/* Write column */}
-                    <div
-                        data-test="markdown-editor-write-panel"
-                        className={cn(
-                            'border-border lg:border-r',
-                            activeTab !== 'write' && 'hidden lg:block',
-                        )}
-                    >
-                        <div className="flex items-center justify-between border-b border-border px-4 py-2">
-                            <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
-                                Markdown
-                            </p>
+            const scrollableHeight =
+                textarea.scrollHeight - textarea.clientHeight;
+
+            if (scrollableHeight <= 0) {
+                return;
+            }
+
+            const ratio = textarea.scrollTop / scrollableHeight;
+            preview.scrollTop =
+                ratio * (preview.scrollHeight - preview.clientHeight);
+        };
+
+        const syncRightToLeft = () => {
+            const textarea = textareaRef.current;
+            const preview = previewRef.current;
+
+            if (!textarea || !preview) {
+                return;
+            }
+
+            const scrollableHeight =
+                preview.scrollHeight - preview.clientHeight;
+
+            if (scrollableHeight <= 0) {
+                return;
+            }
+
+            const ratio = preview.scrollTop / scrollableHeight;
+            textarea.scrollTop =
+                ratio * (textarea.scrollHeight - textarea.clientHeight);
+        };
+
+        const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+            const imageItem = Array.from(e.clipboardData.items).find((item) =>
+                item.type.startsWith('image/'),
+            );
+
+            if (imageItem) {
+                e.preventDefault();
+                const file = imageItem.getAsFile();
+
+                if (file) {
+                    handleImageUpload(file);
+                }
+            }
+        };
+
+        return (
+            <div className="grid gap-2">
+                {label && <Label htmlFor={name}>{label}</Label>}
+
+                <div
+                    data-test="markdown-editor"
+                    className="overflow-hidden rounded-xl border border-border bg-card shadow-sm"
+                >
+                    {/* Tab header */}
+                    <div className="flex items-center justify-between border-b border-border px-4 py-2">
+                        <div className="flex gap-1 rounded-lg bg-muted/50 p-0.5">
                             <button
                                 type="button"
-                                data-test="markdown-editor-sync-preview"
-                                onClick={syncLeftToRight}
-                                title="Sync preview to this position"
-                                className="hidden items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground lg:flex"
+                                data-test="markdown-editor-write-tab"
+                                aria-pressed={activeTab === 'write'}
+                                onClick={() => setActiveTab('write')}
+                                className={cn(
+                                    'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all',
+                                    activeTab === 'write'
+                                        ? 'bg-card text-foreground shadow-sm'
+                                        : 'text-muted-foreground hover:text-foreground',
+                                )}
                             >
-                                <ArrowRight className="size-3" />
-                                Scroll Sync
+                                <Code2 className="size-3.5" />
+                                <span className="hidden sm:inline">
+                                    Markdown
+                                </span>
                             </button>
-                        </div>
-                        <textarea
-                            ref={textareaRef}
-                            id={name}
-                            name={name}
-                            value={value}
-                            onChange={(e) => setValue(e.target.value)}
-                            onDrop={uploadUrl ? handleDrop : undefined}
-                            onDragOver={
-                                uploadUrl
-                                    ? (e) => e.preventDefault()
-                                    : undefined
-                            }
-                            onPaste={uploadUrl ? handlePaste : undefined}
-                            placeholder="Write markdown here..."
-                            className={cn(
-                                'h-[50vh] w-full resize-none border-0 bg-transparent px-4 pb-4 font-mono text-sm shadow-none outline-none placeholder:text-muted-foreground/60 lg:h-[65vh]',
-                                error && 'border-b border-destructive',
-                            )}
-                        />
-                    </div>
-
-                    {/* Preview column */}
-                    <div
-                        data-test="markdown-editor-preview-panel"
-                        className={cn(
-                            'bg-muted/20',
-                            activeTab !== 'preview' && 'hidden lg:block',
-                        )}
-                    >
-                        <div className="flex items-center justify-between border-b border-border px-4 py-2">
-                            <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
-                                Preview
-                            </p>
                             <button
                                 type="button"
-                                data-test="markdown-editor-sync-editor"
-                                onClick={syncRightToLeft}
-                                title="Sync editor to this position"
-                                className="hidden items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground lg:flex"
+                                data-test="markdown-editor-preview-tab"
+                                aria-pressed={activeTab === 'preview'}
+                                onClick={() => setActiveTab('preview')}
+                                className={cn(
+                                    'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all',
+                                    activeTab === 'preview'
+                                        ? 'bg-card text-foreground shadow-sm'
+                                        : 'text-muted-foreground hover:text-foreground',
+                                )}
                             >
-                                <ArrowLeft className="size-3" />
-                                Scroll Sync
+                                <Eye className="size-3.5" />
+                                <span className="hidden sm:inline">
+                                    Preview
+                                </span>
                             </button>
                         </div>
-                        <div
-                            ref={previewRef}
-                            className="h-[50vh] overflow-y-auto px-4 pb-4 text-sm lg:h-[65vh]"
-                        >
-                            {value ? (
-                                <div className="prose prose-sm max-w-none dark:prose-invert">
-                                    <MarkdownContent
-                                        content={value}
-                                        components={createMarkdownComponents()}
-                                    />
-                                </div>
-                            ) : (
-                                <p className="text-muted-foreground">
-                                    Nothing to preview
+                        <div className="flex items-center gap-3">
+                            {uploadUrl && (
+                                <p className="hidden text-xs text-muted-foreground lg:block">
+                                    Drag &amp; drop or paste images to upload
                                 </p>
                             )}
+                            {toolbar}
+                        </div>
+                    </div>
+
+                    <div className="grid lg:grid-cols-2">
+                        {/* Write column */}
+                        <div
+                            data-test="markdown-editor-write-panel"
+                            className={cn(
+                                'border-border lg:border-r',
+                                activeTab !== 'write' && 'hidden lg:block',
+                            )}
+                        >
+                            <div className="flex items-center justify-between border-b border-border px-4 py-2">
+                                <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                                    Markdown
+                                </p>
+                                <button
+                                    type="button"
+                                    data-test="markdown-editor-sync-preview"
+                                    onClick={syncLeftToRight}
+                                    title="Sync preview to this position"
+                                    className="hidden items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground lg:flex"
+                                >
+                                    <ArrowRight className="size-3" />
+                                    Scroll Sync
+                                </button>
+                            </div>
+                            <textarea
+                                ref={textareaRef}
+                                id={name}
+                                name={name}
+                                value={value}
+                                onChange={(e) => setValue(e.target.value)}
+                                onSelect={(e) => {
+                                    const t = e.currentTarget;
+                                    const has =
+                                        t.selectionStart !== t.selectionEnd;
+                                    lastSelectionRef.current = has
+                                        ? {
+                                              text: t.value.slice(
+                                                  t.selectionStart,
+                                                  t.selectionEnd,
+                                              ),
+                                              start: t.selectionStart,
+                                              end: t.selectionEnd,
+                                          }
+                                        : null;
+                                    onSelectionChange?.(has);
+                                }}
+                                onMouseUp={(e) => {
+                                    const t = e.currentTarget;
+                                    const has =
+                                        t.selectionStart !== t.selectionEnd;
+                                    lastSelectionRef.current = has
+                                        ? {
+                                              text: t.value.slice(
+                                                  t.selectionStart,
+                                                  t.selectionEnd,
+                                              ),
+                                              start: t.selectionStart,
+                                              end: t.selectionEnd,
+                                          }
+                                        : null;
+                                    onSelectionChange?.(has);
+                                }}
+                                onKeyUp={(e) => {
+                                    const t = e.currentTarget;
+                                    const has =
+                                        t.selectionStart !== t.selectionEnd;
+                                    lastSelectionRef.current = has
+                                        ? {
+                                              text: t.value.slice(
+                                                  t.selectionStart,
+                                                  t.selectionEnd,
+                                              ),
+                                              start: t.selectionStart,
+                                              end: t.selectionEnd,
+                                          }
+                                        : null;
+                                    onSelectionChange?.(has);
+                                }}
+                                onDrop={uploadUrl ? handleDrop : undefined}
+                                onDragOver={
+                                    uploadUrl
+                                        ? (e) => e.preventDefault()
+                                        : undefined
+                                }
+                                onPaste={uploadUrl ? handlePaste : undefined}
+                                placeholder="Write markdown here..."
+                                className={cn(
+                                    'h-[50vh] w-full resize-none border-0 bg-transparent px-4 pb-4 font-mono text-sm shadow-none outline-none placeholder:text-muted-foreground/60 lg:h-[65vh]',
+                                    error && 'border-b border-destructive',
+                                )}
+                            />
+                        </div>
+
+                        {/* Preview column */}
+                        <div
+                            data-test="markdown-editor-preview-panel"
+                            className={cn(
+                                'bg-muted/20',
+                                activeTab !== 'preview' && 'hidden lg:block',
+                            )}
+                        >
+                            <div className="flex items-center justify-between border-b border-border px-4 py-2">
+                                <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                                    Preview
+                                </p>
+                                <button
+                                    type="button"
+                                    data-test="markdown-editor-sync-editor"
+                                    onClick={syncRightToLeft}
+                                    title="Sync editor to this position"
+                                    className="hidden items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground lg:flex"
+                                >
+                                    <ArrowLeft className="size-3" />
+                                    Scroll Sync
+                                </button>
+                            </div>
+                            <div
+                                ref={previewRef}
+                                className="h-[50vh] overflow-y-auto px-4 pb-4 text-sm lg:h-[65vh]"
+                            >
+                                {value ? (
+                                    <div className="prose prose-sm max-w-none dark:prose-invert">
+                                        <MarkdownContent
+                                            content={value}
+                                            components={createMarkdownComponents()}
+                                        />
+                                    </div>
+                                ) : (
+                                    <p className="text-muted-foreground">
+                                        Nothing to preview
+                                    </p>
+                                )}
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
 
-            <InputError message={error} />
-        </div>
-    );
-}
+                <InputError message={error} />
+            </div>
+        );
+    },
+);
+
+export default MarkdownEditor;

--- a/resources/js/pages/admin/namespaces/edit.tsx
+++ b/resources/js/pages/admin/namespaces/edit.tsx
@@ -1,11 +1,13 @@
 import { Head, router, setLayoutProps, useForm } from '@inertiajs/react';
+import { Sparkles } from 'lucide-react';
+import { useState } from 'react';
 import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import CoverImageDropzone from '@/components/cover-image-dropzone';
 import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
-import { useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
 import { dashboard } from '@/routes';
 import {
     index as namespacesIndex,
@@ -49,11 +51,12 @@ export default function Edit({
     });
 
     const [generating, setGenerating] = useState(false);
+    const [additionalPrompt, setAdditionalPrompt] = useState('');
 
     function generateCoverImage() {
         router.post(
             NamespaceController.generateCoverImage.url(namespace.id),
-            {},
+            { additional_prompt: additionalPrompt },
             {
                 onStart: () => setGenerating(true),
                 onFinish: () => setGenerating(false),
@@ -152,12 +155,29 @@ export default function Edit({
                                     disabled={generating || processing}
                                     onClick={generateCoverImage}
                                 >
+                                    {generating ? (
+                                        <Spinner className="mr-1.5" />
+                                    ) : (
+                                        <Sparkles className="mr-1.5 size-3.5" />
+                                    )}
                                     {generating
                                         ? 'Generating…'
                                         : 'Generate with AI'}
                                 </Button>
                             )}
                         </div>
+                        {aiEnabled && (
+                            <Input
+                                type="text"
+                                value={additionalPrompt}
+                                onChange={(e) =>
+                                    setAdditionalPrompt(e.target.value)
+                                }
+                                placeholder="Optional: add style guidance, colors, mood… (any language)"
+                                disabled={generating || processing}
+                                maxLength={500}
+                            />
+                        )}
                         <CoverImageDropzone
                             id="cover_image"
                             currentImageUrl={namespace.cover_image_url}

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -1,4 +1,4 @@
-import { Form, Head, Link, setLayoutProps } from '@inertiajs/react';
+import { Form, Head, Link, setLayoutProps, useHttp } from '@inertiajs/react';
 import {
     ArrowLeft,
     Calendar,
@@ -10,15 +10,21 @@ import {
     Link2,
     Minimize2,
     Save,
+    Sparkles,
     Tag,
 } from 'lucide-react';
+import { Languages } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import PostController from '@/actions/App/Http/Controllers/Admin/PostController';
 import InputError from '@/components/input-error';
 import MarkdownEditor from '@/components/markdown-editor';
+import type { MarkdownEditorRef } from '@/components/markdown-editor';
 import TagInput from '@/components/tag-input';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
 import { Switch } from '@/components/ui/switch';
 import ViewContextBadge from '@/components/view-context-badge';
 import { cn } from '@/lib/utils';
@@ -58,11 +64,13 @@ export default function Edit({
     post,
     slugPrefix,
     availableTags,
+    aiEnabled,
 }: {
     namespace: Namespace;
     post: Post;
     slugPrefix: string;
     availableTags: string[];
+    aiEnabled: boolean;
 }) {
     const initialPublishedAt = post.published_at
         ? new Date(post.published_at).toISOString().slice(0, 16)
@@ -87,6 +95,70 @@ export default function Edit({
             returnTo: params.get('return_to'),
         };
     }, []);
+
+    const editorRef = useRef<MarkdownEditorRef>(null);
+    const [hasSelection, setHasSelection] = useState(false);
+    const {
+        setData: setStructureData,
+        post: structurePost,
+        processing: structuring,
+    } = useHttp({ content: '' });
+    const {
+        setData: setTranslateData,
+        post: translatePost,
+        processing: translating,
+    } = useHttp({ content: '' });
+
+    function runSelectionAction(
+        setData: (key: string, value: string) => void,
+        post: (url: string, options: object) => void,
+        url: string,
+    ) {
+        const selection = editorRef.current?.getSelection();
+
+        if (!selection) {
+            return;
+        }
+
+        setData('content', selection.text);
+        post(url, {
+            onSuccess: (response: unknown) => {
+                const { content, message } = response as {
+                    content: string;
+                    message: string;
+                };
+                editorRef.current?.replaceRange(
+                    selection.start,
+                    selection.end,
+                    content,
+                );
+                setHasUnsavedChanges(true);
+                toast.success(message);
+            },
+        });
+    }
+
+    function structureMarkdown() {
+        runSelectionAction(
+            setStructureData,
+            structurePost,
+            PostController.structureMarkdown.url({
+                namespace: namespace.id,
+                post: post.slug,
+            }),
+        );
+    }
+
+    function translateMarkdown() {
+        runSelectionAction(
+            setTranslateData,
+            translatePost,
+            PostController.translateMarkdown.url({
+                namespace: namespace.id,
+                post: post.slug,
+            }),
+        );
+    }
 
     const [metaPanelOpen, setMetaPanelOpen] = useState(true);
     const [slug, setSlug] = useState(post.slug);
@@ -343,6 +415,7 @@ export default function Edit({
                                         </div>
 
                                         <MarkdownEditor
+                                            ref={editorRef}
                                             name="content"
                                             defaultValue={post.content}
                                             error={errors.content}
@@ -351,6 +424,72 @@ export default function Edit({
                                                 post: post.slug,
                                             })}
                                             jumpTo={jumpTo}
+                                            onSelectionChange={
+                                                aiEnabled && !post.is_syncing
+                                                    ? setHasSelection
+                                                    : undefined
+                                            }
+                                            toolbar={
+                                                aiEnabled &&
+                                                !post.is_syncing ? (
+                                                    <div className="flex items-center gap-1.5">
+                                                        <Button
+                                                            type="button"
+                                                            variant="outline"
+                                                            size="sm"
+                                                            disabled={
+                                                                !hasSelection ||
+                                                                structuring ||
+                                                                translating
+                                                            }
+                                                            title={
+                                                                !hasSelection
+                                                                    ? 'Select text in the editor to structure it'
+                                                                    : undefined
+                                                            }
+                                                            onClick={
+                                                                structureMarkdown
+                                                            }
+                                                        >
+                                                            {structuring ? (
+                                                                <Spinner className="mr-1.5" />
+                                                            ) : (
+                                                                <Sparkles className="mr-1.5 size-3.5" />
+                                                            )}
+                                                            {structuring
+                                                                ? 'Structuring…'
+                                                                : 'Structure'}
+                                                        </Button>
+                                                        <Button
+                                                            type="button"
+                                                            variant="outline"
+                                                            size="sm"
+                                                            disabled={
+                                                                !hasSelection ||
+                                                                structuring ||
+                                                                translating
+                                                            }
+                                                            title={
+                                                                !hasSelection
+                                                                    ? 'Select text in the editor to translate it'
+                                                                    : undefined
+                                                            }
+                                                            onClick={
+                                                                translateMarkdown
+                                                            }
+                                                        >
+                                                            {translating ? (
+                                                                <Spinner className="mr-1.5" />
+                                                            ) : (
+                                                                <Languages className="mr-1.5 size-3.5" />
+                                                            )}
+                                                            {translating
+                                                                ? 'Translating…'
+                                                                : 'Translate'}
+                                                        </Button>
+                                                    </div>
+                                                ) : undefined
+                                            }
                                         />
                                     </main>
 

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -43,5 +43,7 @@ Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () 
         Route::get('/{namespace}/{post:slug}/revisions', [PostController::class, 'revisions'])->name('revisions')->scopeBindings();
         Route::post('/{namespace}/{post:slug}/revisions/{revision}/restore', [PostController::class, 'restore'])->name('revisions.restore')->scopeBindings();
         Route::post('/{namespace}/{post:slug}/image', [PostController::class, 'uploadImage'])->name('uploadImage')->scopeBindings();
+        Route::post('/{namespace}/{post:slug}/structure-markdown', [PostController::class, 'structureMarkdown'])->name('structureMarkdown')->scopeBindings();
+        Route::post('/{namespace}/{post:slug}/translate-markdown', [PostController::class, 'translateMarkdown'])->name('translateMarkdown')->scopeBindings();
     });
 });

--- a/tests/Feature/Admin/NamespaceControllerTest.php
+++ b/tests/Feature/Admin/NamespaceControllerTest.php
@@ -655,6 +655,43 @@ test('generating a namespace cover image stores a new image and replaces the old
     Storage::disk('public')->assertExists($newPath);
 });
 
+test('generating a namespace cover image includes additional prompt in agent metadata', function () {
+    Storage::fake('public');
+    Image::fake();
+    CoverImagePromptAgent::fake([
+        'A blue ocean-themed abstract illustration representing technical guides.',
+    ])->preventStrayPrompts();
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create(['name' => 'Guides', 'description' => null]);
+
+    $this->actingAs($user)
+        ->from(route('admin.namespaces.edit', $namespace))
+        ->post(route('admin.namespaces.generate-cover-image', $namespace), [
+            'additional_prompt' => '青い海のイメージ',
+        ])
+        ->assertRedirect(route('admin.namespaces.edit', $namespace));
+
+    CoverImagePromptAgent::assertPrompted(fn ($prompt) => str_contains($prompt->prompt, 'Additional style guidance from user: 青い海のイメージ'));
+});
+
+test('generating a namespace cover image validates additional prompt length', function () {
+    Image::fake();
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('admin.namespaces.generate-cover-image', $namespace), [
+            'additional_prompt' => str_repeat('a', 501),
+        ])
+        ->assertSessionHasErrors(['additional_prompt']);
+
+    Image::assertNothingGenerated();
+});
+
 test('guests cannot reorder namespaces', function () {
     $this->patch(route('admin.namespaces.reorder'), ['ids' => [1, 2]])
         ->assertRedirect(route('login'));

--- a/tests/Feature/Admin/PostControllerStructureMarkdownTest.php
+++ b/tests/Feature/Admin/PostControllerStructureMarkdownTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use App\Ai\Agents\MarkdownStructureAgent;
+use App\Models\Post;
+use App\Models\PostNamespace;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('authenticated users can structure markdown content with AI', function () {
+    MarkdownStructureAgent::fake([
+        ['content' => '## Chapter 1\n\nFormatted content here.'],
+    ]);
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($namespace, 'namespace')->create(['content' => 'Chapter 1 Unformatted content here.']);
+
+    $response = $this->actingAs($user)
+        ->postJson(route('admin.posts.structureMarkdown', ['namespace' => $namespace, 'post' => $post->slug]), [
+            'content' => 'Chapter 1 Unformatted content here.',
+        ]);
+
+    $response->assertOk()->assertJsonStructure(['content', 'message']);
+
+    MarkdownStructureAgent::assertPrompted('Chapter 1 Unformatted content here.');
+});
+
+test('the original post is not modified when structuring', function () {
+    MarkdownStructureAgent::fake([
+        ['content' => '## Formatted'],
+    ]);
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($namespace, 'namespace')->create(['content' => 'Original content.']);
+
+    $this->actingAs($user)
+        ->postJson(route('admin.posts.structureMarkdown', ['namespace' => $namespace, 'post' => $post->slug]), [
+            'content' => 'Original content.',
+        ]);
+
+    expect($post->fresh()->content)->toBe('Original content.');
+});
+
+test('structure markdown returns 403 when AI is disabled', function () {
+    config()->set('thinkstream.ai.enabled', false);
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($namespace, 'namespace')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.posts.structureMarkdown', ['namespace' => $namespace, 'post' => $post->slug]), [
+            'content' => 'Some content.',
+        ])
+        ->assertForbidden();
+});
+
+test('structure markdown validates content is required', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($namespace, 'namespace')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.posts.structureMarkdown', ['namespace' => $namespace, 'post' => $post->slug]), [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['content']);
+});
+
+test('structure markdown validates content max length', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($namespace, 'namespace')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.posts.structureMarkdown', ['namespace' => $namespace, 'post' => $post->slug]), [
+            'content' => str_repeat('a', 50001),
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['content']);
+});
+
+test('guests cannot structure markdown', function () {
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($namespace, 'namespace')->create();
+
+    $this->postJson(route('admin.posts.structureMarkdown', ['namespace' => $namespace, 'post' => $post->slug]), [
+        'content' => 'Some content.',
+    ])->assertUnauthorized();
+});

--- a/tests/Feature/Admin/PostControllerTranslateMarkdownTest.php
+++ b/tests/Feature/Admin/PostControllerTranslateMarkdownTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use App\Ai\Agents\TranslateSelectionAgent;
+use App\Models\Post;
+use App\Models\PostNamespace;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('authenticated users can translate selected content with AI', function () {
+    TranslateSelectionAgent::fake([
+        ['content' => 'こんにちは世界'],
+    ]);
+    config()->set('thinkstream.ai.enabled', true);
+    config()->set('app.locale', 'ja');
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($namespace, 'namespace')->create();
+
+    $response = $this->actingAs($user)
+        ->postJson(route('admin.posts.translateMarkdown', ['namespace' => $namespace, 'post' => $post->slug]), [
+            'content' => 'Hello world',
+        ]);
+
+    $response->assertOk()->assertJsonStructure(['content', 'message']);
+    TranslateSelectionAgent::assertPrompted('Hello world');
+});
+
+test('translate message includes target language name', function () {
+    TranslateSelectionAgent::fake([
+        ['content' => 'こんにちは'],
+    ]);
+    config()->set('thinkstream.ai.enabled', true);
+    config()->set('app.locale', 'ja');
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($namespace, 'namespace')->create();
+
+    $response = $this->actingAs($user)
+        ->postJson(route('admin.posts.translateMarkdown', ['namespace' => $namespace, 'post' => $post->slug]), [
+            'content' => 'Hello',
+        ]);
+
+    $response->assertOk()->assertJsonPath('message', fn ($msg) => str_contains($msg, 'Japanese'));
+});
+
+test('the original post is not modified when translating', function () {
+    TranslateSelectionAgent::fake([
+        ['content' => '翻訳済み'],
+    ]);
+    config()->set('thinkstream.ai.enabled', true);
+    config()->set('app.locale', 'ja');
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($namespace, 'namespace')->create(['content' => 'Original content.']);
+
+    $this->actingAs($user)
+        ->postJson(route('admin.posts.translateMarkdown', ['namespace' => $namespace, 'post' => $post->slug]), [
+            'content' => 'Original content.',
+        ]);
+
+    expect($post->fresh()->content)->toBe('Original content.');
+});
+
+test('translate markdown returns 403 when AI is disabled', function () {
+    config()->set('thinkstream.ai.enabled', false);
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($namespace, 'namespace')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.posts.translateMarkdown', ['namespace' => $namespace, 'post' => $post->slug]), [
+            'content' => 'Hello',
+        ])
+        ->assertForbidden();
+});
+
+test('translate markdown validates content is required', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($namespace, 'namespace')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.posts.translateMarkdown', ['namespace' => $namespace, 'post' => $post->slug]), [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['content']);
+});
+
+test('translate markdown validates content max length', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($namespace, 'namespace')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.posts.translateMarkdown', ['namespace' => $namespace, 'post' => $post->slug]), [
+            'content' => str_repeat('a', 50001),
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['content']);
+});
+
+test('guests cannot translate markdown', function () {
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($namespace, 'namespace')->create();
+
+    $this->postJson(route('admin.posts.translateMarkdown', ['namespace' => $namespace, 'post' => $post->slug]), [
+        'content' => 'Hello',
+    ])->assertUnauthorized();
+});


### PR DESCRIPTION
## Summary
- add AI agents and admin endpoints for structuring and translating selected markdown
- add editor toolbar actions and namespace cover-image prompt guidance input
- cover the new AI flows with feature tests

## Validation
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail artisan test --compact tests/Feature/Admin/NamespaceControllerTest.php tests/Feature/Admin/PostControllerStructureMarkdownTest.php tests/Feature/Admin/PostControllerTranslateMarkdownTest.php
- vendor/bin/sail npm run types:check
- vendor/bin/sail npx eslint resources/js/components/markdown-editor.tsx resources/js/pages/admin/posts/edit.tsx resources/js/pages/admin/namespaces/edit.tsx
- vendor/bin/sail npx prettier --check resources/js/components/markdown-editor.tsx resources/js/pages/admin/posts/edit.tsx resources/js/pages/admin/namespaces/edit.tsx
- vendor/bin/sail npm run build