### PR TITLE
Add Thinkstream canvas flow

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,0 +1,402 @@
+# ThinkStream 評価メモ（2026-04-28 更新）
+
+この文書は以下を突き合わせて更新した。
+
+- `http://localhost:8000/meta/analysis` の実表示
+- `http://localhost:8000/meta/analysis.md` の配布 Markdown
+- 現在の実装（Laravel / Inertia / React / Markdown / admin / sync / search / backup 周辺）
+
+---
+
+## 先に結論
+
+ThinkStream は **「Markdown を公開するアプリ」** というより、**「階層 URL と公開制御を中核にした、DB ドリブンなドキュメント / ナレッジ出版基盤」** として評価するのが正しい。
+
+特に強いのは次の 4 点。
+
+1. **`full_path` を中心にした情報設計**
+2. **namespace 単位のバックアップ / リストアとローカル同期**
+3. **公開・非公開・予約公開を含む出版モデル**
+4. **Zenn / Mintlify 系を吸収する Markdown パイプライン**
+
+一方で、競争上の弱点も明確。
+
+1. **Obsidian 的な知識ネットワーク体験が弱い**
+2. **チームコラボ / 権限 / レビューの層がまだ薄い**
+3. **検索は動くが、発見体験の厚みはまだ不足**
+4. **AI は入り始めたが、まだ補助機能に留まる**
+
+---
+
+## `meta/analysis` からの重要な更新点
+
+現在の `meta/analysis(.md)` は全体として良いが、**現行コードとのズレ** がある。
+
+### 1. AI は「未活用」ではない
+
+`meta/analysis.md` では AI が未活用寄りに書かれているが、現行実装ではすでに以下が入っている。
+
+- namespace cover image 用の **AI プロンプト生成 + 画像生成**
+- post 編集画面での **選択範囲の Markdown structure**
+- post 編集画面での **選択範囲の翻訳**
+- Thinkstream の thought 群を **1 本の Scrap 向け Markdown に再構成**
+- Thinkstream canvas の内容から **タイトルを磨く**
+
+つまり現状は **AI 未導入** ではなく、**編集補助と下書き整理に導入済み・ただし戦略の中心にはまだなっていない** が正確。
+
+### 2. 編集体験は「単純な textarea だけ」ではない
+
+今のエディタはプレーンではあるが、少なくとも以下は備える。
+
+- Markdown / Preview の切り替え
+- 画像の paste / drag&drop upload
+- unsaved changes 警告
+- sync mode 中の編集禁止
+- AI structure / translate の選択範囲操作
+
+ただし、それでも **Obsidian / Notion / Outline 的な編集体験** と比べるとまだ弱い。
+
+### 3. プロダクトの中心は「静的サイト代替」ではなく「運用可能な出版系 CMS」
+
+Docusaurus / VitePress のような静的ビルド前提よりも、ThinkStream は
+
+- DB 更新即反映
+- 管理 UI での操作
+- preview / draft / scheduled の扱い
+- backup / restore / import
+
+を持っており、**ドキュメント CMS / knowledge publishing system** と捉えるほうが適切。
+
+### 4. Thinkstream により「公開前の思考整理」レイヤが入った
+
+今回の実装で、ThinkStream は公開済みコンテンツの管理だけでなく、**公開前の思考を溜めて整える私的ワークスペース** を持った。
+
+- Thinkstream canvas に短い thought を時系列で蓄積
+- 複数 thought を AI で Scrap 向け Markdown に構造化
+- 構造化結果を **system namespace の Scrap** に draft として保存
+- Scrap 側から通常 namespace へ移して公開フローに乗せられる
+
+これは単なる「メモ欄追加」ではなく、**発想 -> 整理 -> 下書き化 -> 公開系 namespace へ移送** という前段導線が製品内に入ったことを意味する。
+
+---
+
+## 現在のプロダクト評価
+
+## 1. 情報設計
+
+### 強み
+
+- `PostNamespace` と `Post` の両方に `full_path` があり、URL 解決が明快
+- root segment の予約制御がある
+- namespace 非公開時に子孫全体を止める出版モデルがある
+- admin 側でも namespace を軸に構造を保っている
+
+### 評価
+
+これは ThinkStream の最重要資産。
+単なるカテゴリ機能ではなく、**URL・公開制御・ナビゲーション・バックアップ単位が同じ構造に揃っている** のが強い。
+
+### 弱み
+
+- Obsidian 的な **ノート間の横断リンク網** は主役ではない
+- 構造は強いが、**構造を超えた発見** はまだ弱い
+
+---
+
+## 2. 出版 / 公開モデル
+
+### 強み
+
+- public / preview の切り替えが実装に一貫している
+- draft / scheduled / unpublished namespace を扱える
+- system namespace として **Scrap を常時 private** に保てる
+- `.md` エンドポイントで raw markdown 配布ができる
+- private mode でクローズド運用に切り替えられる
+- SSR を前提に OGP / Twitter Card まで見ている
+
+### 評価
+
+ThinkStream は **「個人メモアプリ」ではなく「公開可能な知識ベース」** として設計されている。
+Obsidian が強いのはローカル知識整理だが、ThinkStream は **公開責務を持った知識運用** に向く。
+
+### 弱み
+
+- 公開サイトのテーマ / ブランディング自由度はまだ限定的
+- コメント、フィードバック、レビュー、公開ワークフローは未整備
+
+---
+
+## 3. 編集 / 運用体験
+
+### 強み
+
+- リビジョン復元がある
+- sync mode によるローカル `.md` 編集フローがある
+- Zenn import がある
+- backup / restore が UI と CLI の両方にある
+- Thinkstream により **短文 thought の収集 -> AI 整理 -> Scrap 保存** が UI で完結する
+
+### 評価
+
+運用体験はかなり実務寄り。
+特に **sync mode + backup/restore + import** のセットは、一般的なノートアプリより **移行性・保全性・再構築性** が高い。
+
+### 弱み
+
+- 複数人編集時の権限・承認・レビューがない
+- コンテンツ比較 / 差分 / 変更理由の運用はまだ薄い
+- UI は実用的だが、長文編集の快適さはまだ改善余地が大きい
+
+---
+
+## 4. Markdown プラットフォーム
+
+### 強み
+
+- Zenn / Mintlify 系の記法を curated に吸収している
+- syntax manifest でサーフェスを固定している
+- Mermaid、cards、tabs、steps、API fields など docs 向け部品が揃っている
+- raw markdown export と public rendering が接続している
+
+### 評価
+
+ここは **単なる Markdown renderer ではなく、軽量な docs authoring platform** と見てよい。
+
+### 弱み
+
+- 双方向リンク・埋め込み・ノート参照など、Obsidian の knowledge graph 的表現は弱い
+- plugin ecosystem で拡張する世界ではなく、**製品側が curated に増やす方式**
+
+---
+
+## 5. 検索 / 発見
+
+### 強み
+
+- Scout database engine で最小構成の検索を持つ
+- namespace 絞り込みと tag 絞り込みがある
+- 公開済みコンテンツだけを対象にしている
+
+### 評価
+
+「使える検索」はある。
+ただし今は **検索 UX の最低限** であり、プロダクト差別化の主戦場ではない。
+
+### 弱み
+
+- typo tolerance や relevance tuning が弱い
+- backlinks / related notes / graph suggestions のような発見導線がない
+- Obsidian の Dataview 的な「動的な見つけ方」はない
+
+---
+
+## Obsidian との比較を含む競争評価
+
+## 1. ThinkStream が Obsidian より強い点
+
+### 公開と運用
+
+- 公開 URL モデルが最初からある
+- 非公開 / 予約公開 / namespace 公開制御がある
+- OGP / SSR / public rendering まで一気通貫
+- backup / restore / import が「運用機能」として存在する
+
+Obsidian は publish できるが、**publish はノートの延長**。
+ThinkStream は **出版システムとしての整合性** が強い。
+
+### 情報設計の統制
+
+- `full_path` を軸に URL / 構造 / バックアップ単位が揃う
+- 管理 UI から構造を維持できる
+
+Obsidian は柔軟だが、構造の統制はユーザー規律や plugin 依存になりやすい。
+ThinkStream は **構造化された docs / KB を壊れにくく運用する** 方向で優位。
+
+### チームへの移譲しやすさ
+
+- DB と admin を前提にしている
+- private mode、auth、2FA、restore、revision がある
+
+Obsidian は個人最適が強く、チーム共有は工夫が必要。
+ThinkStream は現状でも **「個人の第二脳」より「運用される知識ベース」** に近い。
+
+## 2. Obsidian が ThinkStream より強い点
+
+### 知識ネットワーク体験
+
+- 双方向リンク
+- graph view
+- note-first な探索
+- YAML / Dataview / plugin による柔軟な二次ビュー
+
+ThinkStream は tree と path が強いが、**graph と emergent discovery** が弱い。
+
+### ローカルファースト体験
+
+- vault がファイルそのもの
+- オフライン編集が自然
+- Git / Sync / plugin による個人運用が成熟
+
+ThinkStream にも sync mode はあるが、既存 post に対する同期であり、Obsidian ほど「すべてがローカル資産」ではない。
+
+### エディタ拡張の厚み
+
+- plugin ecosystem が巨大
+- ノート作成支援、テンプレート、タスク、クエリ、図表、埋め込みが豊富
+
+ThinkStream は製品内で保証された機能は強いが、拡張の厚みでは Obsidian に劣る。
+
+## 3. どう住み分けるべきか
+
+### Obsidian の主戦場
+
+- 個人の第二脳
+- リサーチノート
+- 草稿の蓄積
+- 非線形な知識探索
+
+### ThinkStream の主戦場
+
+- 公開前提の docs / knowledge base
+- 構造を保って運用するコンテンツ
+- チームやサービスの公式ナレッジ
+- バックアップ / restore / import を含めた運用
+
+### つまり
+
+ThinkStream が Obsidian と真っ向から戦うべきなのは **「ノートアプリとして」** ではない。
+戦うべきなのは **「公開・運用・構造統制を持つ knowledge publishing system として」**。
+
+---
+
+## 現在のポジショニング案
+
+ThinkStream の説明は、今後は次のように寄せたほうが良い。
+
+> ThinkStream is a structured knowledge publishing system for teams and individuals who want Markdown-native authoring, stable URLs, branch-level publishing control, and operational safety such as sync, backup, and restore.
+
+日本語なら:
+
+> ThinkStream は、Markdown ネイティブな執筆体験を保ちながら、安定 URL、階層構造、公開制御、同期、バックアップ/復元を一体で扱える構造化ナレッジ出版基盤。
+
+---
+
+## 優先 TODO（更新版）
+
+## P0: 方向性を明確にする TODO
+
+### 1. README / meta/analysis / FEATURES の語り口を揃える
+
+- 「Markdown アプリ」ではなく「knowledge publishing system」に寄せる
+- AI 未使用など、現況とズレた記述を更新する
+- Obsidian と真っ向勝負するのではなく、住み分けを明記する
+
+### 2. 「構造」と「運用」がコアであることを前面に出す
+
+- full_path
+- branch publish control
+- sync
+- backup / restore
+- import
+
+この 5 点を製品コアとして再定義したい。
+
+## P1: 競争力を増す TODO
+
+### 3. 検索を「発見体験」まで伸ばす
+
+- related posts
+- 同 namespace / 同 tag / 同リンク元による推薦
+- Meilisearch 検討
+- 検索結果の relevance 改善
+
+### 4. Obsidian に対抗できる「知識接続」層を作る
+
+- 双方向リンク or note references
+- backlinks 表示
+- ページ間の関連グラフ
+- 引用 / embeds の一貫した扱い
+
+tree だけでなく graph 側の導線が必要。
+
+### 5. AI を編集補助から知識運用補助へ拡張する
+
+- namespace / post の要約
+- related content suggestion
+- title / taxonomy / tags 提案
+- import 後の structure repair
+- 公開前チェック
+
+今の AI は、編集補助だけでなく **思考整理と下書き化** にも入ってきた。
+それでもまだ **検索 / 発見 / 公開品質管理まで横断する中核価値** には達していない。
+
+## P2: 運用プロダクトとして強化する TODO
+
+### 6. レビュー / 承認 / 権限
+
+- role / permission
+- namespace ごとの編集権限
+- reviewer / approver フロー
+- publish approval
+
+チーム向けに伸ばすなら最重要候補。
+
+### 7. 変更履歴の実務性を上げる
+
+- revision diff をもっと見やすく
+- change summary / reason
+- restore 前後の比較
+- activity log
+
+### 8. backup / restore を製品価値として強化する
+
+- 定期バックアップ
+- 外部ストレージ出力
+- Git export / import
+- namespace 単位の移管フロー
+
+これは ThinkStream 独自性をさらに伸ばせる。
+
+## P3: UX 改善 TODO
+
+### 9. 長文編集 UX の改善
+
+- 見出しアウトライン
+- slash command / quick insert
+- keyboard shortcuts
+- block-level 補助
+- richer split view / focus mode
+
+### 10. 公開サイトの presentation を強くする
+
+- theme / branding
+- landing / doc homepage variations
+- richer namespace covers
+- better mobile reading polish
+
+---
+
+## 最終評価
+
+ThinkStream は、現時点で **Obsidian の代替** というより、
+
+- Obsidian より **公開と運用に強く**
+- Docusaurus / VitePress より **動的運用に強く**
+- Wiki 系より **Markdown と構造 URL の統制に強い**
+
+という中間地帯にいる。
+
+最も良い勝ち筋は、
+
+**「個人のノートアプリを目指さず、構造化された知識を安全に公開・運用できる Markdown-native publishing system を磨くこと」**
+
+である。
+
+その上で、Obsidian 的な強みである
+
+- knowledge graph
+- backlinks
+- discovery
+- local-first 的安心感
+
+を必要な範囲だけ吸収すると、かなり独自のポジションが作れる。

--- a/app/Ai/Agents/ThinkstreamStructureAgent.php
+++ b/app/Ai/Agents/ThinkstreamStructureAgent.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Ai\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\UseSmartestModel;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Promptable;
+use Stringable;
+
+#[UseSmartestModel]
+class ThinkstreamStructureAgent implements Agent, HasStructuredOutput
+{
+    use Promptable;
+
+    public function instructions(): Stringable|string
+    {
+        return <<<'INSTRUCTIONS'
+You are an expert editor. You will receive a canvas title and a collection of raw, informal thought entries separated by "---".
+
+Your task is to proofread and restructure them into a single, coherent, well-formatted markdown document, and propose a Scrap title:
+- Fix grammar, spelling, punctuation, and awkward phrasing
+- Organise the content with appropriate markdown headings (##, ###), lists, and code blocks
+- Merge related ideas naturally; remove redundancy
+- PRESERVE the author's original tone, voice, and personality — do not sanitise or make it sound formal if it wasn't
+- Do not add new information or opinions not present in the source
+- For the title, inherit the canvas title as much as possible while making it work as a concise Scrap note title
+- Keep the title natural and specific, not generic
+- Do not include a top-level `#` heading that simply repeats the title, since the Scrap note title is stored separately
+- Return structured output only
+INSTRUCTIONS;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'title' => $schema->string()->required(),
+            'content' => $schema->string()->required(),
+        ];
+    }
+}

--- a/app/Ai/Agents/ThinkstreamTitleAgent.php
+++ b/app/Ai/Agents/ThinkstreamTitleAgent.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Ai\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\UseSmartestModel;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Promptable;
+use Stringable;
+
+#[UseSmartestModel]
+class ThinkstreamTitleAgent implements Agent, HasStructuredOutput
+{
+    use Promptable;
+
+    public function instructions(): Stringable|string
+    {
+        return <<<'INSTRUCTIONS'
+You are naming a private idea canvas.
+
+You will receive the current canvas title and the canvas thoughts.
+
+Your task:
+- Propose a better title that captures the main theme clearly
+- Keep it concise, specific, and natural
+- Prefer 3 to 8 words
+- Do not use quotation marks
+- Do not add emojis, prefixes, or explanations
+- Preserve the author's language and tone when possible
+- Return only the improved title
+INSTRUCTIONS;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'title' => $schema->string()->required(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Admin/NamespaceController.php
+++ b/app/Http/Controllers/Admin/NamespaceController.php
@@ -88,6 +88,8 @@ class NamespaceController extends Controller
 
     public function update(UpdateNamespaceRequest $request, PostNamespace $namespace): RedirectResponse
     {
+        abort_if($namespace->is_system, 403);
+
         $data = $request->safe()->except('cover_image');
 
         if ($request->hasFile('cover_image')) {
@@ -173,6 +175,8 @@ class NamespaceController extends Controller
 
     public function destroy(PostNamespace $namespace): RedirectResponse
     {
+        abort_if($namespace->is_system, 403);
+
         $namespace->deleteRecursively();
 
         return to_route('admin.posts.index');

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -14,6 +14,7 @@ use App\Models\PostNamespace;
 use App\Models\PostRevision;
 use App\Models\Tag;
 use App\Support\AiCostCalculator;
+use App\Support\ContentPathConflict;
 use App\Support\NamespaceBackupIndex;
 use App\Support\NamespaceRestoreArchive;
 use Illuminate\Http\JsonResponse;
@@ -404,7 +405,14 @@ class PostController extends Controller
         $post->load('tags');
 
         return Inertia::render('admin/posts/show', [
-            'namespace' => $namespace,
+            'namespace' => [
+                'id' => $namespace->id,
+                'name' => $namespace->name,
+                'slug' => $namespace->slug,
+                'full_path' => $namespace->full_path,
+                'is_system' => (bool) $namespace->is_system,
+            ],
+            'availableMoveNamespaces' => $this->availableMoveNamespaces($namespace),
             'navRoot' => $this->buildNavigationTree($rootNamespace),
             'post' => [
                 ...$post->only([
@@ -427,6 +435,67 @@ class PostController extends Controller
                 'tags' => $post->tags->pluck('name')->values()->all(),
             ],
         ]);
+    }
+
+    public function moveToNamespace(Request $request, PostNamespace $namespace, Post $post): RedirectResponse
+    {
+        $availableNamespaceIds = PostNamespace::query()
+            ->where(fn ($query) => $query->where('is_system', false)->orWhereNull('is_system'))
+            ->whereKeyNot($namespace->id)
+            ->pluck('id')
+            ->all();
+
+        $data = $request->validate([
+            'target_namespace_id' => ['required', 'integer', Rule::in($availableNamespaceIds)],
+        ]);
+
+        $targetNamespace = PostNamespace::query()
+            ->select(['id', 'slug', 'full_path', 'name'])
+            ->findOrFail($data['target_namespace_id']);
+
+        $newSlug = $this->resolveAvailableSlugForNamespace($post, $targetNamespace->id);
+
+        $post->update([
+            'namespace_id' => $targetNamespace->id,
+            'slug' => $newSlug,
+            'full_path' => trim(implode('/', array_filter([$targetNamespace->full_path, $newSlug])), '/'),
+        ]);
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => 'Post moved to namespace.']);
+
+        return to_route('admin.posts.show', ['namespace' => $targetNamespace, 'post' => $post->slug]);
+    }
+
+    /**
+     * @return array<int, array{id: int, name: string, full_path: string}>
+     */
+    private function availableMoveNamespaces(PostNamespace $currentNamespace): array
+    {
+        return PostNamespace::query()
+            ->where(fn ($query) => $query->where('is_system', false)->orWhereNull('is_system'))
+            ->whereKeyNot($currentNamespace->id)
+            ->orderBy('full_path')
+            ->get(['id', 'name', 'full_path'])
+            ->map(fn (PostNamespace $namespace) => [
+                'id' => $namespace->id,
+                'name' => $namespace->name,
+                'full_path' => $namespace->full_path,
+            ])
+            ->all();
+    }
+
+    private function resolveAvailableSlugForNamespace(Post $post, int $targetNamespaceId): string
+    {
+        $baseSlug = $post->slug;
+        $slug = $baseSlug;
+        $counter = 2;
+
+        while (ContentPathConflict::findPostConflict($targetNamespaceId, $slug, $post) !== null) {
+            $slug = "{$baseSlug}-{$counter}";
+            $counter++;
+        }
+
+        return $slug;
     }
 
     private function safeExternalUrl(?string $url): ?string
@@ -585,6 +654,11 @@ class PostController extends Controller
         $data = $request->validated();
         $tags = $data['tags'] ?? [];
         $filteredData = collect($data)->except('tags')->all();
+
+        if ($namespace->is_system) {
+            $filteredData['is_draft'] = true;
+            unset($filteredData['published_at']);
+        }
 
         $hasChanges = $post->title !== ($filteredData['title'] ?? $post->title)
             || $post->content !== ($filteredData['content'] ?? $post->content);

--- a/app/Http/Controllers/Admin/ThinkstreamController.php
+++ b/app/Http/Controllers/Admin/ThinkstreamController.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Ai\Agents\ThinkstreamStructureAgent;
+use App\Ai\Agents\ThinkstreamTitleAgent;
+use App\Http\Controllers\Controller;
+use App\Models\Post;
+use App\Models\PostNamespace;
+use App\Models\ThinkstreamPage;
+use App\Models\Thought;
+use App\Support\AiCostCalculator;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ThinkstreamController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $pages = ThinkstreamPage::query()
+            ->whereBelongsTo($request->user())
+            ->withCount('thoughts')
+            ->latest()
+            ->get(['id', 'user_id', 'title', 'created_at']);
+
+        return Inertia::render('admin/thinkstream/index', [
+            'pages' => $pages,
+        ]);
+    }
+
+    public function storePage(Request $request): RedirectResponse
+    {
+        $page = ThinkstreamPage::create([
+            'user_id' => $request->user()->id,
+            'title' => 'Canvas '.now()->format('Y-m-d H:i'),
+        ]);
+
+        return redirect()->route('admin.thinkstream.show', $page);
+    }
+
+    public function destroyPage(Request $request, ThinkstreamPage $page): RedirectResponse
+    {
+        $this->authorizePage($request, $page);
+
+        $page->delete();
+
+        return redirect()->route('admin.thinkstream.index');
+    }
+
+    public function show(Request $request, ThinkstreamPage $page): Response
+    {
+        $this->authorizePage($request, $page);
+
+        $thoughts = $page->thoughts()
+            ->with('user:id,name')
+            ->oldest()
+            ->get(['id', 'page_id', 'user_id', 'content', 'created_at']);
+
+        return Inertia::render('admin/thinkstream/show', [
+            'page' => $page->only('id', 'title', 'created_at'),
+            'thoughts' => $thoughts,
+            'aiEnabled' => config('thinkstream.ai.enabled'),
+        ]);
+    }
+
+    public function store(Request $request, ThinkstreamPage $page): RedirectResponse
+    {
+        $this->authorizePage($request, $page);
+
+        $validated = $request->validate([
+            'content' => ['required', 'string', 'max:10000'],
+        ]);
+
+        Thought::create([
+            'user_id' => $request->user()->id,
+            'page_id' => $page->id,
+            'content' => $validated['content'],
+        ]);
+
+        return back();
+    }
+
+    public function update(Request $request, ThinkstreamPage $page, Thought $thought): RedirectResponse
+    {
+        $this->authorizeThought($request, $page, $thought);
+
+        $validated = $request->validate([
+            'content' => ['required', 'string', 'max:10000'],
+        ]);
+
+        $thought->update($validated);
+
+        return back();
+    }
+
+    public function destroyMany(Request $request, ThinkstreamPage $page): RedirectResponse
+    {
+        $this->authorizePage($request, $page);
+
+        $validated = $request->validate([
+            'ids' => ['required', 'array'],
+            'ids.*' => ['integer'],
+        ]);
+
+        Thought::where('page_id', $page->id)
+            ->whereIn('id', $validated['ids'])
+            ->delete();
+
+        return back();
+    }
+
+    public function structureThoughts(Request $request, ThinkstreamPage $page): JsonResponse
+    {
+        abort_unless(config('thinkstream.ai.enabled'), 403);
+        $this->authorizePage($request, $page);
+
+        $validated = $request->validate([
+            'ids' => ['required', 'array'],
+            'ids.*' => ['integer'],
+        ]);
+
+        $thoughts = Thought::where('page_id', $page->id)
+            ->whereIn('id', $validated['ids'])
+            ->oldest()
+            ->get(['content']);
+
+        $combined = implode("\n\n", [
+            'Canvas title: '.$page->title,
+            'Thoughts:',
+            $thoughts->map(fn ($t) => $t->content)->join("\n\n---\n\n"),
+        ]);
+
+        $agentResponse = (new ThinkstreamStructureAgent)->prompt($combined);
+
+        $cost = AiCostCalculator::forText($agentResponse->meta, $agentResponse->usage);
+
+        Log::info('Thinkstream thoughts structured with AI', [
+            'page_id' => $page->id,
+            'thought_ids' => $validated['ids'],
+            'agent_model' => $agentResponse->meta->model,
+            'agent_usage' => $agentResponse->usage->toArray(),
+            'cost_usd' => $cost,
+        ]);
+
+        $message = $cost !== null
+            ? __('Content structured. (cost: $:cost)', ['cost' => number_format($cost, 4)])
+            : __('Content structured.');
+
+        return response()->json([
+            'title' => $agentResponse['title'],
+            'content' => $agentResponse['content'],
+            'message' => $message,
+        ]);
+    }
+
+    public function refineTitle(Request $request, ThinkstreamPage $page): JsonResponse
+    {
+        abort_unless(config('thinkstream.ai.enabled'), 403);
+        $this->authorizePage($request, $page);
+
+        $thoughts = $page->thoughts()
+            ->oldest()
+            ->get(['content']);
+
+        if ($thoughts->isEmpty()) {
+            throw ValidationException::withMessages([
+                'page' => __('Add at least one thought before refining the title.'),
+            ]);
+        }
+
+        $prompt = implode("\n\n", [
+            'Current title: '.$page->title,
+            'Thoughts:',
+            $thoughts->pluck('content')->join("\n\n---\n\n"),
+        ]);
+
+        $agentResponse = (new ThinkstreamTitleAgent)->prompt($prompt);
+
+        $page->update([
+            'title' => $agentResponse['title'],
+        ]);
+
+        $cost = AiCostCalculator::forText($agentResponse->meta, $agentResponse->usage);
+
+        Log::info('Thinkstream title refined with AI', [
+            'page_id' => $page->id,
+            'thought_count' => $thoughts->count(),
+            'agent_model' => $agentResponse->meta->model,
+            'agent_usage' => $agentResponse->usage->toArray(),
+            'cost_usd' => $cost,
+        ]);
+
+        $message = $cost !== null
+            ? __('Title refined. (cost: $:cost)', ['cost' => number_format($cost, 4)])
+            : __('Title refined.');
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => $message]);
+
+        return response()->json([
+            'title' => $page->title,
+        ]);
+    }
+
+    public function saveToScrap(Request $request): JsonResponse
+    {
+        abort_unless(config('thinkstream.ai.enabled'), 403);
+
+        $validated = $request->validate([
+            'content' => ['required', 'string', 'max:200000'],
+            'title' => ['nullable', 'string', 'max:255'],
+            'delete_canvas' => ['required', 'boolean'],
+            'page_id' => [
+                Rule::requiredIf(fn () => (bool) $request->boolean('delete_canvas')),
+                'nullable',
+                'integer',
+                'exists:thinkstream_pages,id',
+            ],
+        ]);
+
+        $page = null;
+
+        if ($validated['delete_canvas']) {
+            $page = ThinkstreamPage::findOrFail($validated['page_id']);
+
+            $this->authorizePage($request, $page);
+        }
+
+        $scrap = PostNamespace::where('slug', 'scrap')->firstOrFail();
+
+        $title = $validated['title'] ?? null;
+
+        if (empty($title)) {
+            preg_match('/^#\s+(.+)$/m', $validated['content'], $matches);
+            $title = $matches[1] ?? null;
+        }
+
+        if (empty($title)) {
+            $title = 'Scrap '.now()->format('Y-m-d H:i');
+        }
+
+        $content = $this->stripLeadingTitleHeading($validated['content'], $title);
+
+        $dateSuffix = now()->format('Ymd');
+        $base = Str::slug($title);
+        $base = $base !== '' ? "{$base}-{$dateSuffix}" : "scrap-{$dateSuffix}";
+        $slug = $base;
+        $counter = 2;
+
+        while (Post::where('namespace_id', $scrap->id)->where('slug', $slug)->exists()) {
+            $slug = $base.'-'.$counter++;
+        }
+
+        $post = Post::create([
+            'namespace_id' => $scrap->id,
+            'user_id' => $request->user()->id,
+            'title' => $title,
+            'slug' => $slug,
+            'content' => $content,
+            'is_draft' => true,
+        ]);
+
+        if ($page !== null) {
+            $page->delete();
+        }
+
+        return response()->json([
+            'url' => route('admin.posts.show', ['namespace' => $scrap, 'post' => $post->slug]),
+        ]);
+    }
+
+    private function stripLeadingTitleHeading(string $content, string $title): string
+    {
+        $trimmedContent = ltrim($content);
+        $escapedTitle = preg_quote(trim($title), '/');
+
+        $strippedContent = preg_replace(
+            "/^#\\s+{$escapedTitle}\\s*\\n+(.*)$/s",
+            '$1',
+            $trimmedContent,
+        );
+
+        if (! is_string($strippedContent)) {
+            return $content;
+        }
+
+        $strippedContent = ltrim($strippedContent);
+
+        return $strippedContent !== '' ? $strippedContent : $content;
+    }
+
+    private function authorizePage(Request $request, ThinkstreamPage $page): void
+    {
+        abort_unless($page->user_id === $request->user()->id, 403);
+    }
+
+    private function authorizeThought(Request $request, ThinkstreamPage $page, Thought $thought): void
+    {
+        $this->authorizePage($request, $page);
+
+        abort_if(
+            $thought->page_id !== $page->id || $thought->user_id !== $request->user()->id,
+            403,
+        );
+    }
+}

--- a/app/Models/PostNamespace.php
+++ b/app/Models/PostNamespace.php
@@ -27,6 +27,7 @@ class PostNamespace extends Model
         'description',
         'cover_image',
         'is_published',
+        'is_system',
         'post_order',
     ];
 
@@ -36,6 +37,7 @@ class PostNamespace extends Model
     {
         return [
             'is_published' => 'boolean',
+            'is_system' => 'boolean',
             'post_order' => 'array',
         ];
     }

--- a/app/Models/ThinkstreamPage.php
+++ b/app/Models/ThinkstreamPage.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\ThinkstreamPageFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ThinkstreamPage extends Model
+{
+    /** @use HasFactory<ThinkstreamPageFactory> */
+    use HasFactory;
+
+    protected $fillable = ['user_id', 'title'];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function thoughts(): HasMany
+    {
+        return $this->hasMany(Thought::class, 'page_id');
+    }
+}

--- a/app/Models/Thought.php
+++ b/app/Models/Thought.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\ThoughtFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Thought extends Model
+{
+    /** @use HasFactory<ThoughtFactory> */
+    use HasFactory;
+
+    protected $fillable = ['user_id', 'page_id', 'content'];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function page(): BelongsTo
+    {
+        return $this->belongsTo(ThinkstreamPage::class, 'page_id');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.3",
         "inertiajs/inertia-laravel": "^3.0",
-        "laravel/ai": "^0.6.3",
+        "laravel/ai": "^0.6.4",
         "laravel/fortify": "^1.34",
         "laravel/framework": "^13.0",
         "laravel/scout": "^10.25",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c786cfb0ec84dc29e3de20d8eec66577",
+    "content-hash": "9a81724d06f41a8002234c2be6d530f8",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1384,16 +1384,16 @@
         },
         {
             "name": "laravel/ai",
-            "version": "v0.6.3",
+            "version": "v0.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/ai.git",
-                "reference": "42cefc32ae2762b6fd1ec0b3c9272e894623b717"
+                "reference": "32296ee5fc7a6a1dd007a66f32abb15d877b434b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/ai/zipball/42cefc32ae2762b6fd1ec0b3c9272e894623b717",
-                "reference": "42cefc32ae2762b6fd1ec0b3c9272e894623b717",
+                "url": "https://api.github.com/repos/laravel/ai/zipball/32296ee5fc7a6a1dd007a66f32abb15d877b434b",
+                "reference": "32296ee5fc7a6a1dd007a66f32abb15d877b434b",
                 "shasum": ""
             },
             "require": {
@@ -1448,7 +1448,7 @@
                 "issues": "https://github.com/laravel/ai/issues",
                 "source": "https://github.com/laravel/ai"
             },
-            "time": "2026-04-22T21:16:19+00:00"
+            "time": "2026-04-28T05:42:50+00:00"
         },
         {
             "name": "laravel/fortify",

--- a/config/ai.php
+++ b/config/ai.php
@@ -58,12 +58,12 @@ return [
             'secret_access_key' => env('AWS_SECRET_ACCESS_KEY'),
             'session_token' => env('AWS_SESSION_TOKEN'),
             'use_default_credential_provider' => env('AWS_USE_DEFAULT_CREDENTIALS', true),
-            'models' => [
-                'text' => [
-                    'cheapest' => 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
-                    'smartest' => 'us.anthropic.claude-opus-4-6-v1',
-                ],
-            ],
+            // 'models' => [
+            //     'text' => [
+            //         'cheapest' => 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+            //         'smartest' => 'us.anthropic.claude-opus-4-6-v1',
+            //     ],
+            // ],
             'pricing' => [
                 'us.anthropic.claude-haiku-4-5-20251001-v1:0' => ['input_per_1m' => 0.25, 'output_per_1m' => 1.25],
                 'us.anthropic.claude-sonnet-4-5-20250929-v1:0' => ['input_per_1m' => 3.00, 'output_per_1m' => 15.00],

--- a/database/factories/ThinkstreamPageFactory.php
+++ b/database/factories/ThinkstreamPageFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ThinkstreamPage;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ThinkstreamPage>
+ */
+class ThinkstreamPageFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'title' => 'Canvas '.now()->format('Y-m-d H:i'),
+        ];
+    }
+}

--- a/database/factories/ThoughtFactory.php
+++ b/database/factories/ThoughtFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ThinkstreamPage;
+use App\Models\Thought;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Thought>
+ */
+class ThoughtFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'page_id' => ThinkstreamPage::factory(),
+            'content' => fake()->paragraph(),
+        ];
+    }
+}

--- a/database/migrations/2026_04_28_072243_create_thinkstream_pages_table.php
+++ b/database/migrations/2026_04_28_072243_create_thinkstream_pages_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('thinkstream_pages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('title');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('thinkstream_pages');
+    }
+};

--- a/database/migrations/2026_04_28_072244_create_thoughts_table.php
+++ b/database/migrations/2026_04_28_072244_create_thoughts_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('thoughts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('page_id')->constrained('thinkstream_pages')->cascadeOnDelete();
+            $table->text('content');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('thoughts');
+    }
+};

--- a/database/migrations/2026_04_29_000001_add_is_system_to_namespaces_table.php
+++ b/database/migrations/2026_04_29_000001_add_is_system_to_namespaces_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('namespaces', function (Blueprint $table) {
+            $table->boolean('is_system')->default(false)->after('is_published');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('namespaces', function (Blueprint $table) {
+            $table->dropColumn('is_system');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,6 +21,7 @@ class DatabaseSeeder extends Seeder
         ]);
 
         $this->call([
+            ScrapNamespaceSeeder::class,
             SyntaxSeeder::class,
             NamespaceBackupSeeder::class,
             // RoutingCheckSeeder::class, // for testing

--- a/database/seeders/ScrapNamespaceSeeder.php
+++ b/database/seeders/ScrapNamespaceSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\PostNamespace;
+use Illuminate\Database\Seeder;
+
+class ScrapNamespaceSeeder extends Seeder
+{
+    public function run(): void
+    {
+        PostNamespace::updateOrCreate(
+            ['full_path' => 'scrap'],
+            [
+                'slug' => 'scrap',
+                'name' => 'Scrap',
+                'full_path' => 'scrap',
+                'description' => 'Auto-saved drafts and refined thoughts.',
+                'is_published' => false,
+                'is_system' => true,
+            ]
+        );
+    }
+}

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -1,6 +1,7 @@
 import { Link, usePage } from '@inertiajs/react';
 import {
     Archive,
+    Brain,
     Globe,
     LayoutGrid,
     Menu,
@@ -8,6 +9,7 @@ import {
     Search,
 } from 'lucide-react';
 import { index as adminPostsIndex } from '@/actions/App/Http/Controllers/Admin/PostController';
+import { index as adminThinkstreamIndex } from '@/actions/App/Http/Controllers/Admin/ThinkstreamController';
 import AppLogo from '@/components/app-logo';
 import AppLogoIcon from '@/components/app-logo-icon';
 import { Breadcrumbs } from '@/components/breadcrumbs';
@@ -61,6 +63,11 @@ const mainNavItems: NavItem[] = [
         icon: NotebookPen,
     },
     {
+        title: 'Thinkstream',
+        href: adminThinkstreamIndex.url(),
+        icon: Brain,
+    },
+    {
         title: 'Backups',
         href: adminBackupsIndex.url(),
         icon: Archive,
@@ -84,12 +91,16 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
     const { currentUrl, isCurrentUrl, whenCurrentUrl } = useCurrentUrl();
     const postsIndexUrl = adminPostsIndex.url();
     const backupsIndexUrl = adminBackupsIndex.url();
+    const thinkstreamIndexUrl = adminThinkstreamIndex.url();
     const isPostsActive =
         currentUrl === postsIndexUrl ||
         currentUrl.startsWith(`${postsIndexUrl}/`);
     const isBackupsActive =
         currentUrl === backupsIndexUrl ||
         currentUrl.startsWith(`${backupsIndexUrl}/`);
+    const isThinkstreamActive =
+        currentUrl === thinkstreamIndexUrl ||
+        currentUrl.startsWith(`${thinkstreamIndexUrl}/`);
     const resolvedMainNavItems = mainNavItems.map((item) => ({
         ...item,
         isActive:
@@ -97,7 +108,9 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
                 ? isPostsActive
                 : item.href === backupsIndexUrl
                   ? isBackupsActive
-                  : item.isActive,
+                  : item.href === thinkstreamIndexUrl
+                    ? isThinkstreamActive
+                    : item.isActive,
     }));
 
     return (

--- a/resources/js/components/ui/textarea.tsx
+++ b/resources/js/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex w-full min-w-0 rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -42,6 +42,7 @@ type Namespace = {
     slug: string;
     full_path: string;
     name: string;
+    is_system: boolean;
 };
 
 type Post = {
@@ -514,143 +515,173 @@ export default function Edit({
                                                         type="hidden"
                                                         name="is_draft"
                                                         value={
-                                                            isDraft ? '1' : '0'
+                                                            namespace.is_system
+                                                                ? '1'
+                                                                : isDraft
+                                                                  ? '1'
+                                                                  : '0'
                                                         }
                                                     />
-                                                    <div className="flex items-center justify-between">
+                                                    {namespace.is_system ? (
                                                         <div className="flex items-center gap-3">
-                                                            <div
-                                                                className={cn(
-                                                                    'flex size-9 items-center justify-center rounded-lg',
-                                                                    isDraft
-                                                                        ? 'bg-amber-100 dark:bg-amber-900/30'
-                                                                        : 'bg-green-100 dark:bg-green-900/30',
-                                                                )}
-                                                            >
-                                                                {isDraft ? (
-                                                                    <EyeOff className="size-4 text-amber-700 dark:text-amber-400" />
-                                                                ) : (
-                                                                    <Eye className="size-4 text-green-700 dark:text-green-400" />
-                                                                )}
+                                                            <div className="flex size-9 items-center justify-center rounded-lg bg-violet-100 dark:bg-violet-900/30">
+                                                                <EyeOff className="size-4 text-violet-600 dark:text-violet-400" />
                                                             </div>
                                                             <div>
                                                                 <p className="text-sm font-medium">
-                                                                    {isDraft
-                                                                        ? 'Draft'
-                                                                        : 'Published'}
+                                                                    Always
+                                                                    private
                                                                 </p>
                                                                 <p className="text-xs text-muted-foreground">
-                                                                    {isDraft
-                                                                        ? 'Not visible'
-                                                                        : 'Visible to everyone'}
+                                                                    System
+                                                                    namespace —
+                                                                    cannot be
+                                                                    published
                                                                 </p>
                                                             </div>
                                                         </div>
-                                                        <Switch
-                                                            checked={!isDraft}
-                                                            onCheckedChange={(
-                                                                checked,
-                                                            ) => {
-                                                                setIsDraft(
-                                                                    !checked,
-                                                                );
-
-                                                                if (!checked) {
-                                                                    setRelativeTimeHint(
-                                                                        null,
-                                                                    );
-                                                                }
-                                                            }}
-                                                        />
-                                                    </div>
-
-                                                    {!isDraft && (
-                                                        <div className="mt-4 border-t border-border pt-4">
-                                                            <div className="flex items-center justify-between">
-                                                                <div className="flex items-center gap-2">
-                                                                    <Calendar className="size-4 text-muted-foreground" />
-                                                                    <Label className="text-sm font-normal">
-                                                                        Schedule
-                                                                    </Label>
-                                                                </div>
-                                                                <Switch
-                                                                    id="schedule_toggle"
-                                                                    checked={
-                                                                        scheduleEnabled
-                                                                    }
-                                                                    onCheckedChange={(
-                                                                        checked,
-                                                                    ) => {
-                                                                        setScheduleEnabled(
-                                                                            checked,
-                                                                        );
-
-                                                                        if (
-                                                                            !checked
-                                                                        ) {
-                                                                            setPublishedAt(
-                                                                                '',
-                                                                            );
-                                                                            setRelativeTimeHint(
-                                                                                null,
-                                                                            );
-                                                                        }
-                                                                    }}
-                                                                />
-                                                            </div>
-                                                            <input
-                                                                type="hidden"
-                                                                name="published_at"
-                                                                value={
-                                                                    scheduleEnabled
-                                                                        ? publishedAt
-                                                                        : ''
-                                                                }
-                                                            />
-                                                            {scheduleEnabled && (
-                                                                <div className="mt-3 space-y-2">
-                                                                    <Input
-                                                                        id="published_at"
-                                                                        type="datetime-local"
-                                                                        className="text-sm"
-                                                                        value={
-                                                                            publishedAt
-                                                                        }
-                                                                        onChange={(
-                                                                            e,
-                                                                        ) => {
-                                                                            const nextValue =
-                                                                                e
-                                                                                    .target
-                                                                                    .value;
-                                                                            setPublishedAt(
-                                                                                nextValue,
-                                                                            );
-                                                                            setRelativeTimeHint(
-                                                                                getRelativeTimeHint(
-                                                                                    nextValue,
-                                                                                    Date.now(),
-                                                                                ),
-                                                                            );
-                                                                        }}
-                                                                    />
-                                                                    {relativeTimeHint && (
-                                                                        <p className="text-xs text-muted-foreground">
-                                                                            {
-                                                                                relativeTimeHint
-                                                                            }
-                                                                        </p>
+                                                    ) : (
+                                                        <div className="flex items-center justify-between">
+                                                            <div className="flex items-center gap-3">
+                                                                <div
+                                                                    className={cn(
+                                                                        'flex size-9 items-center justify-center rounded-lg',
+                                                                        isDraft
+                                                                            ? 'bg-amber-100 dark:bg-amber-900/30'
+                                                                            : 'bg-green-100 dark:bg-green-900/30',
+                                                                    )}
+                                                                >
+                                                                    {isDraft ? (
+                                                                        <EyeOff className="size-4 text-amber-700 dark:text-amber-400" />
+                                                                    ) : (
+                                                                        <Eye className="size-4 text-green-700 dark:text-green-400" />
                                                                     )}
                                                                 </div>
-                                                            )}
-                                                            <InputError
-                                                                message={
-                                                                    errors.published_at
+                                                                <div>
+                                                                    <p className="text-sm font-medium">
+                                                                        {isDraft
+                                                                            ? 'Draft'
+                                                                            : 'Published'}
+                                                                    </p>
+                                                                    <p className="text-xs text-muted-foreground">
+                                                                        {isDraft
+                                                                            ? 'Not visible'
+                                                                            : 'Visible to everyone'}
+                                                                    </p>
+                                                                </div>
+                                                            </div>
+                                                            <Switch
+                                                                checked={
+                                                                    !isDraft
                                                                 }
+                                                                onCheckedChange={(
+                                                                    checked,
+                                                                ) => {
+                                                                    setIsDraft(
+                                                                        !checked,
+                                                                    );
+
+                                                                    if (
+                                                                        !checked
+                                                                    ) {
+                                                                        setRelativeTimeHint(
+                                                                            null,
+                                                                        );
+                                                                    }
+                                                                }}
                                                             />
                                                         </div>
                                                     )}
-                                                    {isDraft && (
+
+                                                    {!namespace.is_system &&
+                                                        !isDraft && (
+                                                            <div className="mt-4 border-t border-border pt-4">
+                                                                <div className="flex items-center justify-between">
+                                                                    <div className="flex items-center gap-2">
+                                                                        <Calendar className="size-4 text-muted-foreground" />
+                                                                        <Label className="text-sm font-normal">
+                                                                            Schedule
+                                                                        </Label>
+                                                                    </div>
+                                                                    <Switch
+                                                                        id="schedule_toggle"
+                                                                        checked={
+                                                                            scheduleEnabled
+                                                                        }
+                                                                        onCheckedChange={(
+                                                                            checked,
+                                                                        ) => {
+                                                                            setScheduleEnabled(
+                                                                                checked,
+                                                                            );
+
+                                                                            if (
+                                                                                !checked
+                                                                            ) {
+                                                                                setPublishedAt(
+                                                                                    '',
+                                                                                );
+                                                                                setRelativeTimeHint(
+                                                                                    null,
+                                                                                );
+                                                                            }
+                                                                        }}
+                                                                    />
+                                                                </div>
+                                                                <input
+                                                                    type="hidden"
+                                                                    name="published_at"
+                                                                    value={
+                                                                        scheduleEnabled
+                                                                            ? publishedAt
+                                                                            : ''
+                                                                    }
+                                                                />
+                                                                {scheduleEnabled && (
+                                                                    <div className="mt-3 space-y-2">
+                                                                        <Input
+                                                                            id="published_at"
+                                                                            type="datetime-local"
+                                                                            className="text-sm"
+                                                                            value={
+                                                                                publishedAt
+                                                                            }
+                                                                            onChange={(
+                                                                                e,
+                                                                            ) => {
+                                                                                const nextValue =
+                                                                                    e
+                                                                                        .target
+                                                                                        .value;
+                                                                                setPublishedAt(
+                                                                                    nextValue,
+                                                                                );
+                                                                                setRelativeTimeHint(
+                                                                                    getRelativeTimeHint(
+                                                                                        nextValue,
+                                                                                        Date.now(),
+                                                                                    ),
+                                                                                );
+                                                                            }}
+                                                                        />
+                                                                        {relativeTimeHint && (
+                                                                            <p className="text-xs text-muted-foreground">
+                                                                                {
+                                                                                    relativeTimeHint
+                                                                                }
+                                                                            </p>
+                                                                        )}
+                                                                    </div>
+                                                                )}
+                                                                <InputError
+                                                                    message={
+                                                                        errors.published_at
+                                                                    }
+                                                                />
+                                                            </div>
+                                                        )}
+                                                    {(namespace.is_system ||
+                                                        isDraft) && (
                                                         <input
                                                             type="hidden"
                                                             name="published_at"

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -30,6 +30,7 @@ import {
     Folder,
     FolderPlus,
     GripVertical,
+    Inbox,
     Pencil,
     Upload,
     Trash2,
@@ -61,6 +62,7 @@ type Namespace = {
     full_path: string;
     name: string;
     is_published: boolean;
+    is_system: boolean;
     posts_count: number;
     children: Namespace[];
 };
@@ -129,10 +131,12 @@ function summarizeNamespaces(namespaces: Namespace[]): NamespaceSummary {
                 childCount += 1;
             }
 
-            if (namespace.is_published) {
-                publishedCount += 1;
-            } else {
-                draftCount += 1;
+            if (!namespace.is_system) {
+                if (namespace.is_published) {
+                    publishedCount += 1;
+                } else {
+                    draftCount += 1;
+                }
             }
 
             visit(namespace.children, depth + 1);
@@ -163,6 +167,45 @@ function sortLabel(sort: Sort): string {
     const direction = sort.direction === 'asc' ? 'ascending' : 'descending';
 
     return `${label}, ${direction}`;
+}
+
+function SystemRow({ namespace }: { namespace: Namespace }) {
+    return (
+        <tr className="border-b bg-violet-50/50 dark:bg-violet-950/10">
+            <td className="w-8 px-2 py-3" />
+            <td className="px-4 py-3 font-medium">
+                <div className="flex items-center gap-1.5">
+                    <Inbox className="size-3.5 shrink-0 text-violet-500" />
+                    <Link
+                        href={namespaceRoute.url(namespace.id)}
+                        className="text-primary hover:underline"
+                    >
+                        {namespace.name}
+                    </Link>
+                </div>
+            </td>
+            <td className="px-4 py-3 text-muted-foreground">
+                /{namespace.slug}
+            </td>
+            <td className="px-4 py-3">
+                <span className="inline-flex items-center gap-1 rounded-full bg-violet-100 px-2 py-0.5 text-xs font-medium text-violet-700 dark:bg-violet-900/30 dark:text-violet-400">
+                    <Inbox className="size-3" />
+                    System
+                </span>
+            </td>
+            <td className="px-4 py-3 text-muted-foreground">
+                {namespace.posts_count}
+            </td>
+            <td className="px-4 py-3 text-right">
+                <Button variant="outline" size="sm" asChild>
+                    <Link href={namespaceRoute.url(namespace.id)}>
+                        <Folder className="size-4" />
+                        Browse
+                    </Link>
+                </Button>
+            </td>
+        </tr>
+    );
 }
 
 function DeleteNamespaceDialog({ namespace }: { namespace: Namespace }) {
@@ -1139,6 +1182,9 @@ export default function Index({
     const [reorderMode, setReorderMode] = useState(false);
     const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
 
+    const systemNamespaces = namespaces.filter((ns) => ns.is_system);
+    const regularNamespaces = namespaces.filter((ns) => !ns.is_system);
+
     function toggleExpand(id: number) {
         setExpandedIds((prev) => {
             const next = new Set(prev);
@@ -1171,11 +1217,13 @@ export default function Index({
             return;
         }
 
-        const oldIndex = namespaces.findIndex((ns) => ns.id === active.id);
-        const newIndex = namespaces.findIndex((ns) => ns.id === over.id);
-        const reordered = arrayMove(namespaces, oldIndex, newIndex);
+        const oldIndex = regularNamespaces.findIndex(
+            (ns) => ns.id === active.id,
+        );
+        const newIndex = regularNamespaces.findIndex((ns) => ns.id === over.id);
+        const reordered = arrayMove(regularNamespaces, oldIndex, newIndex);
 
-        setNamespaces(reordered);
+        setNamespaces([...systemNamespaces, ...reordered]);
         router.patch(
             NamespaceController.reorder.url(),
             { ids: reordered.map((ns) => ns.id) },
@@ -1317,15 +1365,21 @@ export default function Index({
                                         </tr>
                                     </thead>
                                     <tbody>
+                                        {systemNamespaces.map((ns) => (
+                                            <SystemRow
+                                                key={ns.id}
+                                                namespace={ns}
+                                            />
+                                        ))}
                                         <SortableContext
-                                            items={namespaces.map(
+                                            items={regularNamespaces.map(
                                                 (ns) => ns.id,
                                             )}
                                             strategy={
                                                 verticalListSortingStrategy
                                             }
                                         >
-                                            {namespaces.flatMap((ns) => [
+                                            {regularNamespaces.flatMap((ns) => [
                                                 <SortableRow
                                                     key={ns.id}
                                                     namespace={ns}

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -49,6 +49,7 @@ import {
     destroySyncFile,
     edit,
     index,
+    moveToNamespace,
     namespace as namespaceRoute,
     revisions,
     show,
@@ -127,6 +128,13 @@ type Namespace = {
     name: string;
     slug: string;
     full_path: string;
+    is_system: boolean;
+};
+
+type MoveNamespaceOption = {
+    id: number;
+    name: string;
+    full_path: string;
 };
 
 type Post = {
@@ -149,10 +157,12 @@ type Post = {
 };
 
 export default function Show({
+    availableMoveNamespaces,
     namespace,
     navRoot,
     post,
 }: {
+    availableMoveNamespaces: MoveNamespaceOption[];
     namespace: Namespace;
     navRoot: ContentNavNode;
     post: Post;
@@ -786,6 +796,128 @@ export default function Show({
                                                 <History className="size-4 text-muted-foreground" />
                                                 <span>Revisions</span>
                                             </Link>
+                                            {namespace.is_system &&
+                                                availableMoveNamespaces.length >
+                                                    0 && (
+                                                    <Dialog>
+                                                        <DialogTrigger asChild>
+                                                            <button
+                                                                type="button"
+                                                                className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors hover:bg-accent"
+                                                            >
+                                                                <FolderSync className="size-4 text-muted-foreground" />
+                                                                <span>
+                                                                    Move to
+                                                                    Namespace
+                                                                </span>
+                                                            </button>
+                                                        </DialogTrigger>
+                                                        <DialogContent>
+                                                            <DialogTitle>
+                                                                Move &ldquo;
+                                                                {post.title}
+                                                                &rdquo;
+                                                            </DialogTitle>
+                                                            <DialogDescription>
+                                                                Move this post
+                                                                into an existing
+                                                                namespace. If
+                                                                the slug is
+                                                                already taken
+                                                                there, a numeric
+                                                                suffix will be
+                                                                added
+                                                                automatically.
+                                                            </DialogDescription>
+                                                            <Form
+                                                                action={moveToNamespace(
+                                                                    {
+                                                                        namespace:
+                                                                            namespace.id,
+                                                                        post: post.slug,
+                                                                    },
+                                                                )}
+                                                                className="space-y-4"
+                                                            >
+                                                                {({
+                                                                    processing,
+                                                                    errors,
+                                                                }) => (
+                                                                    <>
+                                                                        <div className="space-y-2">
+                                                                            <label
+                                                                                htmlFor="target_namespace_id"
+                                                                                className="text-sm font-medium"
+                                                                            >
+                                                                                Target
+                                                                                namespace
+                                                                            </label>
+                                                                            <select
+                                                                                id="target_namespace_id"
+                                                                                name="target_namespace_id"
+                                                                                defaultValue=""
+                                                                                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                                                                            >
+                                                                                <option
+                                                                                    value=""
+                                                                                    disabled
+                                                                                >
+                                                                                    Choose
+                                                                                    a
+                                                                                    namespace
+                                                                                </option>
+                                                                                {availableMoveNamespaces.map(
+                                                                                    (
+                                                                                        targetNamespace,
+                                                                                    ) => (
+                                                                                        <option
+                                                                                            key={
+                                                                                                targetNamespace.id
+                                                                                            }
+                                                                                            value={
+                                                                                                targetNamespace.id
+                                                                                            }
+                                                                                        >
+                                                                                            {
+                                                                                                targetNamespace.full_path
+                                                                                            }
+                                                                                        </option>
+                                                                                    ),
+                                                                                )}
+                                                                            </select>
+                                                                            {errors.target_namespace_id && (
+                                                                                <p className="text-sm text-destructive">
+                                                                                    {
+                                                                                        errors.target_namespace_id
+                                                                                    }
+                                                                                </p>
+                                                                            )}
+                                                                        </div>
+                                                                        <DialogFooter className="gap-2">
+                                                                            <DialogClose
+                                                                                asChild
+                                                                            >
+                                                                                <Button variant="secondary">
+                                                                                    Cancel
+                                                                                </Button>
+                                                                            </DialogClose>
+                                                                            <Button
+                                                                                disabled={
+                                                                                    processing
+                                                                                }
+                                                                                asChild
+                                                                            >
+                                                                                <button type="submit">
+                                                                                    Move
+                                                                                </button>
+                                                                            </Button>
+                                                                        </DialogFooter>
+                                                                    </>
+                                                                )}
+                                                            </Form>
+                                                        </DialogContent>
+                                                    </Dialog>
+                                                )}
                                             <Dialog>
                                                 <DialogTrigger asChild>
                                                     <button

--- a/resources/js/pages/admin/thinkstream/index.tsx
+++ b/resources/js/pages/admin/thinkstream/index.tsx
@@ -1,0 +1,170 @@
+import { Head, Link, router, setLayoutProps } from '@inertiajs/react';
+import { Brain, MessagesSquare, Plus, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { timeAgo } from '@/lib/time';
+import { dashboard } from '@/routes';
+import {
+    destroyPage as thinkstreamDestroyPage,
+    index as thinkstreamIndex,
+    show as thinkstreamShow,
+    storePage as thinkstreamStorePage,
+} from '@/actions/App/Http/Controllers/Admin/ThinkstreamController';
+
+type Page = {
+    id: number;
+    title: string;
+    created_at: string;
+    thoughts_count: number;
+};
+
+export default function ThinkstreamIndex({ pages }: { pages: Page[] }) {
+    const [creating, setCreating] = useState(false);
+
+    setLayoutProps({
+        breadcrumbs: [
+            { title: 'Dashboard', href: dashboard() },
+            { title: 'Thinkstream', href: thinkstreamIndex.url() },
+        ],
+    });
+
+    function createCanvas() {
+        setCreating(true);
+        router.post(
+            thinkstreamStorePage.url(),
+            {},
+            {
+                onFinish: () => setCreating(false),
+            },
+        );
+    }
+
+    return (
+        <>
+            <Head title="Thinkstream" />
+            <div className="p-4">
+                <div className="mb-6 flex items-center justify-between">
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <Brain className="size-4" />
+                        {pages.length} canvas{pages.length !== 1 ? 'es' : ''}
+                    </div>
+                    <Button
+                        size="sm"
+                        disabled={creating}
+                        onClick={createCanvas}
+                    >
+                        <Plus className="size-4" />
+                        New Canvas
+                    </Button>
+                </div>
+
+                {pages.length === 0 ? (
+                    <div className="flex flex-col items-center gap-4 py-24 text-muted-foreground">
+                        <Brain className="size-12 opacity-20" />
+                        <p className="text-sm">No canvases yet.</p>
+                        <Button
+                            size="sm"
+                            disabled={creating}
+                            onClick={createCanvas}
+                        >
+                            <Plus className="size-4" />
+                            Create your first canvas
+                        </Button>
+                    </div>
+                ) : (
+                    <div className="space-y-3">
+                        {pages.map((page) => (
+                            <Card
+                                key={page.id}
+                                className="border-border/60 shadow-none transition-colors hover:border-border"
+                            >
+                                <CardContent className="flex items-center gap-4 px-4 py-3">
+                                    <Link
+                                        href={thinkstreamShow.url(page.id)}
+                                        className="min-w-0 flex-1"
+                                    >
+                                        <p className="truncate font-medium">
+                                            {page.title}
+                                        </p>
+                                        <p className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
+                                            <span className="flex items-center gap-1">
+                                                <MessagesSquare className="size-3" />
+                                                {page.thoughts_count} thought
+                                                {page.thoughts_count !== 1
+                                                    ? 's'
+                                                    : ''}
+                                            </span>
+                                            <span>·</span>
+                                            <span
+                                                title={new Date(
+                                                    page.created_at,
+                                                ).toLocaleString()}
+                                            >
+                                                {timeAgo(page.created_at)}
+                                            </span>
+                                        </p>
+                                    </Link>
+                                    <Dialog>
+                                        <DialogTrigger asChild>
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                className="size-8 shrink-0 text-muted-foreground hover:text-destructive"
+                                            >
+                                                <Trash2 className="size-4" />
+                                            </Button>
+                                        </DialogTrigger>
+                                        <DialogContent>
+                                            <DialogTitle>
+                                                Delete canvas?
+                                            </DialogTitle>
+                                            <DialogDescription>
+                                                This will permanently delete
+                                                &ldquo;{page.title}&rdquo; and
+                                                all {page.thoughts_count}{' '}
+                                                thought
+                                                {page.thoughts_count !== 1
+                                                    ? 's'
+                                                    : ''}{' '}
+                                                in it. This cannot be undone.
+                                            </DialogDescription>
+                                            <DialogFooter className="gap-2">
+                                                <DialogClose asChild>
+                                                    <Button variant="secondary">
+                                                        Cancel
+                                                    </Button>
+                                                </DialogClose>
+                                                <Button
+                                                    variant="destructive"
+                                                    onClick={() =>
+                                                        router.delete(
+                                                            thinkstreamDestroyPage.url(
+                                                                page.id,
+                                                            ),
+                                                        )
+                                                    }
+                                                >
+                                                    Delete
+                                                </Button>
+                                            </DialogFooter>
+                                        </DialogContent>
+                                    </Dialog>
+                                </CardContent>
+                            </Card>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </>
+    );
+}

--- a/resources/js/pages/admin/thinkstream/show.tsx
+++ b/resources/js/pages/admin/thinkstream/show.tsx
@@ -1,0 +1,758 @@
+import {
+    Head,
+    router,
+    setLayoutProps,
+    useForm,
+    useHttp,
+} from '@inertiajs/react';
+import {
+    BookmarkPlus,
+    Brain,
+    ExternalLink,
+    ListChecks,
+    PanelRightClose,
+    PanelRightOpen,
+    Pencil,
+    Send,
+    Sparkles,
+    Trash2,
+    Wand2,
+    X,
+} from 'lucide-react';
+import MarkdownContent from '@/components/markdown-content';
+import { createMarkdownComponents } from '@/lib/markdown-components';
+import { useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Spinner } from '@/components/ui/spinner';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+import { timeAgo } from '@/lib/time';
+import { dashboard } from '@/routes';
+import {
+    destroyMany as thinkstreamDestroyMany,
+    index as thinkstreamIndex,
+    refineTitle as thinkstreamRefineTitle,
+    saveToScrap as thinkstreamSaveToScrap,
+    show as thinkstreamShow,
+    store as thinkstreamStore,
+    structureThoughts as thinkstreamStructureThoughts,
+    update as thinkstreamUpdate,
+} from '@/actions/App/Http/Controllers/Admin/ThinkstreamController';
+
+const thoughtMarkdownComponents = createMarkdownComponents();
+
+type Thought = {
+    id: number;
+    content: string;
+    created_at: string;
+    user: { id: number; name: string };
+};
+
+type Page = {
+    id: number;
+    title: string;
+    created_at: string;
+};
+
+function hasThoughtsProp(props: unknown): props is { thoughts: Thought[] } {
+    return (
+        typeof props === 'object' &&
+        props !== null &&
+        'thoughts' in props &&
+        Array.isArray(props.thoughts)
+    );
+}
+
+export default function ThinkstreamShow({
+    page,
+    thoughts,
+    aiEnabled,
+}: {
+    page: Page;
+    thoughts: Thought[];
+    aiEnabled: boolean;
+}) {
+    const [pageTitle, setPageTitle] = useState(page.title);
+    const { data, setData, post, processing, errors, reset } = useForm({
+        content: '',
+    });
+    const [deleteProcessing, setDeleteProcessing] = useState(false);
+    const [selected, setSelected] = useState<Set<number>>(new Set());
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+    const [editMode, setEditMode] = useState(false);
+    const [editingId, setEditingId] = useState<number | null>(null);
+    const [editingContent, setEditingContent] = useState('');
+    const [editSaving, setEditSaving] = useState(false);
+    const [structuredTitle, setStructuredTitle] = useState<string | null>(null);
+    const [structuredContent, setStructuredContent] = useState<string | null>(
+        null,
+    );
+    const [structuredMessage, setStructuredMessage] = useState<string | null>(
+        null,
+    );
+    const [structuredExpanded, setStructuredExpanded] = useState(false);
+    const [scrapUrl, setScrapUrl] = useState<string | null>(null);
+    const [deleteCanvasOnSave, setDeleteCanvasOnSave] = useState(false);
+
+    const structureIdsRef = useRef<number[]>([]);
+    const {
+        post: structurePost,
+        processing: structuring,
+        transform: transformStructure,
+    } = useHttp({ ids: [] as number[] });
+    transformStructure(() => ({ ids: structureIdsRef.current }));
+
+    const { post: refineTitlePost, processing: refiningTitle } = useHttp({});
+
+    const saveContentRef = useRef('');
+    const saveTitleRef = useRef('');
+    const saveDeleteCanvasRef = useRef(false);
+    const savePageIdRef = useRef<number | null>(null);
+    const {
+        post: savePost,
+        processing: saving,
+        transform: transformSave,
+    } = useHttp({
+        content: '',
+        title: '',
+        delete_canvas: false,
+        page_id: null as number | null,
+    });
+    transformSave(() => ({
+        content: saveContentRef.current,
+        title: saveTitleRef.current,
+        delete_canvas: saveDeleteCanvasRef.current,
+        page_id: savePageIdRef.current,
+    }));
+
+    setLayoutProps({
+        breadcrumbs: [
+            { title: 'Dashboard', href: dashboard() },
+            { title: 'Thinkstream', href: thinkstreamIndex.url() },
+            { title: pageTitle, href: thinkstreamShow.url(page.id) },
+        ],
+    });
+
+    function refineTitle() {
+        refineTitlePost(thinkstreamRefineTitle.url(page.id), {
+            onSuccess: (response) => {
+                const { title } = response as { title: string };
+                setPageTitle(title);
+            },
+        });
+    }
+
+    function submit(e: React.FormEvent) {
+        e.preventDefault();
+        post(thinkstreamStore.url(page.id), {
+            preserveScroll: true,
+            onSuccess: () => reset('content'),
+        });
+    }
+
+    function bulkDelete() {
+        setDeleteProcessing(true);
+        router.post(
+            thinkstreamDestroyMany.url(page.id),
+            { ids: Array.from(selected) },
+            {
+                preserveScroll: true,
+                onSuccess: () => {
+                    setSelected(new Set());
+                    setDeleteDialogOpen(false);
+                },
+                onFinish: () => setDeleteProcessing(false),
+            },
+        );
+    }
+
+    function structureThoughts() {
+        structureIdsRef.current = Array.from(selected);
+        structurePost(thinkstreamStructureThoughts.url(page.id), {
+            onSuccess: (response) => {
+                const { title, content, message } = response as {
+                    title: string;
+                    content: string;
+                    message: string;
+                };
+                setStructuredTitle(title);
+                setStructuredContent(content);
+                setStructuredMessage(message ?? null);
+                setScrapUrl(null);
+            },
+        });
+    }
+
+    function saveToScrap() {
+        if (!structuredContent) {
+            return;
+        }
+        saveContentRef.current = structuredContent;
+        saveTitleRef.current = structuredTitle ?? pageTitle;
+        saveDeleteCanvasRef.current = deleteCanvasOnSave;
+        savePageIdRef.current = deleteCanvasOnSave ? page.id : null;
+        savePost(thinkstreamSaveToScrap.url(), {
+            onSuccess: (response) => {
+                const { url } = response as { url: string };
+                setScrapUrl(url);
+                if (saveDeleteCanvasRef.current) {
+                    router.visit(url);
+                }
+            },
+        });
+    }
+
+    function toggleSelected(id: number) {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            next.has(id) ? next.delete(id) : next.add(id);
+            return next;
+        });
+    }
+
+    function toggleSelectAll() {
+        setSelected((prev) => {
+            if (prev.size === thoughts.length) {
+                return new Set();
+            }
+
+            return new Set(thoughts.map((thought) => thought.id));
+        });
+    }
+
+    function exitEditMode() {
+        setEditMode(false);
+        setSelected(new Set());
+        setEditingId(null);
+    }
+
+    function startEditing(thought: Thought, e: React.MouseEvent) {
+        e.stopPropagation();
+        setEditingId(thought.id);
+        setEditingContent(thought.content);
+    }
+
+    function saveEdit(thought: Thought) {
+        const contentToSave = editingContent;
+
+        setEditSaving(true);
+        setEditingId(null);
+
+        router.patch(
+            thinkstreamUpdate.url([page.id, thought.id]),
+            { content: contentToSave },
+            {
+                optimistic: (props) => {
+                    if (!hasThoughtsProp(props)) {
+                        return {};
+                    }
+
+                    return {
+                        thoughts: props.thoughts.map((currentThought) =>
+                            currentThought.id === thought.id
+                                ? { ...currentThought, content: contentToSave }
+                                : currentThought,
+                        ),
+                    };
+                },
+                preserveScroll: true,
+                onError: () => {
+                    setEditingId(thought.id);
+                    setEditingContent(contentToSave);
+                },
+                onFinish: () => setEditSaving(false),
+            },
+        );
+    }
+
+    return (
+        <>
+            <Head title={pageTitle} />
+            <div
+                className={cn(
+                    'flex min-h-0 gap-0',
+                    structuredContent ? 'items-start' : '',
+                )}
+            >
+                {/* Left: main content */}
+                <div
+                    className={cn(
+                        'space-y-6 p-4',
+                        structuredContent
+                            ? structuredExpanded
+                                ? 'hidden'
+                                : 'w-1/2'
+                            : 'w-full',
+                    )}
+                >
+                    <Card className="border-border/60 shadow-none">
+                        <CardContent className="flex flex-col gap-4 p-4 sm:flex-row sm:items-start sm:justify-between">
+                            <div className="space-y-1">
+                                <p className="text-xs font-medium tracking-[0.18em] text-muted-foreground uppercase">
+                                    Canvas
+                                </p>
+                                <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+                                    {pageTitle}
+                                </h1>
+                            </div>
+                            <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+                                {thoughts.length > 0 && (
+                                    <Button
+                                        type="button"
+                                        variant={
+                                            editMode ? 'secondary' : 'default'
+                                        }
+                                        className="shrink-0"
+                                        onClick={
+                                            editMode
+                                                ? exitEditMode
+                                                : () => setEditMode(true)
+                                        }
+                                    >
+                                        <ListChecks className="size-4" />
+                                        {editMode
+                                            ? 'Done Selecting'
+                                            : 'Select Thoughts'}
+                                    </Button>
+                                )}
+                                {aiEnabled && (
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        className="shrink-0"
+                                        disabled={
+                                            refiningTitle ||
+                                            thoughts.length === 0
+                                        }
+                                        onClick={refineTitle}
+                                    >
+                                        <Sparkles className="size-4" />
+                                        {refiningTitle
+                                            ? 'Polishing Title…'
+                                            : 'Polish Title with AI'}
+                                    </Button>
+                                )}
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {thoughts.length > 0 && editMode && (
+                        <div className="rounded-xl border border-primary/20 bg-primary/5 px-4 py-3">
+                            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                                <div className="space-y-1">
+                                    <div className="flex items-center gap-2">
+                                        <p className="text-sm font-medium">
+                                            Selection Mode
+                                        </p>
+                                        <span className="rounded-full bg-background px-2 py-0.5 text-xs text-muted-foreground">
+                                            {selected.size} selected
+                                        </span>
+                                    </div>
+                                    <p className="text-sm text-muted-foreground">
+                                        Choose thoughts to refine into Scrap or
+                                        delete in bulk.
+                                    </p>
+                                </div>
+                                <div className="flex flex-wrap items-center gap-2">
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        variant="secondary"
+                                        onClick={toggleSelectAll}
+                                    >
+                                        {selected.size === thoughts.length
+                                            ? 'Clear Selection'
+                                            : 'Select All'}
+                                    </Button>
+                                    {aiEnabled && (
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            disabled={
+                                                structuring ||
+                                                selected.size === 0
+                                            }
+                                            onClick={structureThoughts}
+                                        >
+                                            {structuring ? (
+                                                <Spinner className="size-4" />
+                                            ) : (
+                                                <Wand2 className="size-4" />
+                                            )}
+                                            {structuring
+                                                ? 'Refining for Scrap…'
+                                                : 'Refine for Scrap'}
+                                        </Button>
+                                    )}
+                                    <Dialog
+                                        open={deleteDialogOpen}
+                                        onOpenChange={setDeleteDialogOpen}
+                                    >
+                                        <DialogTrigger asChild>
+                                            <Button
+                                                variant="destructive"
+                                                size="sm"
+                                                disabled={selected.size === 0}
+                                            >
+                                                <Trash2 className="size-4" />
+                                                Delete
+                                            </Button>
+                                        </DialogTrigger>
+                                        <DialogContent>
+                                            <DialogTitle>
+                                                Delete {selected.size} thought
+                                                {selected.size !== 1 ? 's' : ''}
+                                                ?
+                                            </DialogTitle>
+                                            <DialogDescription>
+                                                This cannot be undone.
+                                            </DialogDescription>
+                                            <DialogFooter className="gap-2">
+                                                <DialogClose asChild>
+                                                    <Button variant="secondary">
+                                                        Cancel
+                                                    </Button>
+                                                </DialogClose>
+                                                <Button
+                                                    variant="destructive"
+                                                    disabled={deleteProcessing}
+                                                    onClick={bulkDelete}
+                                                >
+                                                    Delete
+                                                </Button>
+                                            </DialogFooter>
+                                        </DialogContent>
+                                    </Dialog>
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        variant="ghost"
+                                        onClick={exitEditMode}
+                                    >
+                                        Done
+                                    </Button>
+                                </div>
+                            </div>
+                        </div>
+                    )}
+
+                    {thoughts.length === 0 ? (
+                        <div className="flex flex-col items-center gap-3 py-16 text-muted-foreground">
+                            <Brain className="size-10 opacity-30" />
+                            <p className="text-sm">No thoughts yet.</p>
+                        </div>
+                    ) : (
+                        <div className="space-y-3">
+                            {thoughts.map((thought) => {
+                                const isSelected = selected.has(thought.id);
+                                const isEditing = editingId === thought.id;
+                                return (
+                                    <Card
+                                        key={thought.id}
+                                        onClick={() => {
+                                            if (editMode && !isEditing) {
+                                                toggleSelected(thought.id);
+                                            }
+                                        }}
+                                        className={cn(
+                                            'border shadow-none transition-colors',
+                                            editMode &&
+                                                !isEditing &&
+                                                'cursor-pointer',
+                                            isSelected
+                                                ? 'border-primary/50 bg-primary/5'
+                                                : 'border-border/60 hover:border-border',
+                                        )}
+                                    >
+                                        <CardContent
+                                            className={cn(
+                                                'flex items-start gap-3 px-4',
+                                                isEditing
+                                                    ? 'py-6 sm:px-5 sm:py-8'
+                                                    : 'py-3',
+                                            )}
+                                        >
+                                            {editMode && (
+                                                <Checkbox
+                                                    checked={isSelected}
+                                                    onCheckedChange={() =>
+                                                        toggleSelected(
+                                                            thought.id,
+                                                        )
+                                                    }
+                                                    onClick={(e) =>
+                                                        e.stopPropagation()
+                                                    }
+                                                    className="mt-0.5 shrink-0"
+                                                />
+                                            )}
+                                            <div className="min-w-0 flex-1">
+                                                {isEditing ? (
+                                                    <div
+                                                        className="space-y-4"
+                                                        onClick={(e) =>
+                                                            e.stopPropagation()
+                                                        }
+                                                    >
+                                                        <Textarea
+                                                            value={
+                                                                editingContent
+                                                            }
+                                                            onChange={(e) =>
+                                                                setEditingContent(
+                                                                    e.target
+                                                                        .value,
+                                                                )
+                                                            }
+                                                            rows={12}
+                                                            className="min-h-[24rem] resize-none px-4 py-3 text-[15px] leading-7 sm:min-h-[30rem]"
+                                                            autoFocus
+                                                        />
+                                                        <div className="flex justify-end gap-2 pt-2">
+                                                            <Button
+                                                                size="sm"
+                                                                variant="secondary"
+                                                                onClick={() =>
+                                                                    setEditingId(
+                                                                        null,
+                                                                    )
+                                                                }
+                                                            >
+                                                                Cancel
+                                                            </Button>
+                                                            <Button
+                                                                size="sm"
+                                                                disabled={
+                                                                    editSaving
+                                                                }
+                                                                onClick={() =>
+                                                                    saveEdit(
+                                                                        thought,
+                                                                    )
+                                                                }
+                                                            >
+                                                                Save
+                                                            </Button>
+                                                        </div>
+                                                    </div>
+                                                ) : (
+                                                    <>
+                                                        {!editMode && (
+                                                            <div className="mb-3 flex justify-end">
+                                                                <Button
+                                                                    type="button"
+                                                                    size="sm"
+                                                                    variant="outline"
+                                                                    className="h-7 px-2.5 text-xs"
+                                                                    onClick={(
+                                                                        e,
+                                                                    ) =>
+                                                                        startEditing(
+                                                                            thought,
+                                                                            e,
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    <Pencil className="size-3" />
+                                                                    Edit
+                                                                </Button>
+                                                            </div>
+                                                        )}
+                                                        <div className="prose prose-sm max-w-none prose-neutral dark:prose-invert">
+                                                            <MarkdownContent
+                                                                content={
+                                                                    thought.content
+                                                                }
+                                                                components={
+                                                                    thoughtMarkdownComponents
+                                                                }
+                                                            />
+                                                        </div>
+                                                        <p className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                                                            <span>
+                                                                {
+                                                                    thought.user
+                                                                        .name
+                                                                }{' '}
+                                                                ·{' '}
+                                                                <span
+                                                                    title={new Date(
+                                                                        thought.created_at,
+                                                                    ).toLocaleString()}
+                                                                >
+                                                                    {timeAgo(
+                                                                        thought.created_at,
+                                                                    )}
+                                                                </span>
+                                                            </span>
+                                                        </p>
+                                                    </>
+                                                )}
+                                            </div>
+                                        </CardContent>
+                                    </Card>
+                                );
+                            })}
+                        </div>
+                    )}
+
+                    <Card className="border-border/60 shadow-none">
+                        <CardContent className="p-4">
+                            <form onSubmit={submit} className="space-y-3">
+                                <Textarea
+                                    value={data.content}
+                                    onChange={(e) =>
+                                        setData('content', e.target.value)
+                                    }
+                                    placeholder="Add the next thought..."
+                                    rows={6}
+                                    className="resize-none"
+                                />
+                                {errors.content && (
+                                    <p className="text-sm text-destructive">
+                                        {errors.content}
+                                    </p>
+                                )}
+                                <div className="flex justify-end">
+                                    <Button
+                                        type="submit"
+                                        size="sm"
+                                        disabled={processing}
+                                    >
+                                        <Send className="size-4" />
+                                        Post
+                                    </Button>
+                                </div>
+                            </form>
+                        </CardContent>
+                    </Card>
+                </div>
+
+                {/* Right: structured document panel */}
+                {structuredContent && (
+                    <div
+                        className={cn(
+                            'p-4',
+                            structuredExpanded
+                                ? 'w-full'
+                                : 'sticky top-0 w-1/2 border-l border-border/60',
+                        )}
+                    >
+                        <div className="mb-3 flex items-center justify-between">
+                            <div className="flex items-center gap-2 text-sm font-medium">
+                                <Sparkles className="size-4 text-primary" />
+                                Refined for Scrap
+                            </div>
+                            <div className="flex items-center gap-1">
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="size-7"
+                                    onClick={() =>
+                                        setStructuredExpanded(
+                                            (current) => !current,
+                                        )
+                                    }
+                                    title={
+                                        structuredExpanded
+                                            ? 'Collapse panel'
+                                            : 'Expand panel'
+                                    }
+                                    aria-label={
+                                        structuredExpanded
+                                            ? 'Collapse panel'
+                                            : 'Expand panel'
+                                    }
+                                >
+                                    {structuredExpanded ? (
+                                        <PanelRightClose className="size-4" />
+                                    ) : (
+                                        <PanelRightOpen className="size-4" />
+                                    )}
+                                </Button>
+                                {scrapUrl ? (
+                                    <a
+                                        href={scrapUrl}
+                                        className="flex items-center gap-1 text-xs text-primary hover:underline"
+                                    >
+                                        <ExternalLink className="size-3" />
+                                        View in Scrap
+                                    </a>
+                                ) : (
+                                    <div className="flex items-center gap-2">
+                                        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                                            <Checkbox
+                                                checked={deleteCanvasOnSave}
+                                                onCheckedChange={(checked) =>
+                                                    setDeleteCanvasOnSave(
+                                                        checked === true,
+                                                    )
+                                                }
+                                            />
+                                            <span>
+                                                Delete canvas after saving
+                                            </span>
+                                        </label>
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            className="h-7 text-xs"
+                                            disabled={saving}
+                                            onClick={saveToScrap}
+                                        >
+                                            <BookmarkPlus className="size-3.5" />
+                                            {saving
+                                                ? 'Saving…'
+                                                : 'Save to Scrap'}
+                                        </Button>
+                                    </div>
+                                )}
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="size-7"
+                                    onClick={() => {
+                                        setStructuredExpanded(false);
+                                        setStructuredTitle(null);
+                                        setStructuredContent(null);
+                                        setStructuredMessage(null);
+                                        setScrapUrl(null);
+                                    }}
+                                >
+                                    <X className="size-4" />
+                                </Button>
+                            </div>
+                        </div>
+                        {structuredTitle && (
+                            <p className="mb-2 text-sm font-medium">
+                                {structuredTitle}
+                            </p>
+                        )}
+                        {structuredMessage && (
+                            <p className="mb-3 text-xs text-muted-foreground">
+                                {structuredMessage}
+                            </p>
+                        )}
+                        <div className="prose prose-sm max-w-none prose-neutral dark:prose-invert">
+                            <MarkdownContent
+                                content={structuredContent}
+                                components={thoughtMarkdownComponents}
+                            />
+                        </div>
+                    </div>
+                )}
+            </div>
+        </>
+    );
+}

--- a/resources/js/pages/admin/thinkstream/show.tsx
+++ b/resources/js/pages/admin/thinkstream/show.tsx
@@ -19,26 +19,7 @@ import {
     Wand2,
     X,
 } from 'lucide-react';
-import MarkdownContent from '@/components/markdown-content';
-import { createMarkdownComponents } from '@/lib/markdown-components';
-import { useRef, useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Spinner } from '@/components/ui/spinner';
-import {
-    Dialog,
-    DialogClose,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogTitle,
-    DialogTrigger,
-} from '@/components/ui/dialog';
-import { Textarea } from '@/components/ui/textarea';
-import { cn } from '@/lib/utils';
-import { timeAgo } from '@/lib/time';
-import { dashboard } from '@/routes';
+import { useState } from 'react';
 import {
     destroyMany as thinkstreamDestroyMany,
     index as thinkstreamIndex,
@@ -49,6 +30,25 @@ import {
     structureThoughts as thinkstreamStructureThoughts,
     update as thinkstreamUpdate,
 } from '@/actions/App/Http/Controllers/Admin/ThinkstreamController';
+import MarkdownContent from '@/components/markdown-content';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { Spinner } from '@/components/ui/spinner';
+import { Textarea } from '@/components/ui/textarea';
+import { createMarkdownComponents } from '@/lib/markdown-components';
+import { timeAgo } from '@/lib/time';
+import { cn } from '@/lib/utils';
+import { dashboard } from '@/routes';
 
 const thoughtMarkdownComponents = createMarkdownComponents();
 
@@ -105,36 +105,24 @@ export default function ThinkstreamShow({
     const [scrapUrl, setScrapUrl] = useState<string | null>(null);
     const [deleteCanvasOnSave, setDeleteCanvasOnSave] = useState(false);
 
-    const structureIdsRef = useRef<number[]>([]);
     const {
+        setData: setStructureData,
         post: structurePost,
         processing: structuring,
-        transform: transformStructure,
     } = useHttp({ ids: [] as number[] });
-    transformStructure(() => ({ ids: structureIdsRef.current }));
 
     const { post: refineTitlePost, processing: refiningTitle } = useHttp({});
 
-    const saveContentRef = useRef('');
-    const saveTitleRef = useRef('');
-    const saveDeleteCanvasRef = useRef(false);
-    const savePageIdRef = useRef<number | null>(null);
     const {
+        setData: setSaveData,
         post: savePost,
         processing: saving,
-        transform: transformSave,
     } = useHttp({
         content: '',
         title: '',
         delete_canvas: false,
         page_id: null as number | null,
     });
-    transformSave(() => ({
-        content: saveContentRef.current,
-        title: saveTitleRef.current,
-        delete_canvas: saveDeleteCanvasRef.current,
-        page_id: savePageIdRef.current,
-    }));
 
     setLayoutProps({
         breadcrumbs: [
@@ -178,7 +166,10 @@ export default function ThinkstreamShow({
     }
 
     function structureThoughts() {
-        structureIdsRef.current = Array.from(selected);
+        const ids = Array.from(selected);
+
+        setStructureData('ids', ids);
+
         structurePost(thinkstreamStructureThoughts.url(page.id), {
             onSuccess: (response) => {
                 const { title, content, message } = response as {
@@ -198,15 +189,20 @@ export default function ThinkstreamShow({
         if (!structuredContent) {
             return;
         }
-        saveContentRef.current = structuredContent;
-        saveTitleRef.current = structuredTitle ?? pageTitle;
-        saveDeleteCanvasRef.current = deleteCanvasOnSave;
-        savePageIdRef.current = deleteCanvasOnSave ? page.id : null;
+
+        const pageId = deleteCanvasOnSave ? page.id : null;
+
+        setSaveData('content', structuredContent);
+        setSaveData('title', structuredTitle ?? pageTitle);
+        setSaveData('delete_canvas', deleteCanvasOnSave);
+        setSaveData('page_id', pageId);
+
         savePost(thinkstreamSaveToScrap.url(), {
             onSuccess: (response) => {
                 const { url } = response as { url: string };
                 setScrapUrl(url);
-                if (saveDeleteCanvasRef.current) {
+
+                if (pageId !== null) {
                     router.visit(url);
                 }
             },
@@ -216,7 +212,13 @@ export default function ThinkstreamShow({
     function toggleSelected(id: number) {
         setSelected((prev) => {
             const next = new Set(prev);
-            next.has(id) ? next.delete(id) : next.add(id);
+
+            if (next.has(id)) {
+                next.delete(id);
+            } else {
+                next.add(id);
+            }
+
             return next;
         });
     }
@@ -457,6 +459,7 @@ export default function ThinkstreamShow({
                             {thoughts.map((thought) => {
                                 const isSelected = selected.has(thought.id);
                                 const isEditing = editingId === thought.id;
+
                                 return (
                                     <Card
                                         key={thought.id}

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -1,4 +1,5 @@
 import { Head, Link, usePage } from '@inertiajs/react';
+import { timeAgo } from '@/lib/time';
 import {
     AlertTriangle,
     BookOpen,
@@ -344,11 +345,19 @@ export default function Namespace({
                                                     </p>
                                                 </div>
                                                 <div className="shrink-0 text-sm text-muted-foreground">
-                                                    {post.published_at
-                                                        ? new Date(
-                                                              post.published_at,
-                                                          ).toLocaleDateString()
-                                                        : 'Draft'}
+                                                    {post.published_at ? (
+                                                        <span
+                                                            title={new Date(
+                                                                post.published_at,
+                                                            ).toLocaleDateString()}
+                                                        >
+                                                            {timeAgo(
+                                                                post.published_at,
+                                                            )}
+                                                        </span>
+                                                    ) : (
+                                                        'Draft'
+                                                    )}
                                                 </div>
                                             </Link>
                                         ))}

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -1,4 +1,5 @@
 import { Head, Link, router, usePage } from '@inertiajs/react';
+import { timeAgo } from '@/lib/time';
 import {
     AlertTriangle,
     BookOpen,
@@ -609,9 +610,13 @@ export default function Show({
                                     className="text-xs text-muted-foreground/60"
                                 >
                                     Last updated:{' '}
-                                    {postDateFormatter.format(
-                                        new Date(post.updated_at),
-                                    )}
+                                    <span
+                                        title={postDateFormatter.format(
+                                            new Date(post.updated_at),
+                                        )}
+                                    >
+                                        {timeAgo(post.updated_at)}
+                                    </span>
                                 </time>
                             </footer>
                         </article>

--- a/resources/js/pages/tags/show.tsx
+++ b/resources/js/pages/tags/show.tsx
@@ -1,4 +1,5 @@
 import { Head, Link } from '@inertiajs/react';
+import { timeAgo } from '@/lib/time';
 import { home } from '@/routes';
 import { path as contentPath } from '@/routes/posts';
 
@@ -73,10 +74,15 @@ export default function TagShow({
                                                     <span className="font-medium">
                                                         {post.title}
                                                     </span>
-                                                    <span className="shrink-0 text-xs text-muted-foreground">
-                                                        {new Date(
+                                                    <span
+                                                        className="shrink-0 text-xs text-muted-foreground"
+                                                        title={new Date(
                                                             post.published_at,
                                                         ).toLocaleDateString()}
+                                                    >
+                                                        {timeAgo(
+                                                            post.published_at,
+                                                        )}
                                                     </span>
                                                 </Link>
                                             </li>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -3,10 +3,22 @@
 use App\Http\Controllers\Admin\BackupController;
 use App\Http\Controllers\Admin\NamespaceController;
 use App\Http\Controllers\Admin\PostController;
+use App\Http\Controllers\Admin\ThinkstreamController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () {
     Route::redirect('/', '/admin/posts')->name('index');
+
+    Route::get('thinkstream', [ThinkstreamController::class, 'index'])->name('thinkstream.index');
+    Route::post('thinkstream', [ThinkstreamController::class, 'storePage'])->name('thinkstream.storePage');
+    Route::post('thinkstream/save-to-scrap', [ThinkstreamController::class, 'saveToScrap'])->name('thinkstream.saveToScrap');
+    Route::delete('thinkstream/{page}', [ThinkstreamController::class, 'destroyPage'])->name('thinkstream.destroyPage');
+    Route::get('thinkstream/{page}', [ThinkstreamController::class, 'show'])->name('thinkstream.show');
+    Route::post('thinkstream/{page}', [ThinkstreamController::class, 'store'])->name('thinkstream.store');
+    Route::post('thinkstream/{page}/refine-title', [ThinkstreamController::class, 'refineTitle'])->name('thinkstream.refineTitle');
+    Route::patch('thinkstream/{page}/thoughts/{thought}', [ThinkstreamController::class, 'update'])->name('thinkstream.update');
+    Route::post('thinkstream/{page}/delete', [ThinkstreamController::class, 'destroyMany'])->name('thinkstream.destroyMany');
+    Route::post('thinkstream/{page}/structure', [ThinkstreamController::class, 'structureThoughts'])->name('thinkstream.structureThoughts');
 
     Route::patch('namespaces/reorder', [NamespaceController::class, 'reorder'])->name('namespaces.reorder');
     Route::resource('namespaces', NamespaceController::class)->except(['index', 'show']);
@@ -36,6 +48,7 @@ Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () 
         Route::post('/{namespace}', [PostController::class, 'store'])->name('store');
         Route::get('/{namespace}/{post:slug}', [PostController::class, 'show'])->name('show')->scopeBindings();
         Route::get('/{namespace}/{post:slug}/edit', [PostController::class, 'edit'])->name('edit')->scopeBindings();
+        Route::post('/{namespace}/{post:slug}/move-to-namespace', [PostController::class, 'moveToNamespace'])->name('moveToNamespace')->scopeBindings();
         Route::put('/{namespace}/{post:slug}', [PostController::class, 'update'])->name('update')->scopeBindings();
         Route::delete('/{namespace}/{post:slug}', [PostController::class, 'destroy'])->name('destroy')->scopeBindings();
         Route::post('/{namespace}/{post:slug}/sync-file', [PostController::class, 'storeSyncFile'])->name('storeSyncFile')->scopeBindings();

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -1234,6 +1234,33 @@ test('authenticated users can view a post details page', function () {
         );
 });
 
+test('admin post details page includes move namespace options for system namespaces', function () {
+    $user = User::factory()->create();
+    $scrap = PostNamespace::factory()->create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'is_system' => true,
+    ]);
+    $target = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'full_path' => 'guides',
+        'is_system' => false,
+        'name' => 'Guides',
+    ]);
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $scrap->id,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.show', [$scrap, $post]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/show')
+            ->where('availableMoveNamespaces.0.id', $target->id)
+            ->where('availableMoveNamespaces.0.full_path', 'guides')
+        );
+});
+
 test('admin post details page does not expose unsafe referer links', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create();
@@ -1409,6 +1436,97 @@ test('post details are scoped to their namespace', function () {
     $this->actingAs($user)
         ->get(route('admin.posts.show', [$wrongNamespace, $post]))
         ->assertNotFound();
+});
+
+test('authenticated users can move a post to an existing namespace', function () {
+    $user = User::factory()->create();
+    $sourceNamespace = PostNamespace::factory()->create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'is_system' => true,
+    ]);
+    $targetNamespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'full_path' => 'guides',
+        'is_system' => false,
+    ]);
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $sourceNamespace->id,
+        'slug' => 'artisan-note',
+        'full_path' => 'scrap/artisan-note',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('admin.posts.moveToNamespace', [$sourceNamespace, $post]), [
+            'target_namespace_id' => $targetNamespace->id,
+        ])
+        ->assertRedirect(route('admin.posts.show', [$targetNamespace, 'artisan-note']))
+        ->assertSessionHas('inertia.flash_data.toast', [
+            'type' => 'success',
+            'message' => 'Post moved to namespace.',
+        ]);
+
+    $post->refresh();
+    expect($post->namespace_id)->toBe($targetNamespace->id);
+    expect($post->slug)->toBe('artisan-note');
+    expect($post->full_path)->toBe('guides/artisan-note');
+});
+
+test('moving a post appends a numeric suffix when the slug is already taken in the target namespace', function () {
+    $user = User::factory()->create();
+    $sourceNamespace = PostNamespace::factory()->create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'is_system' => true,
+    ]);
+    $targetNamespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'full_path' => 'guides',
+        'is_system' => false,
+    ]);
+    Post::factory()->for($user)->create([
+        'namespace_id' => $targetNamespace->id,
+        'slug' => 'artisan-note',
+        'full_path' => 'guides/artisan-note',
+    ]);
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $sourceNamespace->id,
+        'slug' => 'artisan-note',
+        'full_path' => 'scrap/artisan-note',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('admin.posts.moveToNamespace', [$sourceNamespace, $post]), [
+            'target_namespace_id' => $targetNamespace->id,
+        ])
+        ->assertRedirect(route('admin.posts.show', [$targetNamespace, 'artisan-note-2']));
+
+    $post->refresh();
+    expect($post->slug)->toBe('artisan-note-2');
+    expect($post->full_path)->toBe('guides/artisan-note-2');
+});
+
+test('moving a post rejects system target namespaces', function () {
+    $user = User::factory()->create();
+    $sourceNamespace = PostNamespace::factory()->create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'is_system' => true,
+    ]);
+    $targetNamespace = PostNamespace::factory()->create([
+        'slug' => 'archive',
+        'full_path' => 'archive',
+        'is_system' => true,
+    ]);
+    $post = Post::factory()->for($user)->create([
+        'namespace_id' => $sourceNamespace->id,
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('admin.posts.moveToNamespace', [$sourceNamespace, $post]), [
+            'target_namespace_id' => $targetNamespace->id,
+        ])
+        ->assertSessionHasErrors('target_namespace_id');
 });
 
 test('authenticated users can update a post', function () {

--- a/tests/Feature/Admin/ThinkstreamControllerTest.php
+++ b/tests/Feature/Admin/ThinkstreamControllerTest.php
@@ -1,0 +1,613 @@
+<?php
+
+use App\Ai\Agents\ThinkstreamStructureAgent;
+use App\Ai\Agents\ThinkstreamTitleAgent;
+use App\Models\Post;
+use App\Models\PostNamespace;
+use App\Models\ThinkstreamPage;
+use App\Models\Thought;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+// Index
+
+test('authenticated users can view the thinkstream index', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)->get(route('admin.thinkstream.index'))->assertOk();
+});
+
+test('thinkstream index only lists the authenticated users canvases', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $ownPage = ThinkstreamPage::factory()->for($user)->create([
+        'title' => 'My Canvas',
+    ]);
+    ThinkstreamPage::factory()->for($otherUser)->create([
+        'title' => 'Other Canvas',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.thinkstream.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/thinkstream/index')
+            ->has('pages', 1)
+            ->where('pages.0.id', $ownPage->id)
+            ->where('pages.0.title', 'My Canvas')
+        );
+});
+
+test('guests are redirected from the thinkstream index', function () {
+    $this->get(route('admin.thinkstream.index'))->assertRedirect(route('login'));
+});
+
+// StorePage
+
+test('authenticated users can create a new canvas', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('admin.thinkstream.storePage'))
+        ->assertRedirect();
+
+    expect(ThinkstreamPage::count())->toBe(1);
+    expect(ThinkstreamPage::first()->user_id)->toBe($user->id);
+    expect(ThinkstreamPage::first()->title)->toMatch('/^Canvas \d{4}-\d{2}-\d{2}/');
+});
+
+test('creating a canvas redirects to its show page', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)->post(route('admin.thinkstream.storePage'));
+
+    $page = ThinkstreamPage::first();
+    expect($page)->not->toBeNull();
+});
+
+// Show
+
+test('authenticated users can view a canvas', function () {
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+
+    $this->actingAs($user)->get(route('admin.thinkstream.show', $page))->assertOk();
+});
+
+test('users cannot view another users canvas', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($otherUser)->create();
+
+    $this->actingAs($user)
+        ->get(route('admin.thinkstream.show', $page))
+        ->assertForbidden();
+});
+
+test('guests are redirected from the canvas show page', function () {
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+
+    $this->get(route('admin.thinkstream.show', $page))->assertRedirect(route('login'));
+});
+
+// DestroyPage
+
+test('authenticated users can delete a canvas', function () {
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    Thought::factory()->count(2)->for($user)->for($page, 'page')->create();
+
+    $this->actingAs($user)
+        ->delete(route('admin.thinkstream.destroyPage', $page))
+        ->assertRedirect(route('admin.thinkstream.index'));
+
+    expect(ThinkstreamPage::count())->toBe(0);
+    expect(Thought::count())->toBe(0);
+});
+
+test('users cannot delete another users canvas', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($otherUser)->create();
+
+    $this->actingAs($user)
+        ->delete(route('admin.thinkstream.destroyPage', $page))
+        ->assertForbidden();
+
+    expect($page->fresh())->not->toBeNull();
+});
+
+// Store
+
+test('authenticated users can post a thought', function () {
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+
+    $this->actingAs($user)
+        ->post(route('admin.thinkstream.store', $page), ['content' => 'Hello world'])
+        ->assertRedirect();
+
+    expect(Thought::count())->toBe(1);
+    expect(Thought::first()->content)->toBe('Hello world');
+    expect(Thought::first()->user_id)->toBe($user->id);
+    expect(Thought::first()->page_id)->toBe($page->id);
+});
+
+test('thought content is required', function () {
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+
+    $this->actingAs($user)
+        ->post(route('admin.thinkstream.store', $page), ['content' => ''])
+        ->assertSessionHasErrors('content');
+});
+
+// Update
+
+test('authenticated users can update a thought', function () {
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create();
+
+    $this->actingAs($user)
+        ->patch(route('admin.thinkstream.update', [$page, $thought]), ['content' => 'Updated content'])
+        ->assertRedirect();
+
+    expect($thought->fresh()->content)->toBe('Updated content');
+});
+
+test('update is scoped to the current canvas', function () {
+    $user = User::factory()->create();
+    $page1 = ThinkstreamPage::factory()->for($user)->create();
+    $page2 = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page2, 'page')->create();
+
+    $this->actingAs($user)
+        ->patch(route('admin.thinkstream.update', [$page1, $thought]), ['content' => 'Hacked'])
+        ->assertForbidden();
+});
+
+test('update content is required', function () {
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create();
+
+    $this->actingAs($user)
+        ->patchJson(route('admin.thinkstream.update', [$page, $thought]), ['content' => ''])
+        ->assertUnprocessable();
+});
+
+// DestroyMany
+
+test('authenticated users can bulk delete thoughts', function () {
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thoughts = Thought::factory()->count(3)->for($user)->for($page, 'page')->create();
+
+    $this->actingAs($user)
+        ->post(route('admin.thinkstream.destroyMany', $page), ['ids' => $thoughts->pluck('id')->all()])
+        ->assertRedirect();
+
+    expect(Thought::count())->toBe(0);
+});
+
+test('bulk delete is scoped to the current canvas', function () {
+    $user = User::factory()->create();
+    $page1 = ThinkstreamPage::factory()->for($user)->create();
+    $page2 = ThinkstreamPage::factory()->for($user)->create();
+    $thoughtOnPage1 = Thought::factory()->for($user)->for($page1, 'page')->create();
+    $thoughtOnPage2 = Thought::factory()->for($user)->for($page2, 'page')->create();
+
+    $this->actingAs($user)
+        ->post(route('admin.thinkstream.destroyMany', $page1), [
+            'ids' => [$thoughtOnPage1->id, $thoughtOnPage2->id],
+        ])
+        ->assertRedirect();
+
+    expect(Thought::count())->toBe(1);
+    expect(Thought::first()->id)->toBe($thoughtOnPage2->id);
+});
+
+// StructureThoughts
+
+test('authenticated users can structure thoughts with AI', function () {
+    ThinkstreamStructureAgent::fake([
+        ['title' => 'Canvas Title Draft', 'content' => "# Canvas Title Draft\n\nContent here."],
+    ]);
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thoughts = Thought::factory()->count(2)->for($user)->for($page, 'page')->create();
+
+    $response = $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.structureThoughts', $page), [
+            'ids' => $thoughts->pluck('id')->all(),
+        ]);
+
+    $response->assertOk()->assertJsonStructure(['title', 'content', 'message']);
+});
+
+test('structure thoughts returns 403 when AI is disabled', function () {
+    config()->set('thinkstream.ai.enabled', false);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thoughts = Thought::factory()->count(2)->for($user)->for($page, 'page')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.structureThoughts', $page), [
+            'ids' => $thoughts->pluck('id')->all(),
+        ])
+        ->assertForbidden();
+});
+
+test('users cannot structure another users thoughts with AI', function () {
+    ThinkstreamStructureAgent::fake([
+        ['title' => 'Canvas Title Draft', 'content' => 'Content here.'],
+    ]);
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($otherUser)->create();
+    $thoughts = Thought::factory()->count(2)->for($otherUser)->for($page, 'page')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.structureThoughts', $page), [
+            'ids' => $thoughts->pluck('id')->all(),
+        ])
+        ->assertForbidden();
+});
+
+// RefineTitle
+
+test('authenticated users can refine a canvas title with AI', function () {
+    ThinkstreamTitleAgent::fake([
+        ['title' => 'Product Strategy Notes'],
+    ]);
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create([
+        'title' => 'Canvas 2026-04-29 12:00',
+    ]);
+    Thought::factory()->count(2)->for($user)->for($page, 'page')->create();
+
+    $response = $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.refineTitle', $page));
+
+    $response
+        ->assertOk()
+        ->assertJson([
+            'title' => 'Product Strategy Notes',
+        ]);
+
+    $response->assertSessionHas('inertia.flash_data.toast', [
+        'type' => 'success',
+        'message' => 'Title refined. (cost: $0.0000)',
+    ]);
+
+    expect($page->fresh()->title)->toBe('Product Strategy Notes');
+});
+
+test('refine title returns 422 when a canvas has no thoughts', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.refineTitle', $page))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('page');
+});
+
+test('refine title returns 403 when AI is disabled', function () {
+    config()->set('thinkstream.ai.enabled', false);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    Thought::factory()->for($user)->for($page, 'page')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.refineTitle', $page))
+        ->assertForbidden();
+});
+
+// SaveToScrap
+
+test('save to scrap creates a post in the scrap namespace', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    PostNamespace::create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'name' => 'Scrap',
+        'is_system' => true,
+        'is_published' => false,
+    ]);
+
+    $response = $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.saveToScrap'), [
+            'content' => "# My Note\n\nSome content here.",
+            'delete_canvas' => false,
+        ]);
+
+    $response->assertOk()->assertJsonStructure(['url']);
+
+    $post = Post::first();
+    expect($post)->not->toBeNull();
+    expect($post->title)->toBe('My Note');
+    expect($post->content)->toBe('Some content here.');
+    expect($post->slug)->toMatch('/^my-note-\d{8}$/');
+    expect($post->namespace->slug)->toBe('scrap');
+    expect($post->is_draft)->toBeTrue();
+    expect($post->published_at)->toBeNull();
+    expect($post->namespace->is_published)->toBeFalse();
+});
+
+test('save to scrap keeps non-title-leading content unchanged', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    PostNamespace::create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'name' => 'Scrap',
+        'is_system' => true,
+        'is_published' => false,
+    ]);
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.saveToScrap'), [
+            'title' => 'My Note',
+            'content' => "## Context\n\nSome content here.",
+            'delete_canvas' => false,
+        ])
+        ->assertOk();
+
+    $post = Post::first();
+    expect($post->title)->toBe('My Note');
+    expect($post->content)->toBe("## Context\n\nSome content here.");
+    expect($post->slug)->toMatch('/^my-note-\d{8}$/');
+});
+
+test('save to scrap falls back to timestamp title when no heading', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    PostNamespace::create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'name' => 'Scrap',
+        'is_system' => true,
+        'is_published' => false,
+    ]);
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.saveToScrap'), [
+            'content' => 'Just some text without a heading.',
+            'delete_canvas' => false,
+        ])
+        ->assertOk();
+
+    $post = Post::first();
+    expect($post->title)->toMatch('/^Scrap \d{4}-\d{2}-\d{2}/');
+    expect($post->slug)->toMatch('/^scrap-\d{4}-\d{2}-\d{2}-.+-\d{8}$/');
+    expect($post->is_draft)->toBeTrue();
+    expect($post->published_at)->toBeNull();
+});
+
+test('save to scrap appends a counter when the dated slug already exists', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $scrap = PostNamespace::create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'name' => 'Scrap',
+        'is_system' => true,
+        'is_published' => false,
+    ]);
+
+    Post::factory()->for($scrap, 'namespace')->create([
+        'user_id' => $user->id,
+        'title' => 'My Note',
+        'slug' => 'my-note-'.now()->format('Ymd'),
+    ]);
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.saveToScrap'), [
+            'title' => 'My Note',
+            'content' => "## Context\n\nSome content here.",
+            'delete_canvas' => false,
+        ])
+        ->assertOk();
+
+    $post = Post::latest('id')->first();
+    expect($post->slug)->toMatch('/^my-note-\d{8}-2$/');
+});
+
+test('save to scrap returns 403 when AI is disabled', function () {
+    config()->set('thinkstream.ai.enabled', false);
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.saveToScrap'), [
+            'content' => 'Some content.',
+            'delete_canvas' => false,
+        ])
+        ->assertForbidden();
+});
+
+test('save to scrap can delete the original canvas', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    Thought::factory()->count(2)->for($user)->for($page, 'page')->create();
+    PostNamespace::create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'name' => 'Scrap',
+        'is_system' => true,
+        'is_published' => false,
+    ]);
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.saveToScrap'), [
+            'title' => 'My Note',
+            'content' => "## Context\n\nSome content here.",
+            'delete_canvas' => true,
+            'page_id' => $page->id,
+        ])
+        ->assertOk();
+
+    expect(ThinkstreamPage::find($page->id))->toBeNull();
+    expect(Thought::where('page_id', $page->id)->count())->toBe(0);
+});
+
+test('save to scrap requires page id when deleting the original canvas', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    PostNamespace::create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'name' => 'Scrap',
+        'is_system' => true,
+        'is_published' => false,
+    ]);
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.saveToScrap'), [
+            'title' => 'My Note',
+            'content' => "## Context\n\nSome content here.",
+            'delete_canvas' => true,
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('page_id');
+});
+
+test('users cannot delete another users canvas when saving to scrap', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($otherUser)->create();
+    Thought::factory()->count(2)->for($otherUser)->for($page, 'page')->create();
+    PostNamespace::create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'name' => 'Scrap',
+        'is_system' => true,
+        'is_published' => false,
+    ]);
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.saveToScrap'), [
+            'title' => 'My Note',
+            'content' => "## Context\n\nSome content here.",
+            'delete_canvas' => true,
+            'page_id' => $page->id,
+        ])
+        ->assertForbidden();
+
+    expect($page->fresh())->not->toBeNull();
+    expect(Post::count())->toBe(0);
+});
+// Namespace system protection
+
+test('system namespaces cannot be deleted', function () {
+    $user = User::factory()->create();
+    $scrap = PostNamespace::create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'name' => 'Scrap',
+        'is_system' => true,
+        'is_published' => false,
+    ]);
+
+    $this->actingAs($user)
+        ->delete(route('admin.namespaces.destroy', $scrap))
+        ->assertForbidden();
+
+    expect(PostNamespace::where('slug', 'scrap')->exists())->toBeTrue();
+});
+
+test('system namespaces cannot be updated', function () {
+    $user = User::factory()->create();
+    $scrap = PostNamespace::create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'name' => 'Scrap',
+        'is_system' => true,
+        'is_published' => false,
+    ]);
+
+    $this->actingAs($user)
+        ->patch(route('admin.namespaces.update', $scrap), [
+            'slug' => 'scrap',
+            'name' => 'Renamed',
+        ])
+        ->assertForbidden();
+
+    expect($scrap->fresh()->name)->toBe('Scrap');
+});
+
+test('system namespace is_published cannot be set to true', function () {
+    $user = User::factory()->create();
+    $scrap = PostNamespace::create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'name' => 'Scrap',
+        'is_system' => true,
+        'is_published' => false,
+    ]);
+
+    $this->actingAs($user)
+        ->patch(route('admin.namespaces.update', $scrap), [
+            'slug' => 'scrap',
+            'name' => 'Scrap',
+            'is_published' => true,
+        ])
+        ->assertForbidden();
+
+    expect($scrap->fresh()->is_published)->toBeFalse();
+});
+
+test('posts in system namespace cannot be published via update', function () {
+    $user = User::factory()->create();
+    $scrap = PostNamespace::create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'name' => 'Scrap',
+        'is_system' => true,
+        'is_published' => false,
+    ]);
+    $post = Post::factory()->for($scrap, 'namespace')->create([
+        'user_id' => $user->id,
+        'is_draft' => true,
+        'published_at' => null,
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.posts.update', ['namespace' => $scrap, 'post' => $post->slug]), [
+            'title' => $post->title,
+            'slug' => $post->slug,
+            'content' => $post->content,
+            'is_draft' => '0',
+            'published_at' => now()->toDateTimeString(),
+        ])
+        ->assertRedirect();
+
+    $post->refresh();
+    expect($post->is_draft)->toBeTrue();
+    expect($post->published_at)->toBeNull();
+});

--- a/tests/Feature/SyntaxSeederTest.php
+++ b/tests/Feature/SyntaxSeederTest.php
@@ -38,11 +38,13 @@ function withinIsolatedNamespaceBackupDirectory(callable $callback): mixed
     }
 }
 
-test('database seeder creates only the syntax namespace', function () {
+test('database seeder creates the system and syntax namespaces', function () {
     withinIsolatedNamespaceBackupDirectory(function (): void {
         $this->seed(DatabaseSeeder::class);
 
-        expect(PostNamespace::query()->pluck('slug')->all())->toBe(['syntax']);
+        expect(
+            PostNamespace::query()->orderBy('slug')->pluck('slug')->all()
+        )->toBe(['scrap', 'syntax']);
     });
 });
 


### PR DESCRIPTION
## Summary
- add Thinkstream canvas pages, thoughts, AI structuring, Scrap save flow, and system Scrap namespace support
- add system-namespace protections and post move-to-namespace flow from Scrap
- update analysis and feature tests for the new Thinkstream workflow

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/Admin/ThinkstreamControllerTest.php tests/Feature/Admin/PostControllerTest.php tests/Feature/SyntaxSeederTest.php
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build