### PR TITLE
Move root restore flow to backups dashboard

### DIFF
--- a/app/Http/Controllers/Admin/BackupController.php
+++ b/app/Http/Controllers/Admin/BackupController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\PostNamespace;
 use App\Support\NamespaceBackupIndex;
+use App\Support\NamespaceRestoreArchive;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
@@ -17,13 +18,26 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class BackupController extends Controller
 {
-    public function index(NamespaceBackupIndex $backupIndex): Response
-    {
+    public function index(
+        Request $request,
+        NamespaceBackupIndex $backupIndex,
+        NamespaceRestoreArchive $restoreArchive
+    ): Response {
         $backups = collect($backupIndex->allFiles());
         $backupCountsByNamespaceId = $backups
             ->pluck('namespace')
             ->filter()
             ->countBy('id');
+        $restoreToken = $request->string('restore')->toString();
+        $restorePreview = null;
+
+        if ($restoreToken !== '' && $restoreArchive->hasToken($restoreToken)) {
+            $restorePreview = [
+                'token' => $restoreToken,
+                ...$restoreArchive->preview($restoreArchive->tokenPath($restoreToken)),
+                'stream_url' => route('admin.posts.restore.stream', ['token' => $restoreToken], absolute: false),
+            ];
+        }
 
         $namespaces = PostNamespace::query()
             ->orderByRaw('sort_order IS NULL, sort_order ASC, name ASC')
@@ -44,6 +58,8 @@ class BackupController extends Controller
             'create_backups_url' => route('admin.backups.storeMany', absolute: false),
             'delete_backups_url' => route('admin.backups.destroyMany', absolute: false),
             'restore_backups_url' => route('admin.backups.restoreMany', absolute: false),
+            'restore_upload_url' => route('admin.posts.restore.upload', absolute: false),
+            'restore_preview' => $restorePreview,
             'backups' => $backups
                 ->map(fn (array $backup): array => [
                     'key' => $backup['filename'],

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -35,7 +35,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class PostController extends Controller
 {
-    public function index(Request $request, NamespaceRestoreArchive $restoreArchive): Response
+    public function index(Request $request): Response
     {
         $allowedColumns = ['name', 'posts_count', 'is_published'];
         $allowedDirections = ['asc', 'desc'];
@@ -60,22 +60,9 @@ class PostController extends Controller
                 ->get();
         }
 
-        $restoreToken = $request->string('restore')->toString();
-        $restorePreview = null;
-
-        if ($restoreToken !== '' && $restoreArchive->hasToken($restoreToken)) {
-            $restorePreview = [
-                'token' => $restoreToken,
-                ...$restoreArchive->preview($restoreArchive->tokenPath($restoreToken)),
-                'stream_url' => route('admin.posts.restore.stream', ['token' => $restoreToken], absolute: false),
-            ];
-        }
-
         return Inertia::render('admin/posts/index', [
             'namespaces' => $namespaces,
             'sort' => ['column' => $column, 'direction' => $direction],
-            'restore_upload_url' => route('admin.posts.restore.upload', absolute: false),
-            'restore_preview' => $restorePreview,
         ]);
     }
 
@@ -279,7 +266,7 @@ class PostController extends Controller
             ]);
         }
 
-        return to_route('admin.posts.index', ['restore' => $token]);
+        return to_route('admin.backups.index', ['restore' => $token]);
     }
 
     public function streamRestoreArchive(string $token, NamespaceRestoreArchive $restoreArchive): StreamedResponse

--- a/app/Support/NamespaceRestoreArchive.php
+++ b/app/Support/NamespaceRestoreArchive.php
@@ -34,11 +34,19 @@ class NamespaceRestoreArchive
 
     public function tokenPath(string $token): string
     {
+        if (! $this->hasValidTokenFormat($token)) {
+            throw new RuntimeException('Invalid restore archive token.');
+        }
+
         return $this->directory().'/'.$token.'.zip';
     }
 
     public function hasToken(string $token): bool
     {
+        if (! $this->hasValidTokenFormat($token)) {
+            return false;
+        }
+
         return File::isFile($this->tokenPath($token));
     }
 
@@ -458,6 +466,11 @@ class NamespaceRestoreArchive
         }
 
         return implode('/', $segments);
+    }
+
+    private function hasValidTokenFormat(string $token): bool
+    {
+        return preg_match('/\A[a-zA-Z0-9_-]+\z/', $token) === 1;
     }
 
     private function removeDirectory(string $path): void

--- a/resources/js/pages/admin/backups/index.tsx
+++ b/resources/js/pages/admin/backups/index.tsx
@@ -1,7 +1,23 @@
-import { Form, Head, Link, setLayoutProps, usePage } from '@inertiajs/react';
-import { Archive, Download, FolderOpen, RotateCcw, Trash2 } from 'lucide-react';
-import { useId, useState } from 'react';
+import {
+    Form,
+    Head,
+    Link,
+    router,
+    setLayoutProps,
+    useForm,
+    usePage,
+} from '@inertiajs/react';
+import {
+    Archive,
+    Download,
+    FolderOpen,
+    RotateCcw,
+    Trash2,
+    Upload,
+} from 'lucide-react';
+import { startTransition, useEffect, useId, useRef, useState } from 'react';
 import CreateBackupDialog from '@/components/create-backup-dialog';
+import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -17,6 +33,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { matchesDeleteConfirmation } from '@/lib/delete-confirmation';
+import { cn } from '@/lib/utils';
 import { dashboard } from '@/routes';
 import { index as backupsIndex } from '@/routes/admin/backups';
 
@@ -50,6 +67,40 @@ type BackupRecord = {
         management_url: string | null;
         namespace_url: string | null;
     };
+};
+
+type RestorePreview = {
+    token: string;
+    root: {
+        name: string;
+        slug: string;
+        full_path: string;
+        status: 'existing' | 'new';
+    };
+    totals: {
+        namespace_count: number;
+        existing_namespace_count: number;
+        new_namespace_count: number;
+        post_count: number;
+        existing_post_count: number;
+        new_post_count: number;
+    };
+    namespaces: Array<{
+        name: string;
+        slug: string;
+        full_path: string;
+        status: 'existing' | 'new';
+        post_count: number;
+        existing_post_count: number;
+        new_post_count: number;
+    }>;
+    stream_url: string;
+};
+
+type RestoreLog = {
+    id: string;
+    type: 'info' | 'success' | 'error';
+    message: string;
 };
 
 function BackupDescriptionCell({
@@ -157,18 +208,455 @@ function RestoreBackupDialog({ backup }: { backup: BackupRecord }) {
     );
 }
 
+function RestorePreviewPanel({
+    restorePreview,
+    hasOverwriteTargets,
+    clearPreview,
+}: {
+    restorePreview: RestorePreview;
+    hasOverwriteTargets: boolean;
+    clearPreview: () => void;
+}) {
+    const [logs, setLogs] = useState<RestoreLog[]>([]);
+    const [isRestoring, setIsRestoring] = useState(false);
+    const [isComplete, setIsComplete] = useState(false);
+    const eventSourceRef = useRef<EventSource | null>(null);
+
+    useEffect(() => {
+        return () => {
+            eventSourceRef.current?.close();
+        };
+    }, []);
+
+    function startRestore() {
+        if (isRestoring) {
+            return;
+        }
+
+        setLogs([]);
+        setIsRestoring(true);
+        setIsComplete(false);
+
+        const eventSource = new EventSource(restorePreview.stream_url);
+        eventSourceRef.current = eventSource;
+
+        eventSource.addEventListener('update', (event) => {
+            if (!(event instanceof MessageEvent)) {
+                return;
+            }
+
+            if (event.data === '</stream>') {
+                eventSource.close();
+                eventSourceRef.current = null;
+                setIsRestoring(false);
+                setIsComplete(true);
+
+                return;
+            }
+
+            try {
+                const payload = JSON.parse(event.data) as RestoreLog;
+
+                startTransition(() => {
+                    setLogs((current) => [...current, payload]);
+                });
+            } catch {
+                startTransition(() => {
+                    setLogs((current) => [
+                        ...current,
+                        {
+                            id: crypto.randomUUID(),
+                            type: 'error',
+                            message: 'Failed to parse restore progress output.',
+                        },
+                    ]);
+                });
+            }
+        });
+
+        eventSource.onerror = () => {
+            eventSource.close();
+            eventSourceRef.current = null;
+            setIsRestoring(false);
+            setIsComplete(true);
+            setLogs((current) => [
+                ...current,
+                {
+                    id: crypto.randomUUID(),
+                    type: 'error',
+                    message: 'The restore stream disconnected unexpectedly.',
+                },
+            ]);
+        };
+    }
+
+    return (
+        <div className="space-y-5">
+            <div className="rounded-lg border bg-muted/30 p-4">
+                <div className="flex flex-wrap items-center gap-2 text-sm">
+                    <span className="font-medium">Root namespace:</span>
+                    <span>{restorePreview.root.name}</span>
+                    <span className="text-muted-foreground">
+                        /{restorePreview.root.full_path}
+                    </span>
+                    <span className="rounded-full bg-background px-2 py-0.5 text-xs">
+                        {restorePreview.root.status}
+                    </span>
+                </div>
+                <div className="mt-3 grid gap-2 text-sm text-muted-foreground sm:grid-cols-3">
+                    <div>
+                        {restorePreview.totals.namespace_count} namespaces
+                    </div>
+                    <div>
+                        {restorePreview.totals.new_namespace_count} new /{' '}
+                        {restorePreview.totals.existing_namespace_count}{' '}
+                        existing
+                    </div>
+                    <div>
+                        {restorePreview.totals.post_count} posts (
+                        {restorePreview.totals.new_post_count} new /{' '}
+                        {restorePreview.totals.existing_post_count} existing)
+                    </div>
+                </div>
+            </div>
+
+            <div className="rounded-lg border bg-black p-3 font-mono text-xs text-green-400">
+                {logs.length === 0 ? (
+                    <div className="text-muted">
+                        {isRestoring
+                            ? 'Waiting for restore output...'
+                            : 'No restore output yet.'}
+                    </div>
+                ) : (
+                    <div className="max-h-56 space-y-1 overflow-auto">
+                        {logs.map((log) => (
+                            <div key={log.id}>
+                                [{log.type}] {log.message}
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            <div className="max-h-56 overflow-auto rounded-lg border">
+                <table className="w-full text-sm">
+                    <thead>
+                        <tr className="border-b bg-muted/50">
+                            <th className="px-4 py-2 text-left font-medium">
+                                Namespace
+                            </th>
+                            <th className="px-4 py-2 text-left font-medium">
+                                Status
+                            </th>
+                            <th className="px-4 py-2 text-left font-medium">
+                                Posts
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {restorePreview.namespaces.map((item) => (
+                            <tr
+                                key={item.full_path}
+                                className="border-b last:border-0"
+                            >
+                                <td className="px-4 py-2">
+                                    <div className="font-medium">
+                                        {item.name}
+                                    </div>
+                                    <div className="text-xs text-muted-foreground">
+                                        /{item.full_path}
+                                    </div>
+                                </td>
+                                <td className="px-4 py-2">
+                                    <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground capitalize">
+                                        {item.status}
+                                    </span>
+                                </td>
+                                <td className="px-4 py-2 text-muted-foreground">
+                                    {item.post_count} total /{' '}
+                                    {item.new_post_count} new /{' '}
+                                    {item.existing_post_count} existing
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+
+            <DialogDescription className="space-y-2">
+                {hasOverwriteTargets ? (
+                    <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                        Existing namespaces and posts matched by backup path
+                        will be overwritten by this restore.
+                    </div>
+                ) : (
+                    <p>
+                        Existing namespaces and posts will be overwritten when
+                        their backup paths match.
+                    </p>
+                )}
+            </DialogDescription>
+
+            <DialogFooter className="gap-2">
+                <Button
+                    variant="secondary"
+                    onClick={clearPreview}
+                    disabled={isRestoring}
+                >
+                    {isComplete ? 'Close' : 'Cancel'}
+                </Button>
+                <Button
+                    onClick={startRestore}
+                    disabled={isRestoring || isComplete}
+                >
+                    <Upload className="size-4" />
+                    {isRestoring
+                        ? 'Restoring...'
+                        : isComplete
+                          ? 'Restore Complete'
+                          : 'Run Restore'}
+                </Button>
+            </DialogFooter>
+        </div>
+    );
+}
+
+function RestoreNamespacesDialog({
+    restoreUploadUrl,
+    restorePreview,
+}: {
+    restoreUploadUrl: string;
+    restorePreview: RestorePreview | null;
+}) {
+    const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false);
+    const [isDraggingBackup, setIsDraggingBackup] = useState(false);
+    const backupInputRef = useRef<HTMLInputElement | null>(null);
+    const dragCounterRef = useRef(0);
+    const uploadForm = useForm<{ backup: File | null }>({ backup: null });
+
+    const hasOverwriteTargets =
+        (restorePreview?.totals.existing_namespace_count ?? 0) > 0 ||
+        (restorePreview?.totals.existing_post_count ?? 0) > 0;
+    const open = restorePreview !== null || isUploadDialogOpen;
+
+    function clearPreview() {
+        router.get(backupsIndex.url(), undefined, {
+            preserveScroll: true,
+            replace: true,
+        });
+    }
+
+    function handleOpenChange(nextOpen: boolean) {
+        if (!nextOpen && restorePreview) {
+            clearPreview();
+
+            return;
+        }
+
+        setIsUploadDialogOpen(nextOpen);
+    }
+
+    function uploadBackup() {
+        uploadForm.post(restoreUploadUrl, {
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => uploadForm.reset('backup'),
+        });
+    }
+
+    function handleBackupFile(file: File | null) {
+        if (!file) {
+            return;
+        }
+
+        const isZipFile =
+            file.type === 'application/zip' || file.name.endsWith('.zip');
+
+        if (!isZipFile) {
+            return;
+        }
+
+        uploadForm.setData('backup', file);
+
+        if (backupInputRef.current) {
+            const transfer = new DataTransfer();
+            transfer.items.add(file);
+            backupInputRef.current.files = transfer.files;
+        }
+    }
+
+    function handleDragEnter(event: React.DragEvent<HTMLDivElement>) {
+        event.preventDefault();
+        dragCounterRef.current++;
+        setIsDraggingBackup(true);
+    }
+
+    function handleDragLeave() {
+        dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
+
+        if (dragCounterRef.current === 0) {
+            setIsDraggingBackup(false);
+        }
+    }
+
+    function handleDrop(event: React.DragEvent<HTMLDivElement>) {
+        event.preventDefault();
+        dragCounterRef.current = 0;
+        setIsDraggingBackup(false);
+
+        handleBackupFile(event.dataTransfer.files[0] ?? null);
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogTrigger asChild>
+                <Button variant="outline" size="sm">
+                    <Upload className="size-4" />
+                    Restore ZIP
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-3xl">
+                <DialogTitle>Restore Namespaces From ZIP</DialogTitle>
+                <DialogDescription className="space-y-2">
+                    <p>
+                        Upload a namespace backup zip from the backups
+                        dashboard.
+                    </p>
+                </DialogDescription>
+
+                {restorePreview ? (
+                    <RestorePreviewPanel
+                        key={restorePreview.token}
+                        restorePreview={restorePreview}
+                        hasOverwriteTargets={hasOverwriteTargets}
+                        clearPreview={clearPreview}
+                    />
+                ) : (
+                    <form
+                        onSubmit={(event) => {
+                            event.preventDefault();
+                            uploadBackup();
+                        }}
+                        className="space-y-4"
+                    >
+                        <div
+                            onClick={() => backupInputRef.current?.click()}
+                            onDragEnter={handleDragEnter}
+                            onDragOver={(event) => event.preventDefault()}
+                            onDragLeave={handleDragLeave}
+                            onDrop={handleDrop}
+                            className={cn(
+                                'cursor-pointer rounded-lg border border-dashed p-8 transition-colors',
+                                isDraggingBackup
+                                    ? 'border-ring bg-ring/8'
+                                    : 'border-input bg-muted/30 hover:border-ring/60 hover:bg-muted/50',
+                            )}
+                        >
+                            <div className="flex flex-col items-center gap-3 text-center">
+                                <div
+                                    className={cn(
+                                        'rounded-full border-2 border-dashed p-4 transition-colors',
+                                        isDraggingBackup
+                                            ? 'border-ring text-ring'
+                                            : 'border-muted-foreground/30 text-muted-foreground',
+                                    )}
+                                >
+                                    <Upload className="size-8" />
+                                </div>
+                                <div className="space-y-1">
+                                    <p className="text-sm font-medium">
+                                        {isDraggingBackup
+                                            ? 'Drop zip to upload'
+                                            : uploadForm.data.backup
+                                              ? uploadForm.data.backup.name
+                                              : 'Drop zip here'}
+                                    </p>
+                                    <p className="text-xs text-muted-foreground">
+                                        {uploadForm.data.backup
+                                            ? 'Click or drop another zip to replace the current selection.'
+                                            : 'or click to browse for a backup zip'}
+                                    </p>
+                                </div>
+                                <p className="text-xs text-muted-foreground/80">
+                                    ZIP archive only
+                                </p>
+                            </div>
+                        </div>
+                        <input
+                            ref={backupInputRef}
+                            type="file"
+                            name="backup"
+                            accept=".zip,application/zip"
+                            className="sr-only"
+                            onChange={(event) =>
+                                handleBackupFile(
+                                    event.currentTarget.files?.[0] ?? null,
+                                )
+                            }
+                        />
+                        {uploadForm.progress && (
+                            <p className="text-sm text-muted-foreground">
+                                Uploading... {uploadForm.progress.percentage}%
+                            </p>
+                        )}
+                        {uploadForm.data.backup && (
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    uploadForm.setData('backup', null);
+
+                                    if (backupInputRef.current) {
+                                        const transfer = new DataTransfer();
+                                        backupInputRef.current.files =
+                                            transfer.files;
+                                    }
+                                }}
+                                className="text-xs text-muted-foreground hover:text-destructive"
+                            >
+                                Clear selection
+                            </button>
+                        )}
+                        {uploadForm.errors.backup && (
+                            <InputError message={uploadForm.errors.backup} />
+                        )}
+                        <DialogFooter className="gap-2">
+                            <DialogClose asChild>
+                                <Button variant="secondary">Cancel</Button>
+                            </DialogClose>
+                            <Button
+                                type="submit"
+                                disabled={
+                                    uploadForm.processing ||
+                                    uploadForm.data.backup === null
+                                }
+                            >
+                                <Upload className="size-4" />
+                                Upload ZIP
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+}
+
 export default function AdminBackupsIndex({
     namespaces,
     backups,
     create_backups_url,
     delete_backups_url,
     restore_backups_url,
+    restore_upload_url,
+    restore_preview,
 }: {
     namespaces: NamespaceSummary[];
     backups: BackupRecord[];
     create_backups_url: string;
     delete_backups_url: string;
     restore_backups_url: string;
+    restore_upload_url: string;
+    restore_preview: RestorePreview | null;
 }) {
     const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -200,7 +688,10 @@ export default function AdminBackupsIndex({
     ).length;
     const canRestoreSelected = restoreConfirmation === 'RESTORE';
     const fallbackTab =
-        errors?.keys || errors?.backup || errors?.confirmation
+        restore_preview ||
+        errors?.keys ||
+        errors?.backup ||
+        errors?.confirmation
             ? 'restore'
             : 'create';
     const [activeTab, setActiveTab] = useState(fallbackTab);
@@ -282,12 +773,14 @@ export default function AdminBackupsIndex({
                                     value="create"
                                     data-test="admin-backups-tab-create"
                                 >
+                                    <Archive className="size-4" />
                                     Create
                                 </TabsTrigger>
                                 <TabsTrigger
                                     value="restore"
                                     data-test="admin-backups-tab-restore"
                                 >
+                                    <RotateCcw className="size-4" />
                                     Restore
                                 </TabsTrigger>
                             </TabsList>
@@ -541,180 +1034,193 @@ export default function AdminBackupsIndex({
                                 </p>
                             </div>
 
-                            <Dialog
-                                open={isRestoreDialogOpen}
-                                onOpenChange={setIsRestoreDialogOpen}
-                            >
-                                <DialogTrigger asChild>
-                                    <Button
-                                        variant="outline"
-                                        size="sm"
-                                        disabled={selectedKeys.length === 0}
-                                    >
-                                        <RotateCcw className="size-4" />
-                                        Restore Selected
-                                    </Button>
-                                </DialogTrigger>
-                                <DialogContent>
-                                    <DialogTitle>
-                                        Restore selected backups?
-                                    </DialogTitle>
-                                    <DialogDescription className="space-y-3">
-                                        <p>
-                                            This will apply each selected backup
-                                            in sequence. If multiple selected
-                                            backups target the same namespace,
-                                            the request will be rejected.
-                                        </p>
-                                        <p>
-                                            Type{' '}
-                                            <span className="font-semibold">
-                                                RESTORE
-                                            </span>{' '}
-                                            to confirm.
-                                        </p>
-                                    </DialogDescription>
-                                    <Form
-                                        action={restore_backups_url}
-                                        method="post"
-                                        onSuccess={() => {
-                                            setIsRestoreDialogOpen(false);
-                                            setSelectedKeys([]);
-                                            setRestoreConfirmation('');
-                                        }}
-                                    >
-                                        {({ processing, errors }) => (
-                                            <div className="space-y-4">
-                                                {selectedKeys.map((key) => (
-                                                    <input
-                                                        key={key}
-                                                        type="hidden"
-                                                        name="keys[]"
-                                                        value={key}
-                                                    />
-                                                ))}
-                                                <Input
-                                                    value={restoreConfirmation}
-                                                    onChange={(event) =>
-                                                        setRestoreConfirmation(
-                                                            event.target.value,
-                                                        )
-                                                    }
-                                                    autoComplete="off"
-                                                    placeholder="RESTORE"
-                                                />
-                                                {errors.keys && (
-                                                    <p className="text-sm text-destructive">
-                                                        {errors.keys}
-                                                    </p>
-                                                )}
-                                                {errors.backup && (
-                                                    <p className="text-sm text-destructive">
-                                                        {errors.backup}
-                                                    </p>
-                                                )}
-                                                <DialogFooter className="gap-2">
-                                                    <DialogClose asChild>
-                                                        <Button
-                                                            variant="secondary"
-                                                            onClick={() =>
-                                                                setRestoreConfirmation(
-                                                                    '',
-                                                                )
-                                                            }
-                                                        >
-                                                            Cancel
-                                                        </Button>
-                                                    </DialogClose>
-                                                    <Button
-                                                        variant="destructive"
-                                                        disabled={
-                                                            processing ||
-                                                            !canRestoreSelected
-                                                        }
-                                                        asChild
-                                                    >
-                                                        <button type="submit">
-                                                            Restore Selected
-                                                        </button>
-                                                    </Button>
-                                                </DialogFooter>
-                                            </div>
-                                        )}
-                                    </Form>
-                                </DialogContent>
-                            </Dialog>
+                            <div className="flex flex-wrap items-center gap-2">
+                                <RestoreNamespacesDialog
+                                    restoreUploadUrl={restore_upload_url}
+                                    restorePreview={restore_preview}
+                                />
 
-                            <Dialog
-                                open={isDeleteDialogOpen}
-                                onOpenChange={setIsDeleteDialogOpen}
-                            >
-                                <DialogTrigger asChild>
-                                    <Button
-                                        variant="destructive"
-                                        size="sm"
-                                        disabled={selectedKeys.length === 0}
-                                    >
-                                        <Trash2 className="size-4" />
-                                        Delete Selected
-                                    </Button>
-                                </DialogTrigger>
-                                <DialogContent>
-                                    <DialogTitle>
-                                        Delete selected backups?
-                                    </DialogTitle>
-                                    <DialogDescription className="space-y-3">
-                                        <p>
-                                            This will permanently remove the
-                                            selected backup files.
-                                        </p>
-                                        <p>
-                                            {selectedKeys.length} backup
-                                            {selectedKeys.length === 1
-                                                ? ''
-                                                : 's'}{' '}
-                                            will be deleted.
-                                        </p>
-                                    </DialogDescription>
-                                    <Form
-                                        action={delete_backups_url}
-                                        method="post"
-                                        onSuccess={() => {
-                                            setIsDeleteDialogOpen(false);
-                                            setSelectedKeys([]);
-                                        }}
-                                    >
-                                        {({ processing }) => (
-                                            <div className="space-y-4">
-                                                {selectedKeys.map((key) => (
-                                                    <input
-                                                        key={key}
-                                                        type="hidden"
-                                                        name="keys[]"
-                                                        value={key}
+                                <Dialog
+                                    open={isRestoreDialogOpen}
+                                    onOpenChange={setIsRestoreDialogOpen}
+                                >
+                                    <DialogTrigger asChild>
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            disabled={selectedKeys.length === 0}
+                                        >
+                                            <RotateCcw className="size-4" />
+                                            Restore Selected
+                                        </Button>
+                                    </DialogTrigger>
+                                    <DialogContent>
+                                        <DialogTitle>
+                                            Restore selected backups?
+                                        </DialogTitle>
+                                        <DialogDescription className="space-y-3">
+                                            <p>
+                                                This will apply each selected
+                                                backup in sequence. If multiple
+                                                selected backups target the same
+                                                namespace, the request will be
+                                                rejected.
+                                            </p>
+                                            <p>
+                                                Type{' '}
+                                                <span className="font-semibold">
+                                                    RESTORE
+                                                </span>{' '}
+                                                to confirm.
+                                            </p>
+                                        </DialogDescription>
+                                        <Form
+                                            action={restore_backups_url}
+                                            method="post"
+                                            onSuccess={() => {
+                                                setIsRestoreDialogOpen(false);
+                                                setSelectedKeys([]);
+                                                setRestoreConfirmation('');
+                                            }}
+                                        >
+                                            {({ processing, errors }) => (
+                                                <div className="space-y-4">
+                                                    {selectedKeys.map((key) => (
+                                                        <input
+                                                            key={key}
+                                                            type="hidden"
+                                                            name="keys[]"
+                                                            value={key}
+                                                        />
+                                                    ))}
+                                                    <Input
+                                                        value={
+                                                            restoreConfirmation
+                                                        }
+                                                        onChange={(event) =>
+                                                            setRestoreConfirmation(
+                                                                event.target
+                                                                    .value,
+                                                            )
+                                                        }
+                                                        autoComplete="off"
+                                                        placeholder="RESTORE"
                                                     />
-                                                ))}
-                                                <DialogFooter className="gap-2">
-                                                    <DialogClose asChild>
-                                                        <Button variant="secondary">
-                                                            Cancel
+                                                    {errors.keys && (
+                                                        <p className="text-sm text-destructive">
+                                                            {errors.keys}
+                                                        </p>
+                                                    )}
+                                                    {errors.backup && (
+                                                        <p className="text-sm text-destructive">
+                                                            {errors.backup}
+                                                        </p>
+                                                    )}
+                                                    <DialogFooter className="gap-2">
+                                                        <DialogClose asChild>
+                                                            <Button
+                                                                variant="secondary"
+                                                                onClick={() =>
+                                                                    setRestoreConfirmation(
+                                                                        '',
+                                                                    )
+                                                                }
+                                                            >
+                                                                Cancel
+                                                            </Button>
+                                                        </DialogClose>
+                                                        <Button
+                                                            variant="destructive"
+                                                            disabled={
+                                                                processing ||
+                                                                !canRestoreSelected
+                                                            }
+                                                            asChild
+                                                        >
+                                                            <button type="submit">
+                                                                Restore Selected
+                                                            </button>
                                                         </Button>
-                                                    </DialogClose>
-                                                    <Button
-                                                        variant="destructive"
-                                                        disabled={processing}
-                                                        asChild
-                                                    >
-                                                        <button type="submit">
-                                                            Delete Selected
-                                                        </button>
-                                                    </Button>
-                                                </DialogFooter>
-                                            </div>
-                                        )}
-                                    </Form>
-                                </DialogContent>
-                            </Dialog>
+                                                    </DialogFooter>
+                                                </div>
+                                            )}
+                                        </Form>
+                                    </DialogContent>
+                                </Dialog>
+
+                                <Dialog
+                                    open={isDeleteDialogOpen}
+                                    onOpenChange={setIsDeleteDialogOpen}
+                                >
+                                    <DialogTrigger asChild>
+                                        <Button
+                                            variant="destructive"
+                                            size="sm"
+                                            disabled={selectedKeys.length === 0}
+                                        >
+                                            <Trash2 className="size-4" />
+                                            Delete Selected
+                                        </Button>
+                                    </DialogTrigger>
+                                    <DialogContent>
+                                        <DialogTitle>
+                                            Delete selected backups?
+                                        </DialogTitle>
+                                        <DialogDescription className="space-y-3">
+                                            <p>
+                                                This will permanently remove the
+                                                selected backup files.
+                                            </p>
+                                            <p>
+                                                {selectedKeys.length} backup
+                                                {selectedKeys.length === 1
+                                                    ? ''
+                                                    : 's'}{' '}
+                                                will be deleted.
+                                            </p>
+                                        </DialogDescription>
+                                        <Form
+                                            action={delete_backups_url}
+                                            method="post"
+                                            onSuccess={() => {
+                                                setIsDeleteDialogOpen(false);
+                                                setSelectedKeys([]);
+                                            }}
+                                        >
+                                            {({ processing }) => (
+                                                <div className="space-y-4">
+                                                    {selectedKeys.map((key) => (
+                                                        <input
+                                                            key={key}
+                                                            type="hidden"
+                                                            name="keys[]"
+                                                            value={key}
+                                                        />
+                                                    ))}
+                                                    <DialogFooter className="gap-2">
+                                                        <DialogClose asChild>
+                                                            <Button variant="secondary">
+                                                                Cancel
+                                                            </Button>
+                                                        </DialogClose>
+                                                        <Button
+                                                            variant="destructive"
+                                                            disabled={
+                                                                processing
+                                                            }
+                                                            asChild
+                                                        >
+                                                            <button type="submit">
+                                                                Delete Selected
+                                                            </button>
+                                                        </Button>
+                                                    </DialogFooter>
+                                                </div>
+                                            )}
+                                        </Form>
+                                    </DialogContent>
+                                </Dialog>
+                            </div>
                         </div>
 
                         {backups.length === 0 ? (

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -16,8 +16,9 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Form } from '@inertiajs/react';
-import { Head, Link, router, useForm } from '@inertiajs/react';
+import { Head, Link, router } from '@inertiajs/react';
 import {
+    Archive,
     ArrowUpDown,
     Check,
     CheckCircle2,
@@ -32,12 +33,10 @@ import {
     GripVertical,
     Inbox,
     Pencil,
-    Upload,
     Trash2,
 } from 'lucide-react';
-import { startTransition, useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
-import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import {
@@ -53,6 +52,7 @@ import { Input } from '@/components/ui/input';
 import { matchesDeleteConfirmation } from '@/lib/delete-confirmation';
 import { cn } from '@/lib/utils';
 import { dashboard } from '@/routes';
+import { index as backupsIndex } from '@/routes/admin/backups';
 import { create as namespaceCreate } from '@/routes/admin/namespaces';
 import { index, namespace as namespaceRoute } from '@/routes/admin/posts';
 
@@ -70,40 +70,6 @@ type Namespace = {
 type Sort = {
     column: string;
     direction: 'asc' | 'desc';
-};
-
-type RestorePreview = {
-    token: string;
-    root: {
-        name: string;
-        slug: string;
-        full_path: string;
-        status: 'existing' | 'new';
-    };
-    totals: {
-        namespace_count: number;
-        existing_namespace_count: number;
-        new_namespace_count: number;
-        post_count: number;
-        existing_post_count: number;
-        new_post_count: number;
-    };
-    namespaces: Array<{
-        name: string;
-        slug: string;
-        full_path: string;
-        status: 'existing' | 'new';
-        post_count: number;
-        existing_post_count: number;
-        new_post_count: number;
-    }>;
-    stream_url: string;
-};
-
-type RestoreLog = {
-    id: string;
-    type: 'info' | 'success' | 'error';
-    message: string;
 };
 
 type NamespaceSummary = {
@@ -273,455 +239,14 @@ function DeleteNamespaceDialog({ namespace }: { namespace: Namespace }) {
     );
 }
 
-function RestorePreviewPanel({
-    restorePreview,
-    hasOverwriteTargets,
-    clearPreview,
-}: {
-    restorePreview: RestorePreview;
-    hasOverwriteTargets: boolean;
-    clearPreview: () => void;
-}) {
-    const [logs, setLogs] = useState<RestoreLog[]>([]);
-    const [isRestoring, setIsRestoring] = useState(false);
-    const [isComplete, setIsComplete] = useState(false);
-    const eventSourceRef = useRef<EventSource | null>(null);
-
-    useEffect(() => {
-        return () => {
-            eventSourceRef.current?.close();
-        };
-    }, []);
-
-    function startRestore() {
-        if (isRestoring) {
-            return;
-        }
-
-        setLogs([]);
-        setIsRestoring(true);
-        setIsComplete(false);
-
-        const eventSource = new EventSource(restorePreview.stream_url);
-        eventSourceRef.current = eventSource;
-
-        eventSource.addEventListener('update', (event) => {
-            if (!(event instanceof MessageEvent)) {
-                return;
-            }
-
-            if (event.data === '</stream>') {
-                eventSource.close();
-                eventSourceRef.current = null;
-                setIsRestoring(false);
-                setIsComplete(true);
-
-                return;
-            }
-
-            try {
-                const payload = JSON.parse(event.data) as RestoreLog;
-
-                startTransition(() => {
-                    setLogs((current) => [...current, payload]);
-                });
-            } catch {
-                startTransition(() => {
-                    setLogs((current) => [
-                        ...current,
-                        {
-                            id: crypto.randomUUID(),
-                            type: 'error',
-                            message: 'Failed to parse restore progress output.',
-                        },
-                    ]);
-                });
-            }
-        });
-
-        eventSource.onerror = () => {
-            eventSource.close();
-            eventSourceRef.current = null;
-            setIsRestoring(false);
-            setIsComplete(true);
-            setLogs((current) => [
-                ...current,
-                {
-                    id: crypto.randomUUID(),
-                    type: 'error',
-                    message: 'The restore stream disconnected unexpectedly.',
-                },
-            ]);
-        };
-    }
-
-    return (
-        <div className="space-y-5">
-            <div className="rounded-lg border bg-muted/30 p-4">
-                <div className="flex flex-wrap items-center gap-2 text-sm">
-                    <span className="font-medium">Root namespace:</span>
-                    <span>{restorePreview.root.name}</span>
-                    <span className="text-muted-foreground">
-                        /{restorePreview.root.full_path}
-                    </span>
-                    <span className="rounded-full bg-background px-2 py-0.5 text-xs">
-                        {restorePreview.root.status}
-                    </span>
-                </div>
-                <div className="mt-3 grid gap-2 text-sm text-muted-foreground sm:grid-cols-3">
-                    <div>
-                        {restorePreview.totals.namespace_count} namespaces
-                    </div>
-                    <div>
-                        {restorePreview.totals.new_namespace_count} new /{' '}
-                        {restorePreview.totals.existing_namespace_count}{' '}
-                        existing
-                    </div>
-                    <div>
-                        {restorePreview.totals.post_count} posts (
-                        {restorePreview.totals.new_post_count} new /{' '}
-                        {restorePreview.totals.existing_post_count} existing)
-                    </div>
-                </div>
-            </div>
-
-            <div className="rounded-lg border bg-black p-3 font-mono text-xs text-green-400">
-                {logs.length === 0 ? (
-                    <div className="text-muted">
-                        {isRestoring
-                            ? 'Waiting for restore output...'
-                            : 'No restore output yet.'}
-                    </div>
-                ) : (
-                    <div className="max-h-56 space-y-1 overflow-auto">
-                        {logs.map((log) => (
-                            <div key={log.id}>
-                                [{log.type}] {log.message}
-                            </div>
-                        ))}
-                    </div>
-                )}
-            </div>
-
-            <div className="max-h-56 overflow-auto rounded-lg border">
-                <table className="w-full text-sm">
-                    <thead>
-                        <tr className="border-b bg-muted/50">
-                            <th className="px-4 py-2 text-left font-medium">
-                                Namespace
-                            </th>
-                            <th className="px-4 py-2 text-left font-medium">
-                                Status
-                            </th>
-                            <th className="px-4 py-2 text-left font-medium">
-                                Posts
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {restorePreview.namespaces.map((item) => (
-                            <tr
-                                key={item.full_path}
-                                className="border-b last:border-0"
-                            >
-                                <td className="px-4 py-2">
-                                    <div className="font-medium">
-                                        {item.name}
-                                    </div>
-                                    <div className="text-xs text-muted-foreground">
-                                        /{item.full_path}
-                                    </div>
-                                </td>
-                                <td className="px-4 py-2">
-                                    <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground capitalize">
-                                        {item.status}
-                                    </span>
-                                </td>
-                                <td className="px-4 py-2 text-muted-foreground">
-                                    {item.post_count} total /{' '}
-                                    {item.new_post_count} new /{' '}
-                                    {item.existing_post_count} existing
-                                </td>
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
-
-            <DialogDescription className="space-y-2">
-                {hasOverwriteTargets ? (
-                    <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                        Existing namespaces and posts matched by backup path
-                        will be overwritten by this restore.
-                    </div>
-                ) : (
-                    <p>
-                        Existing namespaces and posts will be overwritten when
-                        their backup paths match.
-                    </p>
-                )}
-            </DialogDescription>
-
-            <DialogFooter className="gap-2">
-                <Button
-                    variant="secondary"
-                    onClick={clearPreview}
-                    disabled={isRestoring}
-                >
-                    {isComplete ? 'Close' : 'Cancel'}
-                </Button>
-                <Button
-                    onClick={startRestore}
-                    disabled={isRestoring || isComplete}
-                >
-                    <Upload className="size-4" />
-                    {isRestoring
-                        ? 'Restoring...'
-                        : isComplete
-                          ? 'Restore Complete'
-                          : 'Run Restore'}
-                </Button>
-            </DialogFooter>
-        </div>
-    );
-}
-
-function RestoreNamespacesDialog({
-    restoreUploadUrl,
-    restorePreview,
-    triggerClassName,
-}: {
-    restoreUploadUrl: string;
-    restorePreview: RestorePreview | null;
-    triggerClassName?: string;
-}) {
-    const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false);
-    const [isDraggingBackup, setIsDraggingBackup] = useState(false);
-    const backupInputRef = useRef<HTMLInputElement | null>(null);
-    const dragCounterRef = useRef(0);
-    const uploadForm = useForm<{ backup: File | null }>({ backup: null });
-
-    const hasOverwriteTargets =
-        (restorePreview?.totals.existing_namespace_count ?? 0) > 0 ||
-        (restorePreview?.totals.existing_post_count ?? 0) > 0;
-    const open = restorePreview !== null || isUploadDialogOpen;
-
-    function clearPreview() {
-        router.get(index.url(), undefined, {
-            preserveScroll: true,
-            replace: true,
-        });
-    }
-
-    function handleOpenChange(nextOpen: boolean) {
-        if (!nextOpen && restorePreview) {
-            clearPreview();
-
-            return;
-        }
-
-        setIsUploadDialogOpen(nextOpen);
-    }
-
-    const hasErrors = Object.keys(uploadForm.errors).length > 0;
-
-    function uploadBackup() {
-        uploadForm.post(restoreUploadUrl, {
-            forceFormData: true,
-            preserveScroll: true,
-            onSuccess: () => uploadForm.reset('backup'),
-        });
-    }
-
-    function handleBackupFile(file: File | null) {
-        if (!file) {
-            return;
-        }
-
-        const isZipFile =
-            file.type === 'application/zip' || file.name.endsWith('.zip');
-
-        if (!isZipFile) {
-            return;
-        }
-
-        uploadForm.setData('backup', file);
-
-        if (backupInputRef.current) {
-            const transfer = new DataTransfer();
-            transfer.items.add(file);
-            backupInputRef.current.files = transfer.files;
-        }
-    }
-
-    function handleDragEnter(event: React.DragEvent<HTMLDivElement>) {
-        event.preventDefault();
-        dragCounterRef.current++;
-        setIsDraggingBackup(true);
-    }
-
-    function handleDragLeave() {
-        dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
-
-        if (dragCounterRef.current === 0) {
-            setIsDraggingBackup(false);
-        }
-    }
-
-    function handleDrop(event: React.DragEvent<HTMLDivElement>) {
-        event.preventDefault();
-        dragCounterRef.current = 0;
-        setIsDraggingBackup(false);
-
-        handleBackupFile(event.dataTransfer.files[0] ?? null);
-    }
-
-    return (
-        <Dialog open={open} onOpenChange={handleOpenChange}>
-            <DialogTrigger asChild>
-                <Button variant="outline" className={triggerClassName}>
-                    <Upload className="size-4" />
-                    Restore Zip
-                </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-3xl">
-                <DialogTitle>Restore Namespaces From Zip</DialogTitle>
-                <DialogDescription className="space-y-2">
-                    <p>
-                        Upload a namespace backup zip from the root namespace
-                        dashboard.
-                    </p>
-                </DialogDescription>
-
-                {restorePreview ? (
-                    <RestorePreviewPanel
-                        key={restorePreview.token}
-                        restorePreview={restorePreview}
-                        hasOverwriteTargets={hasOverwriteTargets}
-                        clearPreview={clearPreview}
-                    />
-                ) : (
-                    <form
-                        onSubmit={(event) => {
-                            event.preventDefault();
-                            uploadBackup();
-                        }}
-                        className="space-y-4"
-                    >
-                        <div
-                            onClick={() => backupInputRef.current?.click()}
-                            onDragEnter={handleDragEnter}
-                            onDragOver={(event) => event.preventDefault()}
-                            onDragLeave={handleDragLeave}
-                            onDrop={handleDrop}
-                            className={cn(
-                                'cursor-pointer rounded-lg border border-dashed p-8 transition-colors',
-                                isDraggingBackup
-                                    ? 'border-ring bg-ring/8'
-                                    : 'border-input bg-muted/30 hover:border-ring/60 hover:bg-muted/50',
-                            )}
-                        >
-                            <div className="flex flex-col items-center gap-3 text-center">
-                                <div
-                                    className={cn(
-                                        'rounded-full border-2 border-dashed p-4 transition-colors',
-                                        isDraggingBackup
-                                            ? 'border-ring text-ring'
-                                            : 'border-muted-foreground/30 text-muted-foreground',
-                                    )}
-                                >
-                                    <Upload className="size-8" />
-                                </div>
-                                <div className="space-y-1">
-                                    <p className="text-sm font-medium">
-                                        {isDraggingBackup
-                                            ? 'Drop zip to upload'
-                                            : uploadForm.data.backup
-                                              ? uploadForm.data.backup.name
-                                              : 'Drop zip here'}
-                                    </p>
-                                    <p className="text-xs text-muted-foreground">
-                                        {uploadForm.data.backup
-                                            ? 'Click or drop another zip to replace the current selection.'
-                                            : 'or click to browse for a backup zip'}
-                                    </p>
-                                </div>
-                                <p className="text-xs text-muted-foreground/80">
-                                    ZIP archive only
-                                </p>
-                            </div>
-                        </div>
-                        <input
-                            ref={backupInputRef}
-                            type="file"
-                            name="backup"
-                            accept=".zip,application/zip"
-                            className="sr-only"
-                            onChange={(event) =>
-                                handleBackupFile(
-                                    event.currentTarget.files?.[0] ?? null,
-                                )
-                            }
-                        />
-                        {uploadForm.progress && (
-                            <p className="text-sm text-muted-foreground">
-                                Uploading... {uploadForm.progress.percentage}%
-                            </p>
-                        )}
-                        {uploadForm.data.backup && (
-                            <button
-                                type="button"
-                                onClick={() => {
-                                    uploadForm.setData('backup', null);
-
-                                    if (backupInputRef.current) {
-                                        const transfer = new DataTransfer();
-                                        backupInputRef.current.files =
-                                            transfer.files;
-                                    }
-                                }}
-                                className="text-xs text-muted-foreground hover:text-destructive"
-                            >
-                                Clear selection
-                            </button>
-                        )}
-                        {hasErrors && (
-                            <InputError message={uploadForm.errors.backup} />
-                        )}
-                        <DialogFooter className="gap-2">
-                            <DialogClose asChild>
-                                <Button variant="secondary">Cancel</Button>
-                            </DialogClose>
-                            <Button
-                                type="submit"
-                                disabled={
-                                    uploadForm.processing ||
-                                    uploadForm.data.backup === null
-                                }
-                            >
-                                <Upload className="size-4" />
-                                Upload Zip
-                            </Button>
-                        </DialogFooter>
-                    </form>
-                )}
-            </DialogContent>
-        </Dialog>
-    );
-}
-
 function NamespacesHeaderPanel({
     namespaces,
     reorderMode,
-    restoreUploadUrl,
-    restorePreview,
     sort,
     onToggleReorder,
 }: {
     namespaces: Namespace[];
     reorderMode: boolean;
-    restoreUploadUrl: string;
-    restorePreview: RestorePreview | null;
     sort: Sort;
     onToggleReorder: () => void;
 }) {
@@ -838,8 +363,8 @@ function NamespacesHeaderPanel({
                                 </h2>
                                 <p className="text-sm leading-6 text-muted-foreground">
                                     Create a new root namespace, reorder the
-                                    current tree, or restore a zip backup into
-                                    the hierarchy.
+                                    current tree, or jump to Backups to restore
+                                    a zip archive into the hierarchy.
                                 </p>
                             </div>
 
@@ -875,11 +400,12 @@ function NamespacesHeaderPanel({
                                         )}
                                     </Button>
 
-                                    <RestoreNamespacesDialog
-                                        restoreUploadUrl={restoreUploadUrl}
-                                        restorePreview={restorePreview}
-                                        triggerClassName="w-full"
-                                    />
+                                    <Button variant="outline" size="lg" asChild>
+                                        <Link href={backupsIndex.url()}>
+                                            <Archive className="size-4" />
+                                            Open Backups
+                                        </Link>
+                                    </Button>
                                 </div>
                             </div>
 
@@ -1170,13 +696,9 @@ function ChildRow({
 export default function Index({
     namespaces: initialNamespaces,
     sort,
-    restore_upload_url,
-    restore_preview,
 }: {
     namespaces: Namespace[];
     sort: Sort;
-    restore_upload_url: string;
-    restore_preview: RestorePreview | null;
 }) {
     const [namespaces, setNamespaces] = useState(initialNamespaces);
     const [reorderMode, setReorderMode] = useState(false);
@@ -1259,8 +781,6 @@ export default function Index({
                 <NamespacesHeaderPanel
                     namespaces={namespaces}
                     reorderMode={reorderMode}
-                    restoreUploadUrl={restore_upload_url}
-                    restorePreview={restore_preview}
                     sort={sort}
                     onToggleReorder={handleReorderToggle}
                 />

--- a/tests/Feature/Admin/BackupControllerTest.php
+++ b/tests/Feature/Admin/BackupControllerTest.php
@@ -138,8 +138,22 @@ test('authenticated users can view the backups index', function () {
                 ->where('backups.1.namespace.id', $alpha->id)
                 ->where('delete_backups_url', route('admin.backups.destroyMany', absolute: false))
                 ->where('create_backups_url', route('admin.backups.storeMany', absolute: false))
+                ->where('restore_upload_url', route('admin.posts.restore.upload', absolute: false))
+                ->where('restore_preview', null)
             );
     });
+});
+
+test('backups index ignores invalid restore tokens', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('admin.backups.index', ['restore' => '../malicious']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/backups/index')
+            ->where('restore_preview', null)
+        );
 });
 
 test('authenticated users can delete selected backups from the backups index', function () {

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -126,15 +126,15 @@ test('posts index defaults to namespace sort order', function () {
         );
 });
 
-test('posts index exposes root restore upload metadata', function () {
+test('posts index no longer exposes root restore upload metadata', function () {
     $user = User::factory()->create();
 
     $this->actingAs($user)
         ->get(route('admin.posts.index'))
         ->assertInertia(fn ($page) => $page
             ->component('admin/posts/index')
-            ->where('restore_upload_url', route('admin.posts.restore.upload', absolute: false))
-            ->where('restore_preview', null)
+            ->missing('restore_upload_url')
+            ->missing('restore_preview')
         );
 });
 
@@ -184,7 +184,7 @@ test('create form includes available tags', function () {
         );
 });
 
-test('uploading a restore zip from the posts index returns a restore preview', function () {
+test('uploading a restore zip from the backups index returns a restore preview', function () {
     $user = User::factory()->create();
     $existingNamespace = PostNamespace::factory()->create([
         'slug' => 'guides',
@@ -244,12 +244,12 @@ test('uploading a restore zip from the posts index returns a restore preview', f
 
         $location = $response->headers->get('Location');
 
-        expect($location)->not->toBeNull()->and($location)->toContain('/admin/posts?restore=');
+        expect($location)->not->toBeNull()->and($location)->toContain('/admin/backups?restore=');
 
         $this->actingAs($user)
             ->get($location)
             ->assertInertia(fn ($page) => $page
-                ->component('admin/posts/index')
+                ->component('admin/backups/index')
                 ->where('restore_preview.root.full_path', 'guides')
                 ->where('restore_preview.root.status', 'existing')
                 ->where('restore_preview.totals.namespace_count', 2)


### PR DESCRIPTION
## Summary
- move root restore upload/preview props from the posts index to the backups dashboard
- add the backups-page restore UI and restore the posts-page backlink to Backups
- harden restore token path handling and cover the moved flow with feature tests

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/Admin/BackupControllerTest.php tests/Feature/Admin/PostControllerTest.php
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build
- vendor/bin/sail npm run format:check
- vendor/bin/sail bin pint --dirty --format agent