### PR TITLE
Refine sticky docs chrome and cover image UX

### DIFF
--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -115,7 +115,7 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
 
     return (
         <>
-            <div className="border-b border-sidebar-border/80">
+            <div className="sticky top-0 z-50 border-b border-sidebar-border/80 bg-background">
                 <div className="mx-auto flex h-16 items-center px-4 md:max-w-7xl">
                     {/* Mobile Menu */}
                     <div className="lg:hidden">

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -141,7 +141,9 @@ function MessageBox({
             {...props}
         >
             <Icon className={cn('mt-0.5 shrink-0', iconColor)} size={18} />
-            <div className="min-w-0 flex-1">{children}</div>
+            <div className="min-w-0 flex-1 [&_h1]:mb-2 [&_h1]:font-semibold [&_h2]:mb-2 [&_h2]:font-semibold [&_h3]:mb-1.5 [&_h3]:font-semibold [&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-4 [&_p:not(:last-child)]:mb-2 [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-4">
+                {children}
+            </div>
         </aside>
     );
 }

--- a/resources/js/lib/markdown-components.tsx
+++ b/resources/js/lib/markdown-components.tsx
@@ -26,6 +26,7 @@ export const HeadingIdContext = createContext<
 
 export type MarkdownComponentOptions = {
     headingAnchorPlacement?: 'inline' | 'gutter';
+    scrollMargin?: string;
     onEditHeading?: (payload: {
         level: number;
         text: string;
@@ -96,6 +97,7 @@ function makeHeadingComponents(
     postSlug?: string,
     {
         headingAnchorPlacement = 'inline',
+        scrollMargin = 'scroll-mt-24',
         onEditHeading,
     }: MarkdownComponentOptions = {},
 ): Pick<Components, 'h1' | 'h2' | 'h3'> {
@@ -118,7 +120,8 @@ function makeHeadingComponents(
                 <Tag
                     id={id}
                     className={cn(
-                        'group scroll-mt-24',
+                        'group',
+                        scrollMargin,
                         headingAnchorPlacement === 'gutter' && 'relative',
                     )}
                 >

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -266,6 +266,7 @@ export function preprocessMintlifySyntax(markdown: string): string {
     let activeFence: string | null = null;
     let activeFenceIndent = 0;
     let mintlifyTabsDepth = 0;
+    const mintlifyCalloutColonCounts: number[] = [];
     const mintlifyTagStack: Array<
         | 'Tabs'
         | 'Tab'
@@ -373,12 +374,16 @@ export function preprocessMintlifySyntax(markdown: string): string {
 
         if (calloutOpenMatch) {
             const tag = calloutOpenMatch.groups!.tag as MintlifyCalloutTag;
+            const colonCount = 3 + 5 - mintlifyCalloutColonCounts.length;
+            const template = MINTLIFY_CALLOUT_TAGS[tag];
+            const directiveBody = template.slice(3);
 
             pushBlankLineIfNeeded();
-            pushLine(MINTLIFY_CALLOUT_TAGS[tag]);
+            pushLine(':'.repeat(colonCount) + directiveBody);
             pushLine('');
             mintlifyTagLeadingSpaces.push(leadingSpaces);
             mintlifyTagStack.push(tag);
+            mintlifyCalloutColonCounts.push(colonCount);
 
             continue;
         }
@@ -389,14 +394,16 @@ export function preprocessMintlifySyntax(markdown: string): string {
 
         if (calloutCloseMatch) {
             const tag = calloutCloseMatch.groups!.tag as MintlifyCalloutTag;
+            let colonCount = 3;
 
             if (mintlifyTagStack.at(-1) === tag) {
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
+                colonCount = mintlifyCalloutColonCounts.pop() ?? 3;
             }
 
             pushBlankLineIfNeeded();
-            pushLine(':::');
+            pushLine(':'.repeat(colonCount));
 
             continue;
         }

--- a/resources/js/pages/admin/namespaces/edit.tsx
+++ b/resources/js/pages/admin/namespaces/edit.tsx
@@ -5,6 +5,14 @@ import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceC
 import CoverImageDropzone from '@/components/cover-image-dropzone';
 import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogTitle,
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
@@ -52,8 +60,10 @@ export default function Edit({
 
     const [generating, setGenerating] = useState(false);
     const [additionalPrompt, setAdditionalPrompt] = useState('');
+    const [showGenerateConfirm, setShowGenerateConfirm] = useState(false);
 
     function generateCoverImage() {
+        setShowGenerateConfirm(false);
         router.post(
             NamespaceController.generateCoverImage.url(namespace.id),
             { additional_prompt: additionalPrompt },
@@ -62,6 +72,14 @@ export default function Edit({
                 onFinish: () => setGenerating(false),
             },
         );
+    }
+
+    function handleGenerateClick() {
+        if (namespace.cover_image_url) {
+            setShowGenerateConfirm(true);
+        } else {
+            generateCoverImage();
+        }
     }
 
     const { data, setData, post, processing, errors } = useForm<{
@@ -153,7 +171,7 @@ export default function Edit({
                                     variant="outline"
                                     size="sm"
                                     disabled={generating || processing}
-                                    onClick={generateCoverImage}
+                                    onClick={handleGenerateClick}
                                 >
                                     {generating ? (
                                         <Spinner className="mr-1.5" />
@@ -173,6 +191,13 @@ export default function Edit({
                                 onChange={(e) =>
                                     setAdditionalPrompt(e.target.value)
                                 }
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter') {
+                                        e.preventDefault();
+                                        if (!generating && !processing)
+                                            handleGenerateClick();
+                                    }
+                                }}
                                 placeholder="Optional: add style guidance, colors, mood… (any language)"
                                 disabled={generating || processing}
                                 maxLength={500}
@@ -215,6 +240,26 @@ export default function Edit({
                     </div>
                 </form>
             </div>
+            <Dialog
+                open={showGenerateConfirm}
+                onOpenChange={setShowGenerateConfirm}
+            >
+                <DialogContent>
+                    <DialogTitle>Replace existing cover image?</DialogTitle>
+                    <DialogDescription>
+                        This namespace already has a cover image. Generating a
+                        new one will permanently replace it.
+                    </DialogDescription>
+                    <DialogFooter className="gap-2">
+                        <DialogClose asChild>
+                            <Button variant="secondary">Cancel</Button>
+                        </DialogClose>
+                        <Button onClick={generateCoverImage}>
+                            Generate anyway
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </>
     );
 }

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -210,6 +210,7 @@ export default function Show({
         auth.user
             ? {
                   headingAnchorPlacement: 'gutter',
+                  scrollMargin: 'scroll-mt-40',
                   onEditHeading: handleEditHeading,
               }
             : {},
@@ -315,7 +316,9 @@ export default function Show({
                     </div>
                 )}
 
-                <header className="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur">
+                <header
+                    className={`sticky z-50 border-b border-border/60 bg-background/80 backdrop-blur ${auth.user ? 'top-16' : 'top-0'}`}
+                >
                     <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-4 lg:py-6">
                         <div className="flex min-w-0 items-center gap-2">
                             <Link
@@ -460,11 +463,13 @@ export default function Show({
                     className={`mx-auto max-w-7xl px-4 py-10 ${gridCols ? `lg:grid lg:gap-12 ${gridCols}` : ''}`}
                 >
                     {hasNav && (
-                        <aside className="hidden self-start lg:sticky lg:top-20 lg:block">
+                        <aside
+                            className={`hidden self-start lg:sticky lg:block ${auth.user ? 'lg:top-36' : 'lg:top-20'}`}
+                        >
                             {navVisible ? (
                                 <div
                                     data-test="content-nav-shell"
-                                    className="flex max-h-[calc(100vh-6rem)] flex-col text-sm"
+                                    className={`flex flex-col text-sm ${auth.user ? 'max-h-[calc(100vh-10rem)]' : 'max-h-[calc(100vh-6rem)]'}`}
                                 >
                                     <div className="shrink-0 pb-4">
                                         <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
@@ -514,7 +519,7 @@ export default function Show({
                         <article className="space-y-4">
                             <header
                                 id={`post-${post.slug}`}
-                                className="scroll-mt-24 space-y-4"
+                                className={`space-y-4 ${auth.user ? 'scroll-mt-40' : 'scroll-mt-24'}`}
                             >
                                 <div
                                     data-test="post-title-row"
@@ -623,7 +628,9 @@ export default function Show({
                     </main>
 
                     {tocVisible && hasHeadings && (
-                        <aside className="hidden self-start lg:sticky lg:top-20 lg:block">
+                        <aside
+                            className={`hidden self-start lg:sticky lg:block ${auth.user ? 'lg:top-36' : 'lg:top-20'}`}
+                        >
                             <TableOfContents
                                 sticky
                                 posts={[

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -564,6 +564,76 @@ const x = 1;
     assert.match(output, /<CodeGroup>/);
 });
 
+test('preprocessMarkdownSyntax uses more colons for outer callout than inner when nested', () => {
+    const output = preprocessMarkdownSyntax(`<Note>
+  Outer note.
+  <Info>
+    Inner info.
+  </Info>
+</Note>`);
+
+    const lines = output.split('\n');
+    const outerLine = lines.find((l) => l.includes('message{.note}')) ?? '';
+    const innerLine = lines.find((l) => /^:{3,}message(?!\{\.note\})/.test(l)) ?? '';
+    const outerColons = (outerLine.match(/^(:{3,})/)?.[1] ?? '').length;
+    const innerColons = (innerLine.match(/^(:{3,})/)?.[1] ?? '').length;
+
+    assert.ok(outerColons >= 3, 'outer directive should use at least 3 colons');
+    assert.ok(innerColons >= 3, 'inner directive should use at least 3 colons');
+    assert.ok(outerColons > innerColons, 'outer directive must use more colons than inner to allow nesting');
+    assert.match(output, /Outer note\./);
+    assert.match(output, /Inner info\./);
+});
+
+test('preprocessMarkdownSyntax nested callout produces no stray ::: in output', () => {
+    const output = preprocessMarkdownSyntax(`<Note>
+  Some content.
+
+  <Info>
+    Nested hint.
+  </Info>
+</Note>`);
+
+    const lines = output.split('\n');
+    const strayClosings = lines.filter((l) => /^:{3}$/.test(l.trim()));
+
+    assert.equal(strayClosings.length, 0, 'no stray ::: close tags should appear in output');
+    assert.match(output, /Some content\./);
+    assert.match(output, /Nested hint\./);
+});
+
+test('preprocessMarkdownSyntax supports three levels of callout nesting without stray :::', () => {
+    const output = preprocessMarkdownSyntax(`<Note>
+  Level one.
+  <Info>
+    Level two.
+    <Tip>
+      Level three.
+    </Tip>
+  </Info>
+</Note>`);
+
+    const lines = output.split('\n');
+    const strayClosings = lines.filter((l) => /^:{3}$/.test(l.trim()));
+
+    assert.equal(strayClosings.length, 0, 'no stray ::: close tags should appear');
+    assert.match(output, /Level one\./);
+    assert.match(output, /Level two\./);
+    assert.match(output, /Level three\./);
+});
+
+test('preprocessMarkdownSyntax non-nested callout still emits a valid message directive', () => {
+    const output = preprocessMarkdownSyntax(`<Note>
+  Stand-alone note.
+</Note>`);
+
+    const lines = output.split('\n');
+    const directiveLine = lines.find((l) => l.includes('message{.note}')) ?? '';
+
+    assert.ok(/^:{3,}message\{\.note\}$/.test(directiveLine), 'directive line should be colons + message{.note}');
+    assert.match(output, /Stand-alone note\./);
+});
+
 test('preprocessMarkdownContent encodes image metadata outside fences only', () => {
     const output =
         preprocessMarkdownContent(`![Guide cover](/storage/guide.png =250x)

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -312,6 +312,93 @@ test('desktop sidebars stay sticky while the article scrolls', function () {
     JS))->toBeTrue();
 });
 
+test('signed-in post pages keep sticky navigation and hash scrolling below the stacked headers', function () {
+    $user = User::factory()->create([
+        'email' => 'test@example.com',
+    ]);
+
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+        'is_published' => true,
+    ]);
+
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'slug' => 'signed-in-sticky-offsets',
+        'title' => 'Signed In Sticky Offsets',
+        'content' => collect([
+            '## Installation',
+            str_repeat('Setup steps. ', 120),
+            '## Cache Behavior',
+            str_repeat('Cache notes. ', 120),
+            ...collect(range(1, 24))
+                ->map(
+                    fn (int $section): string => "## Section {$section}\n\n".str_repeat(
+                        'Long body content. ',
+                        40,
+                    ),
+                )
+                ->all(),
+        ])->implode("\n\n"),
+    ]);
+
+    $headingId = 'signed-in-sticky-offsets-cache-behavior';
+
+    $this->actingAs($user);
+
+    $page = visit(route('posts.path', ['path' => $post->full_path]))->resize(1440, 1200);
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="app-header-search-toggle"]')
+        ->assertPresent('[data-test="content-nav-shell"]')
+        ->assertPresent('[data-test="table-of-contents"][data-sticky="true"]');
+
+    $page->script('window.scrollTo(0, 1400)');
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const leftSidebar = document.querySelector('[data-test="content-nav-shell"]');
+            const rightSidebar = document.querySelector('[data-test="table-of-contents"][data-sticky="true"]');
+
+            if (! leftSidebar || ! rightSidebar) {
+                return null;
+            }
+
+            return {
+                leftTop: Math.round(leftSidebar.getBoundingClientRect().top),
+                rightTop: Math.round(rightSidebar.getBoundingClientRect().top),
+            };
+        })()
+    JS))->toBe([
+        'leftTop' => 144,
+        'rightTop' => 144,
+    ]);
+
+    $page
+        ->click("[data-test=\"table-of-contents\"][data-sticky=\"true\"] [data-test=\"toc-link-{$headingId}\"]")
+        ->wait(0.5);
+
+    $metrics = $page->script(<<<JS
+        (() => {
+            const heading = document.getElementById('{$headingId}');
+
+            if (! heading) {
+                return null;
+            }
+
+            return {
+                hash: window.location.hash,
+                top: Math.round(heading.getBoundingClientRect().top),
+            };
+        })()
+    JS);
+
+    expect($metrics['hash'])->toBe("#{$headingId}");
+    expect($metrics['top'])->toBeGreaterThanOrEqual(128);
+    expect($metrics['top'])->toBeLessThanOrEqual(220);
+});
+
 test('post navigation folders can be expanded from the sidebar', function () {
     $namespace = PostNamespace::factory()->create([
         'slug' => 'docs',
@@ -939,6 +1026,75 @@ test('admin namespace page shows a cover image thumbnail in the manage header', 
             'src',
             '/storage/namespaces/guides-cover.jpg',
         );
+});
+
+test('admin namespace edit asks before replacing an existing AI-generated cover image', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create([
+        'email' => 'test@example.com',
+    ]);
+
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+        'cover_image' => 'namespaces/guides-cover.jpg',
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.namespaces.edit', $namespace, absolute: false))->resize(1440, 900);
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertSee('Edit Namespace')
+        ->assertSee('Generate with AI')
+        ->type('input[maxlength="500"]', 'moody cinematic colors');
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const input = document.querySelector('input[maxlength="500"]');
+
+            if (! input) {
+                return false;
+            }
+
+            input.dispatchEvent(new KeyboardEvent('keydown', {
+                key: 'Enter',
+                bubbles: true,
+                cancelable: true,
+            }));
+
+            return true;
+        })()
+    JS))->toBeTrue();
+
+    $page
+        ->wait(0.3)
+        ->assertPresent('[role="dialog"]')
+        ->assertSee('Replace existing cover image?')
+        ->assertSee('Generate anyway');
+
+    expect($page->script(<<<'JS'
+        (() => window.location.pathname)()
+    JS))->toBe(route('admin.namespaces.edit', $namespace, false));
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const cancelButton = [...document.querySelectorAll('[role="dialog"] button')]
+                .find((button) => button.textContent?.includes('Cancel'));
+
+            if (! cancelButton) {
+                return false;
+            }
+
+            cancelButton.click();
+
+            return true;
+        })()
+    JS))->toBeTrue();
+
+    $page->wait(0.2)->assertMissing('[role="dialog"]');
 });
 
 test('admin namespace page shows backup count and backup management button when backups exist', function () {


### PR DESCRIPTION
## Summary
- keep the authenticated docs chrome stacked correctly on public post pages and preserve heading hash offsets
- add a confirmation step before AI cover generation overwrites an existing namespace cover image
- extend browser and markdown regression coverage for the new sticky/header and nested callout behaviors

## Testing
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run format:check
- vendor/bin/sail bin pint --dirty --format agent
- rm -f public/hot && vendor/bin/sail npm run build
- vendor/bin/sail artisan test --compact tests/Browser/SmokeTest.php --filter="signed-in post pages keep sticky navigation and hash scrolling below the stacked headers|admin namespace edit asks before replacing an existing AI-generated cover image"