### PR TITLE
Add post referrer analytics

### DIFF
--- a/app/Console/Commands/NamespaceBackupCommand.php
+++ b/app/Console/Commands/NamespaceBackupCommand.php
@@ -93,8 +93,8 @@ class NamespaceBackupCommand extends Command
         }
 
         $posts = $withRevisions
-            ? $namespace->posts()->with('revisions.user', 'tags')->get()
-            : $namespace->posts()->with('tags')->get();
+            ? $namespace->posts()->with('revisions.user', 'tags', 'referrers')->get()
+            : $namespace->posts()->with('tags', 'referrers')->get();
 
         foreach ($posts as $post) {
             $frontmatter = [
@@ -102,7 +102,9 @@ class NamespaceBackupCommand extends Command
                 'slug' => $post->slug,
                 'full_path' => $post->full_path,
                 'page_views' => $post->page_views,
-                'http_referer' => $post->http_referer,
+                'referrers' => $post->referrers
+                    ->map(fn ($r) => ['url' => $r->http_referer, 'count' => $r->count])
+                    ->all(),
                 'is_draft' => $post->is_draft,
                 'published_at' => $post->published_at?->toIso8601String(),
                 'reference_title' => $post->reference_title,

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -389,7 +389,7 @@ class PostController extends Controller
     public function show(PostNamespace $namespace, Post $post): Response
     {
         $rootNamespace = $this->rootNamespace($namespace);
-        $post->load('tags');
+        $post->load('tags', 'referrers');
 
         return Inertia::render('admin/posts/show', [
             'namespace' => [
@@ -412,14 +412,23 @@ class PostController extends Controller
                     'published_at',
                     'created_at',
                     'page_views',
-                    'http_referer',
                     'reference_title',
                     'reference_url',
                 ]),
-                'http_referer_url' => $this->safeExternalUrl($post->http_referer),
                 'is_syncing' => $post->is_syncing,
                 'sync_file_path' => $post->sync_file_path,
                 'tags' => $post->tags->pluck('name')->values()->all(),
+                'referrers' => $post->referrers
+                    ->sortByDesc('count')
+                    ->take(10)
+                    ->map(fn ($referrer) => [
+                        'http_referer' => $referrer->http_referer,
+                        'http_referer_url' => $this->safeExternalUrl($referrer->http_referer),
+                        'count' => $referrer->count,
+                        'last_seen_at' => $referrer->last_seen_at?->toISOString(),
+                    ])
+                    ->values()
+                    ->all(),
             ],
         ]);
     }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Post;
+use App\Models\PostReferrer;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -10,6 +11,37 @@ class DashboardController extends Controller
 {
     public function __invoke(): Response
     {
+        $recentPosts = Post::query()
+            ->orderByDesc('updated_at')
+            ->limit(10)
+            ->get([
+                'id',
+                'namespace_id',
+                'title',
+                'slug',
+                'full_path',
+                'page_views',
+                'is_draft',
+                'published_at',
+                'updated_at',
+            ])
+            ->map(fn (Post $post): array => [
+                'id' => $post->id,
+                'title' => $post->title,
+                'full_path' => $post->full_path,
+                'page_views' => $post->page_views,
+                'updated_at' => $post->updated_at->toISOString(),
+                'canonical_url' => ! $post->is_draft && $post->published_at !== null && $post->published_at->isPast()
+                    ? route('posts.path', ['path' => $post->full_path], absolute: false)
+                    : null,
+                'admin_url' => route('admin.posts.show', [
+                    'namespace' => $post->namespace_id,
+                    'post' => $post->slug,
+                ], absolute: false),
+            ])
+            ->values()
+            ->all();
+
         $topPosts = Post::query()
             ->where('page_views', '>', 0)
             ->orderByDesc('page_views')
@@ -42,33 +74,26 @@ class DashboardController extends Controller
             ->values()
             ->all();
 
-        $topReferrers = Post::query()
-            ->whereNotNull('http_referer')
-            ->where('page_views', '>', 0)
-            ->get(['http_referer', 'page_views'])
-            ->groupBy(fn (Post $post): string => $this->referrerHost($post))
-            ->map(fn ($group, string $host): array => [
-                'host' => $host,
-                'post_count' => $group->count(),
-                'total_views' => $group->sum('page_views'),
+        $topReferrers = PostReferrer::query()
+            ->select('referrer_host')
+            ->selectRaw('COUNT(DISTINCT post_id) as post_count')
+            ->selectRaw('SUM(count) as total_views')
+            ->groupBy('referrer_host')
+            ->orderByDesc('total_views')
+            ->limit(10)
+            ->get()
+            ->map(fn (PostReferrer $referrer): array => [
+                'host' => $referrer->referrer_host,
+                'post_count' => (int) $referrer->post_count,
+                'total_views' => (int) $referrer->total_views,
             ])
-            ->sortByDesc('total_views')
-            ->take(10)
             ->values()
             ->all();
 
         return Inertia::render('dashboard', [
+            'recent_posts' => $recentPosts,
             'top_posts' => $topPosts,
             'top_referrers' => $topReferrers,
         ]);
-    }
-
-    private function referrerHost(Post $post): string
-    {
-        $host = parse_url($post->http_referer, PHP_URL_HOST);
-
-        return is_string($host) && $host !== ''
-            ? $host
-            : $post->http_referer;
     }
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -4,8 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Models\Post;
 use App\Models\PostNamespace;
+use App\Models\PostReferrer;
 use App\Support\ReservedContentPath;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Collection;
@@ -194,12 +196,10 @@ class PostController extends Controller
         ) {
             $referer = $this->resolveHttpReferer($request);
 
+            $post->increment('page_views');
+
             if ($referer !== null) {
-                $post->increment('page_views', 1, [
-                    'http_referer' => $referer,
-                ]);
-            } else {
-                $post->increment('page_views');
+                $this->recordReferrerView($post, $referer);
             }
 
             $pageViews++;
@@ -242,6 +242,53 @@ class PostController extends Controller
             ->value();
 
         return $referer === '' ? null : $referer;
+    }
+
+    private function recordReferrerView(Post $post, string $referer): void
+    {
+        $seenAt = now();
+        $attributes = [
+            'post_id' => $post->id,
+            'http_referer' => $referer,
+        ];
+
+        $updated = PostReferrer::query()
+            ->where($attributes)
+            ->increment('count', 1, [
+                'last_seen_at' => $seenAt,
+                'referrer_host' => PostReferrer::normalizeHost($referer),
+            ]);
+
+        if ($updated > 0) {
+            return;
+        }
+
+        try {
+            PostReferrer::query()->create([
+                ...$attributes,
+                'referrer_host' => PostReferrer::normalizeHost($referer),
+                'count' => 1,
+                'last_seen_at' => $seenAt,
+            ]);
+        } catch (QueryException $exception) {
+            if (! $this->isUniqueConstraintViolation($exception)) {
+                throw $exception;
+            }
+
+            PostReferrer::query()
+                ->where($attributes)
+                ->increment('count', 1, [
+                    'last_seen_at' => $seenAt,
+                    'referrer_host' => PostReferrer::normalizeHost($referer),
+                ]);
+        }
+    }
+
+    private function isUniqueConstraintViolation(QueryException $exception): bool
+    {
+        $sqlState = (string) ($exception->errorInfo[0] ?? $exception->getCode());
+
+        return in_array($sqlState, ['23000', '23505'], true);
     }
 
     private function isBotRequest(Request $request): bool

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -23,7 +23,6 @@ class Post extends Model
         'full_path',
         'content',
         'page_views',
-        'http_referer',
         'user_id',
         'is_draft',
         'published_at',
@@ -115,5 +114,10 @@ class Post extends Model
     public function revisions(): HasMany
     {
         return $this->hasMany(PostRevision::class);
+    }
+
+    public function referrers(): HasMany
+    {
+        return $this->hasMany(PostReferrer::class);
     }
 }

--- a/app/Models/PostReferrer.php
+++ b/app/Models/PostReferrer.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PostReferrer extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'post_id',
+        'http_referer',
+        'referrer_host',
+        'count',
+        'last_seen_at',
+    ];
+
+    protected $attributes = [
+        'count' => 0,
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'count' => 'integer',
+            'last_seen_at' => 'datetime',
+        ];
+    }
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    public static function normalizeHost(string $url): string
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+
+        return is_string($host) && $host !== '' ? $host : $url;
+    }
+}

--- a/app/Support/NamespaceRestoreArchive.php
+++ b/app/Support/NamespaceRestoreArchive.php
@@ -4,6 +4,7 @@ namespace App\Support;
 
 use App\Models\Post;
 use App\Models\PostNamespace;
+use App\Models\PostReferrer;
 use App\Models\PostRevision;
 use App\Models\Tag;
 use App\Models\User;
@@ -281,7 +282,6 @@ class NamespaceRestoreArchive
             $post->slug = (string) $frontmatter['slug'];
             $post->content = $body;
             $post->page_views = (int) ($frontmatter['page_views'] ?? 0);
-            $post->http_referer = $frontmatter['http_referer'] ?? null;
             $post->is_draft = (bool) ($frontmatter['is_draft'] ?? false);
             $post->published_at = $frontmatter['published_at'] ?? null;
             $post->reference_title = $frontmatter['reference_title'] ?? null;
@@ -300,6 +300,20 @@ class NamespaceRestoreArchive
                 ->all();
 
             $post->tags()->sync($tagIds);
+
+            if (isset($frontmatter['referrers']) && is_array($frontmatter['referrers'])) {
+                $post->referrers()->delete();
+                foreach ($frontmatter['referrers'] as $referrerData) {
+                    if (isset($referrerData['url']) && $referrerData['url'] !== '') {
+                        PostReferrer::create([
+                            'post_id' => $post->id,
+                            'http_referer' => (string) $referrerData['url'],
+                            'referrer_host' => PostReferrer::normalizeHost((string) $referrerData['url']),
+                            'count' => (int) ($referrerData['count'] ?? 1),
+                        ]);
+                    }
+                }
+            }
 
             if ($withRevisions) {
                 $revisionsPath = $path.'/'.$post->slug.'.revisions.json';

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -24,7 +24,6 @@ class PostFactory extends Factory
             'slug' => Str::slug($title),
             'content' => implode("\n\n", fake()->paragraphs(3)),
             'page_views' => 0,
-            'http_referer' => null,
             'is_draft' => false,
             'published_at' => now(),
         ];

--- a/database/migrations/2026_04_29_122933_create_post_referrers_table.php
+++ b/database/migrations/2026_04_29_122933_create_post_referrers_table.php
@@ -1,0 +1,96 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('post_referrers', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->string('http_referer', 2048);
+            $table->string('referrer_host', 2048);
+            $table->unsignedInteger('count')->default(1);
+            $table->timestamp('last_seen_at')->nullable();
+
+            $table->unique(['post_id', 'http_referer']);
+            $table->index('referrer_host');
+        });
+
+        $this->backfillLegacyReferrers();
+
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('http_referer');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('http_referer', 2048)->nullable();
+        });
+
+        $this->restoreLegacyReferrers();
+
+        Schema::dropIfExists('post_referrers');
+    }
+
+    private function backfillLegacyReferrers(): void
+    {
+        DB::table('posts')
+            ->select(['id', 'http_referer'])
+            ->whereNotNull('http_referer')
+            ->where('http_referer', '!=', '')
+            ->orderBy('id')
+            ->chunkById(100, function ($posts): void {
+                $rows = $posts
+                    ->map(fn (object $post): array => [
+                        'post_id' => $post->id,
+                        'http_referer' => $post->http_referer,
+                        'referrer_host' => $this->resolveReferrerHost($post->http_referer),
+                        'count' => 1,
+                        'last_seen_at' => null,
+                    ])
+                    ->all();
+
+                if ($rows !== []) {
+                    DB::table('post_referrers')->insert($rows);
+                }
+            });
+    }
+
+    private function restoreLegacyReferrers(): void
+    {
+        $restoredPostId = null;
+
+        foreach (
+            DB::table('post_referrers')
+                ->select(['id', 'post_id', 'http_referer', 'count'])
+                ->orderBy('post_id')
+                ->orderByDesc('count')
+                ->orderByDesc('id')
+                ->cursor() as $referrer
+        ) {
+            if ($referrer->post_id === $restoredPostId) {
+                continue;
+            }
+
+            DB::table('posts')
+                ->where('id', $referrer->post_id)
+                ->update(['http_referer' => $referrer->http_referer]);
+
+            $restoredPostId = $referrer->post_id;
+        }
+    }
+
+    private function resolveReferrerHost(string $url): string
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+
+        return is_string($host) && $host !== '' ? $host : $url;
+    }
+};

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -144,8 +144,12 @@ type Post = {
     full_path: string;
     content: string;
     page_views: number;
-    http_referer: string | null;
-    http_referer_url: string | null;
+    referrers: {
+        http_referer: string;
+        http_referer_url: string | null;
+        count: number;
+        last_seen_at: string | null;
+    }[];
     is_draft: boolean;
     published_at: string | null;
     created_at: string;
@@ -636,26 +640,45 @@ export default function Show({
                                                     /{post.full_path}
                                                 </span>
                                             </div>
-                                            <div className="flex items-center justify-between gap-3 px-4 py-3">
-                                                <span className="text-sm text-muted-foreground">
-                                                    Referer
+                                            <div className="flex flex-col gap-1 px-4 py-3">
+                                                <span className="mb-1 text-sm text-muted-foreground">
+                                                    Referrers
                                                 </span>
-                                                {post.http_referer &&
-                                                post.http_referer_url ? (
-                                                    <a
-                                                        href={
-                                                            post.http_referer_url
-                                                        }
-                                                        target="_blank"
-                                                        rel="noreferrer"
-                                                        className="max-w-32 truncate text-right text-xs text-muted-foreground underline-offset-4 hover:underline"
-                                                    >
-                                                        {post.http_referer}
-                                                    </a>
-                                                ) : post.http_referer ? (
-                                                    <span className="max-w-32 truncate text-right text-xs text-muted-foreground">
-                                                        {post.http_referer}
-                                                    </span>
+                                                {post.referrers.length > 0 ? (
+                                                    post.referrers.map(
+                                                        (referrer, i) => (
+                                                            <div
+                                                                key={i}
+                                                                className="flex items-center justify-between gap-3"
+                                                            >
+                                                                {referrer.http_referer_url ? (
+                                                                    <a
+                                                                        href={
+                                                                            referrer.http_referer_url
+                                                                        }
+                                                                        target="_blank"
+                                                                        rel="noreferrer"
+                                                                        className="max-w-48 truncate text-xs text-muted-foreground underline-offset-4 hover:underline"
+                                                                    >
+                                                                        {
+                                                                            referrer.http_referer
+                                                                        }
+                                                                    </a>
+                                                                ) : (
+                                                                    <span className="max-w-48 truncate text-xs text-muted-foreground">
+                                                                        {
+                                                                            referrer.http_referer
+                                                                        }
+                                                                    </span>
+                                                                )}
+                                                                <span className="shrink-0 text-xs font-medium">
+                                                                    {
+                                                                        referrer.count
+                                                                    }
+                                                                </span>
+                                                            </div>
+                                                        ),
+                                                    )
                                                 ) : (
                                                     <span className="text-sm font-medium">
                                                         -

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,5 +1,12 @@
 import { Head, Link } from '@inertiajs/react';
-import { BarChart3, ExternalLink, Eye, FileText, Globe } from 'lucide-react';
+import {
+    BarChart3,
+    Clock,
+    ExternalLink,
+    Eye,
+    FileText,
+    Globe,
+} from 'lucide-react';
 import {
     Card,
     CardContent,
@@ -9,6 +16,16 @@ import {
 } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { dashboard } from '@/routes';
+
+type RecentPost = {
+    id: number;
+    title: string;
+    full_path: string;
+    page_views: number;
+    updated_at: string;
+    canonical_url: string | null;
+    admin_url: string;
+};
 
 type TopPost = {
     id: number;
@@ -26,10 +43,23 @@ type TopReferrer = {
     total_views: number;
 };
 
+function formatRelativeTime(isoString: string): string {
+    const diff = Date.now() - new Date(isoString).getTime();
+    const minutes = Math.floor(diff / 60000);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days < 30) return `${days}d ago`;
+    return new Date(isoString).toLocaleDateString();
+}
+
 export default function Dashboard({
+    recent_posts,
     top_posts,
     top_referrers,
 }: {
+    recent_posts: RecentPost[];
     top_posts: TopPost[];
     top_referrers: TopReferrer[];
 }) {
@@ -59,7 +89,7 @@ export default function Dashboard({
                     </Card>
 
                     <Card className="shadow-none">
-                        <Tabs defaultValue="posts">
+                        <Tabs defaultValue="recent">
                             <CardHeader>
                                 <div className="flex items-center justify-between gap-4">
                                     <div>
@@ -69,9 +99,13 @@ export default function Dashboard({
                                         <CardTitle>Top 10</CardTitle>
                                     </div>
                                     <TabsList>
-                                        <TabsTrigger value="posts">
-                                            <FileText />
-                                            Posts
+                                        <TabsTrigger value="recent">
+                                            <Clock />
+                                            Recent
+                                        </TabsTrigger>
+                                        <TabsTrigger value="pv">
+                                            <Eye />
+                                            PV
                                         </TabsTrigger>
                                         <TabsTrigger value="referrers">
                                             <Globe />
@@ -81,7 +115,71 @@ export default function Dashboard({
                                 </div>
                             </CardHeader>
                             <CardContent>
-                                <TabsContent value="posts">
+                                <TabsContent value="recent">
+                                    {recent_posts.length === 0 ? (
+                                        <div className="rounded-xl border border-dashed px-6 py-10 text-center text-sm text-muted-foreground">
+                                            No posts yet.
+                                        </div>
+                                    ) : (
+                                        <div className="space-y-3">
+                                            {recent_posts.map((post) => (
+                                                <div
+                                                    key={post.id}
+                                                    className="flex flex-col gap-3 rounded-xl border px-4 py-4 sm:flex-row sm:items-center sm:justify-between"
+                                                >
+                                                    <div className="flex min-w-0 items-start gap-4">
+                                                        <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                                                            <Clock className="size-4" />
+                                                        </div>
+                                                        <div className="min-w-0">
+                                                            <Link
+                                                                href={
+                                                                    post.admin_url
+                                                                }
+                                                                className="inline-flex items-center gap-2 font-medium hover:underline"
+                                                            >
+                                                                <FileText className="size-4 shrink-0 text-muted-foreground" />
+                                                                <span className="truncate">
+                                                                    {post.title}
+                                                                </span>
+                                                            </Link>
+                                                            <p className="mt-1 truncate text-sm text-muted-foreground">
+                                                                /
+                                                                {post.full_path}
+                                                            </p>
+                                                        </div>
+                                                    </div>
+                                                    <div className="flex items-center justify-between gap-4 sm:justify-end">
+                                                        {post.page_views >
+                                                            0 && (
+                                                            <div className="inline-flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-sm font-medium">
+                                                                <Eye className="size-4 text-muted-foreground" />
+                                                                {post.page_views.toLocaleString()}
+                                                            </div>
+                                                        )}
+                                                        <span className="shrink-0 text-sm text-muted-foreground">
+                                                            {formatRelativeTime(
+                                                                post.updated_at,
+                                                            )}
+                                                        </span>
+                                                        {post.canonical_url ? (
+                                                            <Link
+                                                                href={
+                                                                    post.canonical_url
+                                                                }
+                                                                className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                                                            >
+                                                                <ExternalLink className="size-4" />
+                                                            </Link>
+                                                        ) : null}
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    )}
+                                </TabsContent>
+
+                                <TabsContent value="pv">
                                     {top_posts.length === 0 ? (
                                         <div className="rounded-xl border border-dashed px-6 py-10 text-center text-sm text-muted-foreground">
                                             No tracked page views yet.

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Post;
 use App\Models\PostNamespace;
+use App\Models\PostReferrer;
 use App\Models\Tag;
 use App\Models\User;
 use App\Support\NamespaceBackupArchive;
@@ -57,8 +58,8 @@ function addAdminNamespaceBackupTreeToZip(ZipArchive $zip, array $tree, string $
             $frontmatter['page_views'] = $post['page_views'];
         }
 
-        if (array_key_exists('http_referer', $post)) {
-            $frontmatter['http_referer'] = $post['http_referer'];
+        if (array_key_exists('referrers', $post)) {
+            $frontmatter['referrers'] = $post['referrers'];
         }
 
         if (array_key_exists('tags', $post)) {
@@ -1211,10 +1212,16 @@ test('authenticated users can view a post details page', function () {
         'title' => 'Release Notes',
         'slug' => 'release-notes',
         'page_views' => 27,
-        'http_referer' => 'https://example.com/changelog',
         'is_draft' => false,
         'reference_title' => 'Release Notes Source',
         'reference_url' => 'https://example.com/release-notes',
+    ]);
+    PostReferrer::create([
+        'post_id' => $post->id,
+        'http_referer' => 'https://example.com/changelog',
+        'referrer_host' => 'example.com',
+        'count' => 5,
+        'last_seen_at' => now(),
     ]);
 
     $this->actingAs($user)
@@ -1227,8 +1234,9 @@ test('authenticated users can view a post details page', function () {
             ->where('post.slug', 'release-notes')
             ->where('post.title', 'Release Notes')
             ->where('post.page_views', 27)
-            ->where('post.http_referer', 'https://example.com/changelog')
-            ->where('post.http_referer_url', 'https://example.com/changelog')
+            ->where('post.referrers.0.http_referer', 'https://example.com/changelog')
+            ->where('post.referrers.0.http_referer_url', 'https://example.com/changelog')
+            ->where('post.referrers.0.count', 5)
             ->where('post.reference_title', 'Release Notes Source')
             ->where('post.reference_url', 'https://example.com/release-notes')
         );
@@ -1264,9 +1272,12 @@ test('admin post details page includes move namespace options for system namespa
 test('admin post details page does not expose unsafe referer links', function () {
     $user = User::factory()->create();
     $namespace = PostNamespace::factory()->create();
-    $post = Post::factory()->for($user)->create([
-        'namespace_id' => $namespace->id,
+    $post = Post::factory()->for($user)->create(['namespace_id' => $namespace->id]);
+    PostReferrer::create([
+        'post_id' => $post->id,
         'http_referer' => 'javascript:alert(1)',
+        'referrer_host' => 'javascript:alert(1)',
+        'count' => 1,
     ]);
 
     $this->actingAs($user)
@@ -1274,8 +1285,8 @@ test('admin post details page does not expose unsafe referer links', function ()
         ->assertOk()
         ->assertInertia(fn ($page) => $page
             ->component('admin/posts/show')
-            ->where('post.http_referer', 'javascript:alert(1)')
-            ->where('post.http_referer_url', null)
+            ->where('post.referrers.0.http_referer', 'javascript:alert(1)')
+            ->where('post.referrers.0.http_referer_url', null)
         );
 });
 

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Post;
 use App\Models\PostNamespace;
+use App\Models\PostReferrer;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -63,26 +64,41 @@ test('dashboard groups top referrers by host and keeps malformed referrers reada
         'full_path' => 'guides',
     ]);
 
-    Post::factory()->for($user)->for($namespace, 'namespace')->published()->create([
+    $laravelPost = Post::factory()->for($user)->for($namespace, 'namespace')->published()->create([
         'title' => 'Laravel',
         'slug' => 'laravel',
         'full_path' => 'guides/laravel',
         'page_views' => 40,
-        'http_referer' => 'https://example.com/docs/laravel',
     ]);
-    Post::factory()->for($user)->for($namespace, 'namespace')->published()->create([
+    $phpPost = Post::factory()->for($user)->for($namespace, 'namespace')->published()->create([
         'title' => 'PHP',
         'slug' => 'php',
         'full_path' => 'guides/php',
         'page_views' => 15,
-        'http_referer' => 'https://example.com/docs/php',
     ]);
-    Post::factory()->for($user)->for($namespace, 'namespace')->published()->create([
+    $oddPost = Post::factory()->for($user)->for($namespace, 'namespace')->published()->create([
         'title' => 'Odd',
         'slug' => 'odd',
         'full_path' => 'guides/odd',
         'page_views' => 25,
+    ]);
+    PostReferrer::create([
+        'post_id' => $laravelPost->id,
+        'http_referer' => 'https://example.com/docs/laravel',
+        'referrer_host' => 'example.com',
+        'count' => 40,
+    ]);
+    PostReferrer::create([
+        'post_id' => $phpPost->id,
+        'http_referer' => 'https://example.com/docs/php',
+        'referrer_host' => 'example.com',
+        'count' => 15,
+    ]);
+    PostReferrer::create([
+        'post_id' => $oddPost->id,
         'http_referer' => 'not a valid url',
+        'referrer_host' => 'not a valid url',
+        'count' => 25,
     ]);
 
     $this->actingAs($user)

--- a/tests/Feature/NamespaceBackupCommandTest.php
+++ b/tests/Feature/NamespaceBackupCommandTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Post;
 use App\Models\PostNamespace;
+use App\Models\PostReferrer;
 use App\Models\PostRevision;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -52,8 +53,8 @@ function addNamespaceBackupTreeToZip(ZipArchive $zip, array $tree, string $prefi
             $frontmatter['page_views'] = $post['page_views'];
         }
 
-        if (array_key_exists('http_referer', $post)) {
-            $frontmatter['http_referer'] = $post['http_referer'];
+        if (array_key_exists('referrers', $post)) {
+            $frontmatter['referrers'] = $post['referrers'];
         }
 
         if (array_key_exists('reference_title', $post)) {
@@ -104,15 +105,20 @@ test('namespace backup command exports namespace metadata and markdown posts', f
 
     $namespace->forceFill(['sort_order' => 3])->save();
 
-    Post::factory()->for($user)->for($namespace, 'namespace')->published()->create([
+    $routingPost = Post::factory()->for($user)->for($namespace, 'namespace')->published()->create([
         'title' => 'Routing',
         'slug' => 'routing',
         'full_path' => 'guides/routing',
         'page_views' => 42,
-        'http_referer' => 'https://example.com/search?q=routing',
         'reference_title' => 'Laravel Routing Docs',
         'reference_url' => 'https://laravel.com/docs/routing',
         'content' => "# Routing\n\n![Diagram](/images/posts/123/diagram.png)\n\nBackup me.",
+    ]);
+    PostReferrer::create([
+        'post_id' => $routingPost->id,
+        'http_referer' => 'https://example.com/search?q=routing',
+        'referrer_host' => 'example.com',
+        'count' => 5,
     ]);
 
     $zipPath = storage_path('framework/testing/'.Str::uuid().'.zip');
@@ -153,7 +159,7 @@ test('namespace backup command exports namespace metadata and markdown posts', f
         ->toContain('slug: routing')
         ->toContain('full_path: guides/routing')
         ->toContain('page_views: 42')
-        ->toContain('http_referer:')
+        ->toContain('referrers:')
         ->toContain('https://example.com/search?q=routing')
         ->toContain("reference_title: 'Laravel Routing Docs'")
         ->toContain("reference_url: 'https://laravel.com/docs/routing'")
@@ -181,7 +187,7 @@ test('namespace restore command imports a namespace backup zip', function () {
                 'title' => 'Laravel AI SDK',
                 'slug' => 'laravel-ai-sdk',
                 'page_views' => 11,
-                'http_referer' => 'https://example.com/docs/ai',
+                'referrers' => [['url' => 'https://example.com/docs/ai', 'count' => 3]],
                 'reference_title' => 'Laravel AI SDK Docs',
                 'reference_url' => 'https://laravel.com/docs/ai',
                 'content' => "# Laravel AI SDK\n\n![Diagram](/images/posts/legacy-id/ai-sdk.png)\n\nIntro.",
@@ -218,17 +224,21 @@ test('namespace restore command imports a namespace backup zip', function () {
             ->orderBy('slug')
             ->get();
 
+        $aiSdkPost = $posts->firstWhere('slug', 'laravel-ai-sdk');
+        $aiSdkReferrer = PostReferrer::where('post_id', $aiSdkPost?->id)->first();
+
         expect($posts)->toHaveCount(2)
             ->and($posts->pluck('slug')->all())->toBe([
                 'laravel-ai-sdk',
                 'upgrade-12-to-13',
             ])
-            ->and($posts->firstWhere('slug', 'laravel-ai-sdk')?->page_views)->toBe(11)
-            ->and($posts->firstWhere('slug', 'laravel-ai-sdk')?->http_referer)->toBe('https://example.com/docs/ai')
-            ->and($posts->firstWhere('slug', 'laravel-ai-sdk')?->reference_title)->toBe('Laravel AI SDK Docs')
-            ->and($posts->firstWhere('slug', 'laravel-ai-sdk')?->reference_url)->toBe('https://laravel.com/docs/ai')
+            ->and($aiSdkPost?->page_views)->toBe(11)
+            ->and($aiSdkReferrer?->http_referer)->toBe('https://example.com/docs/ai')
+            ->and($aiSdkReferrer?->count)->toBe(3)
+            ->and($aiSdkPost?->reference_title)->toBe('Laravel AI SDK Docs')
+            ->and($aiSdkPost?->reference_url)->toBe('https://laravel.com/docs/ai')
             ->and($posts->firstWhere('slug', 'upgrade-12-to-13')?->page_views)->toBe(0)
-            ->and($posts->firstWhere('slug', 'upgrade-12-to-13')?->http_referer)->toBeNull()
+            ->and(PostReferrer::whereIn('post_id', $posts->pluck('id'))->count())->toBe(1)
             ->and($posts->pluck('user_id')->unique()->all())->toBe([$user->id]);
 
         Storage::disk('public')->assertExists('namespaces/laravel-13-cover.jpg');
@@ -343,7 +353,7 @@ test('namespace restore command defaults page views to zero for older backups', 
         expect($post)->not->toBeNull()
             ->and($post->user_id)->toBe($user->id)
             ->and($post->page_views)->toBe(0)
-            ->and($post->http_referer)->toBeNull();
+            ->and(PostReferrer::where('post_id', $post->id)->count())->toBe(0);
     } finally {
         File::delete($zipPath);
     }

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -2,9 +2,11 @@
 
 use App\Models\Post;
 use App\Models\PostNamespace;
+use App\Models\PostReferrer;
 use App\Models\Tag;
 use App\Models\User;
 use App\Support\ReservedContentPath;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
@@ -253,7 +255,7 @@ test('published post increments page views and queues a tracking cookie', functi
         );
 
     expect($post->fresh()->page_views)->toBe(5)
-        ->and($post->fresh()->http_referer)->toBe('https://example.com/search?q=laravel');
+        ->and(PostReferrer::where('post_id', $post->id)->where('http_referer', 'https://example.com/search?q=laravel')->value('count'))->toBe(1);
 });
 
 test('published post does not increment page views again while tracking cookie exists', function () {
@@ -278,7 +280,7 @@ test('published post does not increment page views again while tracking cookie e
     expect($post->fresh()->page_views)->toBe(9);
 });
 
-test('published post keeps the previous referer when the request has no referer header', function () {
+test('published post does not create a referrer record when the request has no referer header', function () {
     $namespace = PostNamespace::factory()->create([
         'slug' => 'guides',
         'is_published' => true,
@@ -286,13 +288,72 @@ test('published post keeps the previous referer when the request has no referer 
     $post = Post::factory()->for($namespace, 'namespace')->published()->create([
         'slug' => 'routing',
         'page_views' => 1,
+    ]);
+    PostReferrer::create([
+        'post_id' => $post->id,
         'http_referer' => 'https://old.example.com/article',
+        'referrer_host' => 'old.example.com',
+        'count' => 1,
     ]);
 
     $this->get(route('posts.path', ['path' => $post->full_path]))->assertSuccessful();
 
     expect($post->fresh()->page_views)->toBe(2)
-        ->and($post->fresh()->http_referer)->toBe('https://old.example.com/article');
+        ->and(PostReferrer::where('post_id', $post->id)->count())->toBe(1);
+});
+
+test('published post increments an existing referrer row instead of creating a duplicate', function () {
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'is_published' => true,
+    ]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'slug' => 'routing',
+        'page_views' => 1,
+    ]);
+    PostReferrer::create([
+        'post_id' => $post->id,
+        'http_referer' => 'https://example.com/search?q=laravel',
+        'referrer_host' => 'example.com',
+        'count' => 1,
+    ]);
+
+    $this->withHeader('Referer', 'https://example.com/search?q=laravel')
+        ->get(route('posts.path', ['path' => $post->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/show')
+            ->where('post.id', $post->id)
+            ->where('post.page_views', 2)
+        );
+
+    $referrer = PostReferrer::query()
+        ->where('post_id', $post->id)
+        ->where('http_referer', 'https://example.com/search?q=laravel')
+        ->first();
+
+    expect($post->fresh()->page_views)->toBe(2)
+        ->and($referrer)->not->toBeNull()
+        ->and($referrer->count)->toBe(2)
+        ->and(PostReferrer::where('post_id', $post->id)->count())->toBe(1);
+});
+
+test('post referrers table enforces unique referrers per post', function () {
+    $post = Post::factory()->published()->create();
+
+    PostReferrer::create([
+        'post_id' => $post->id,
+        'http_referer' => 'https://example.com/search?q=laravel',
+        'referrer_host' => 'example.com',
+        'count' => 1,
+    ]);
+
+    expect(fn () => PostReferrer::create([
+        'post_id' => $post->id,
+        'http_referer' => 'https://example.com/search?q=laravel',
+        'referrer_host' => 'example.com',
+        'count' => 1,
+    ]))->toThrow(QueryException::class);
 });
 
 test('published post does not increment page views for bot user agents', function () {


### PR DESCRIPTION
## Summary
- add post referrer analytics to public post views, admin post details, and the dashboard
- preserve referrer and page-view data in namespace backup and restore flows
- harden referrer persistence with a unique constraint, host aggregation, and feature test coverage