### PR TITLE
Review markdown editor paste links

### DIFF
--- a/resources/js/components/markdown-editor.tsx
+++ b/resources/js/components/markdown-editor.tsx
@@ -2,6 +2,7 @@ import { router, usePage } from '@inertiajs/react';
 import { ArrowLeft, ArrowRight, Code2, Eye } from 'lucide-react';
 import {
     forwardRef,
+    useCallback,
     useEffect,
     useImperativeHandle,
     useRef,
@@ -13,6 +14,7 @@ import MarkdownContent from '@/components/markdown-content';
 import { Label } from '@/components/ui/label';
 import { createMarkdownComponents } from '@/lib/markdown-components';
 import { normalizeMarkdownHeadingText } from '@/lib/markdown-heading-text';
+import { isAbsoluteUrl } from '@/lib/markdown-syntax';
 import { slugify } from '@/lib/slugify';
 import { cn } from '@/lib/utils';
 
@@ -30,6 +32,7 @@ type Props = {
     error?: string;
     uploadUrl?: string;
     jumpTo?: number;
+    disabled?: boolean;
     onSelectionChange?: (hasSelection: boolean) => void;
     toolbar?: React.ReactNode;
 };
@@ -43,6 +46,7 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
             error,
             uploadUrl,
             jumpTo,
+            disabled = false,
             onSelectionChange,
             toolbar,
         }: Props,
@@ -52,6 +56,7 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
         const [activeTab, setActiveTab] = useState<'write' | 'preview'>(
             'write',
         );
+        const valueRef = useRef(defaultValue);
 
         const lastSelectionRef = useRef<{
             text: string;
@@ -59,22 +64,37 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
             end: number;
         } | null>(null);
 
+        const updateValue = useCallback(
+            (updater: React.SetStateAction<string>) => {
+                const nextValue =
+                    typeof updater === 'function'
+                        ? (updater as (previous: string) => string)(
+                              valueRef.current,
+                          )
+                        : updater;
+
+                valueRef.current = nextValue;
+                setValue(nextValue);
+            },
+            [],
+        );
+
         useImperativeHandle(
             ref,
             () => ({
-                setContent: (content: string) => setValue(content),
+                setContent: (content: string) => updateValue(content),
                 getContent: () => value,
                 getSelection: () => lastSelectionRef.current,
                 replaceRange: (start: number, end: number, newText: string) => {
                     lastSelectionRef.current = null;
                     onSelectionChange?.(false);
-                    setValue(
+                    updateValue(
                         (prev) =>
                             prev.slice(0, start) + newText + prev.slice(end),
                     );
                 },
             }),
-            [value, onSelectionChange],
+            [onSelectionChange, updateValue, value],
         );
         const textareaRef = useRef<HTMLTextAreaElement>(null);
         const previewRef = useRef<HTMLDivElement>(null);
@@ -94,7 +114,7 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
                 const { selectionStart, selectionEnd } = textarea;
                 const markdown = `![image](${props.imageUrl})`;
 
-                setValue((prevContent) => {
+                updateValue((prevContent) => {
                     const newContent =
                         prevContent.substring(0, selectionStart) +
                         markdown +
@@ -109,7 +129,7 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
                     return newContent;
                 });
             }
-        }, [props.imageUrl]);
+        }, [props.imageUrl, updateValue]);
 
         useEffect(() => {
             if (hasJumpedRef.current || jumpTo === undefined) {
@@ -138,10 +158,9 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
                 ) || 20;
             const lineIndex =
                 textarea.value.slice(0, clamped).split(/\r?\n/).length - 1;
-            textarea.scrollTop = Math.max(
-                0,
-                lineIndex * lineHeight - lineHeight * 2,
-            );
+            textarea.scrollTo({
+                top: Math.max(0, lineIndex * lineHeight - lineHeight * 2),
+            });
 
             const line = textarea.value.slice(clamped, selectionEnd);
             const headingMatch = /^(#{1,6})\s+(.+?)(?:\s+#+\s*)?$/.exec(line);
@@ -158,7 +177,13 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
                     const containerTop =
                         previewRef.current.getBoundingClientRect().top;
                     const elTop = el.getBoundingClientRect().top;
-                    previewRef.current.scrollTop += elTop - containerTop - 16;
+                    previewRef.current.scrollTo({
+                        top:
+                            previewRef.current.scrollTop +
+                            elTop -
+                            containerTop -
+                            16,
+                    });
                 }
             }
 
@@ -210,8 +235,9 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
             }
 
             const ratio = textarea.scrollTop / scrollableHeight;
-            preview.scrollTop =
-                ratio * (preview.scrollHeight - preview.clientHeight);
+            preview.scrollTo({
+                top: ratio * (preview.scrollHeight - preview.clientHeight),
+            });
         };
 
         const syncRightToLeft = () => {
@@ -230,8 +256,9 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
             }
 
             const ratio = preview.scrollTop / scrollableHeight;
-            textarea.scrollTop =
-                ratio * (textarea.scrollHeight - textarea.clientHeight);
+            textarea.scrollTo({
+                top: ratio * (textarea.scrollHeight - textarea.clientHeight),
+            });
         };
 
         const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
@@ -246,6 +273,37 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
                 if (file) {
                     handleImageUpload(file);
                 }
+
+                return;
+            }
+
+            const pastedText = e.clipboardData.getData('text/plain').trim();
+            const { selectionStart, selectionEnd } = e.currentTarget;
+
+            if (selectionStart !== selectionEnd && isAbsoluteUrl(pastedText)) {
+                e.preventDefault();
+                const selectedText = e.currentTarget.value.slice(
+                    selectionStart,
+                    selectionEnd,
+                );
+                const markdownLink = `[${selectedText}](${pastedText})`;
+
+                updateValue(
+                    (prev) =>
+                        prev.slice(0, selectionStart) +
+                        markdownLink +
+                        prev.slice(selectionEnd),
+                );
+
+                setTimeout(() => {
+                    if (textareaRef.current) {
+                        const pos = selectionStart + markdownLink.length;
+                        textareaRef.current.setSelectionRange(pos, pos);
+                    }
+                }, 0);
+
+                lastSelectionRef.current = null;
+                onSelectionChange?.(false);
             }
         };
 
@@ -334,7 +392,7 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
                                 id={name}
                                 name={name}
                                 value={value}
-                                onChange={(e) => setValue(e.target.value)}
+                                onChange={(e) => updateValue(e.target.value)}
                                 onSelect={(e) => {
                                     const t = e.currentTarget;
                                     const has =
@@ -389,11 +447,13 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
                                         ? (e) => e.preventDefault()
                                         : undefined
                                 }
-                                onPaste={uploadUrl ? handlePaste : undefined}
+                                onPaste={handlePaste}
+                                readOnly={disabled}
                                 placeholder="Write markdown here..."
                                 className={cn(
                                     'h-[50vh] w-full resize-none border-0 bg-transparent px-4 pb-4 font-mono text-sm shadow-none outline-none placeholder:text-muted-foreground/60 lg:h-[65vh]',
                                     error && 'border-b border-destructive',
+                                    disabled && 'cursor-not-allowed opacity-50',
                                 )}
                             />
                         </div>

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -24,7 +24,7 @@ type EncodedMetadata = {
     caption?: string;
 };
 
-function isAbsoluteUrl(url: string): boolean {
+export function isAbsoluteUrl(url: string): boolean {
     return (
         url.startsWith('http://') ||
         url.startsWith('https://') ||

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -111,8 +111,7 @@ export default function Edit({
     } = useHttp({ content: '' });
 
     function runSelectionAction(
-        setData: (key: string, value: string) => void,
-        post: (url: string, options: object) => void,
+        post: (url: string, options: object) => Promise<unknown>,
         url: string,
     ) {
         const selection = editorRef.current?.getSelection();
@@ -121,7 +120,6 @@ export default function Edit({
             return;
         }
 
-        setData('content', selection.text);
         post(url, {
             onSuccess: (response: unknown) => {
                 const { content, message } = response as {
@@ -133,15 +131,18 @@ export default function Edit({
                     selection.end,
                     content,
                 );
-                setHasUnsavedChanges(true);
                 toast.success(message);
             },
+            onError: (errors: Record<string, string>) => {
+                toast.error(errors.content ?? 'Failed to process content.');
+            },
+        }).catch(() => {
+            toast.error('AI request failed. Try selecting less content.');
         });
     }
 
     function structureMarkdown() {
         runSelectionAction(
-            setStructureData,
             structurePost,
             PostController.structureMarkdown.url({
                 namespace: namespace.id,
@@ -152,7 +153,6 @@ export default function Edit({
 
     function translateMarkdown() {
         runSelectionAction(
-            setTranslateData,
             translatePost,
             PostController.translateMarkdown.url({
                 namespace: namespace.id,
@@ -425,9 +425,31 @@ export default function Edit({
                                                 post: post.slug,
                                             })}
                                             jumpTo={jumpTo}
+                                            disabled={
+                                                structuring || translating
+                                            }
                                             onSelectionChange={
                                                 aiEnabled && !post.is_syncing
-                                                    ? setHasSelection
+                                                    ? (has) => {
+                                                          setHasSelection(has);
+
+                                                          if (has) {
+                                                              const sel =
+                                                                  editorRef.current?.getSelection();
+
+                                                              if (sel) {
+                                                                  setStructureData(
+                                                                      'content',
+                                                                      sel.text,
+                                                                  );
+
+                                                                  setTranslateData(
+                                                                      'content',
+                                                                      sel.text,
+                                                                  );
+                                                              }
+                                                          }
+                                                      }
                                                     : undefined
                                             }
                                             toolbar={

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -1286,6 +1286,76 @@ test('admin post edit warns before leaving with unsaved changes', function () {
     ]);
 });
 
+test('admin post edit pastes selected text as a markdown link', function () {
+    $user = User::factory()->create([
+        'email' => 'test@example.com',
+    ]);
+
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+    ]);
+
+    $post = Post::factory()->for($namespace, 'namespace')->create([
+        'slug' => 'todo',
+        'title' => 'Todo',
+        'content' => 'Read docs here.',
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.posts.edit', [
+        'namespace' => $namespace->id,
+        'post' => $post->slug,
+    ], absolute: false))->resize(1440, 900);
+
+    $page->assertNoJavaScriptErrors();
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const textarea = document.querySelector('textarea[name="content"]');
+
+            if (! (textarea instanceof HTMLTextAreaElement) || typeof DataTransfer === 'undefined') {
+                return null;
+            }
+
+            textarea.focus();
+            textarea.setSelectionRange(5, 9);
+
+            const clipboardData = new DataTransfer();
+            clipboardData.setData('text/plain', 'https://example.com/docs');
+
+            const event = new Event('paste', { bubbles: true, cancelable: true });
+            Object.defineProperty(event, 'clipboardData', { value: clipboardData });
+
+            textarea.dispatchEvent(event);
+
+            return event.defaultPrevented;
+        })()
+    JS))->toBeTrue();
+
+    $page->wait(0.2);
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const textarea = document.querySelector('textarea[name="content"]');
+
+            if (! (textarea instanceof HTMLTextAreaElement)) {
+                return null;
+            }
+
+            return {
+                value: textarea.value,
+                selectionCollapsed: textarea.selectionStart === textarea.selectionEnd,
+            };
+        })()
+    JS))->toBe([
+        'value' => 'Read [docs](https://example.com/docs) here.',
+        'selectionCollapsed' => true,
+    ]);
+
+});
+
 test('admin post edit can collapse the metadata panel', function () {
     $user = User::factory()->create([
         'email' => 'test@example.com',


### PR DESCRIPTION
## Summary
- review and keep the markdown editor paste-link behavior and edit-page AI state handling changes
- export the absolute-url helper for editor paste handling
- add browser coverage for pasting a selected absolute URL into markdown content

## Validation
- targeted ESLint on the touched frontend files
- TypeScript type check
- markdown test suite
- focused browser smoke tests for the edit page
- Pint on dirty PHP files