### PR TITLE
Add shared markdown link paste support

### DIFF
--- a/app/Http/Controllers/Admin/ThinkstreamController.php
+++ b/app/Http/Controllers/Admin/ThinkstreamController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Ai\Agents\ThinkstreamStructureAgent;
 use App\Ai\Agents\ThinkstreamTitleAgent;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\UploadThoughtImageRequest;
 use App\Models\Post;
 use App\Models\PostNamespace;
 use App\Models\ThinkstreamPage;
@@ -311,6 +312,22 @@ class ThinkstreamController extends Controller
             'thoughts' => $thoughts,
             'aiEnabled' => config('thinkstream.ai.enabled'),
         ]);
+    }
+
+    public function uploadImage(UploadThoughtImageRequest $request, ThinkstreamPage $page): RedirectResponse
+    {
+        $this->authorizePage($request, $page);
+
+        $path = $request->file('image')->store("thoughts/{$page->id}", 'public');
+
+        $imageUrl = '/images/'.$path;
+
+        return to_route('admin.thinkstream.show', $page)
+            ->with('thoughtImageUrl', $imageUrl)
+            ->with('thoughtImageUpload', [
+                'key' => $request->string('upload_key')->toString(),
+                'url' => $imageUrl,
+            ]);
     }
 
     public function store(Request $request, ThinkstreamPage $page): RedirectResponse

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -62,6 +62,8 @@ class HandleInertiaRequests extends Middleware
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
             'imageUrl' => session('imageUrl'),
+            'thoughtImageUrl' => session('thoughtImageUrl'),
+            'thoughtImageUpload' => session('thoughtImageUpload'),
         ];
     }
 }

--- a/app/Http/Requests/Admin/UploadThoughtImageRequest.php
+++ b/app/Http/Requests/Admin/UploadThoughtImageRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UploadThoughtImageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'image' => ['required', 'image', 'max:5120', 'mimes:jpg,jpeg,png,gif,webp'],
+            'upload_key' => ['nullable', 'string', 'max:64'],
+        ];
+    }
+}

--- a/resources/js/components/markdown-editor.tsx
+++ b/resources/js/components/markdown-editor.tsx
@@ -14,7 +14,7 @@ import MarkdownContent from '@/components/markdown-content';
 import { Label } from '@/components/ui/label';
 import { createMarkdownComponents } from '@/lib/markdown-components';
 import { normalizeMarkdownHeadingText } from '@/lib/markdown-heading-text';
-import { isAbsoluteUrl } from '@/lib/markdown-syntax';
+import { getMarkdownLinkPasteResult } from '@/lib/markdown-link-paste';
 import { slugify } from '@/lib/slugify';
 import { cn } from '@/lib/utils';
 
@@ -277,28 +277,23 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
                 return;
             }
 
-            const pastedText = e.clipboardData.getData('text/plain').trim();
-            const { selectionStart, selectionEnd } = e.currentTarget;
+            const pasteResult = getMarkdownLinkPasteResult({
+                currentValue: e.currentTarget.value,
+                pastedText: e.clipboardData.getData('text/plain'),
+                selectionStart: e.currentTarget.selectionStart,
+                selectionEnd: e.currentTarget.selectionEnd,
+            });
 
-            if (selectionStart !== selectionEnd && isAbsoluteUrl(pastedText)) {
+            if (pasteResult) {
                 e.preventDefault();
-                const selectedText = e.currentTarget.value.slice(
-                    selectionStart,
-                    selectionEnd,
-                );
-                const markdownLink = `[${selectedText}](${pastedText})`;
-
-                updateValue(
-                    (prev) =>
-                        prev.slice(0, selectionStart) +
-                        markdownLink +
-                        prev.slice(selectionEnd),
-                );
+                updateValue(pasteResult.nextValue);
 
                 setTimeout(() => {
                     if (textareaRef.current) {
-                        const pos = selectionStart + markdownLink.length;
-                        textareaRef.current.setSelectionRange(pos, pos);
+                        textareaRef.current.setSelectionRange(
+                            pasteResult.nextSelectionStart,
+                            pasteResult.nextSelectionEnd,
+                        );
                     }
                 }, 0);
 

--- a/resources/js/lib/markdown-link-paste.ts
+++ b/resources/js/lib/markdown-link-paste.ts
@@ -1,0 +1,39 @@
+import { isAbsoluteUrl } from './markdown-syntax.js';
+
+type MarkdownLinkPasteInput = {
+    currentValue: string;
+    pastedText: string;
+    selectionStart: number;
+    selectionEnd: number;
+};
+
+type MarkdownLinkPasteResult = {
+    nextValue: string;
+    nextSelectionStart: number;
+    nextSelectionEnd: number;
+};
+
+export function getMarkdownLinkPasteResult({
+    currentValue,
+    pastedText,
+    selectionStart,
+    selectionEnd,
+}: MarkdownLinkPasteInput): MarkdownLinkPasteResult | null {
+    const normalizedText = pastedText.trim();
+
+    if (selectionStart === selectionEnd || !isAbsoluteUrl(normalizedText)) {
+        return null;
+    }
+
+    const selectedText = currentValue.slice(selectionStart, selectionEnd);
+    const markdownLink = `[${selectedText}](${normalizedText})`;
+
+    return {
+        nextValue:
+            currentValue.slice(0, selectionStart) +
+            markdownLink +
+            currentValue.slice(selectionEnd),
+        nextSelectionStart: selectionStart + markdownLink.length,
+        nextSelectionEnd: selectionStart + markdownLink.length,
+    };
+}

--- a/resources/js/pages/admin/thinkstream/show.tsx
+++ b/resources/js/pages/admin/thinkstream/show.tsx
@@ -45,6 +45,7 @@ import {
 } from '@/components/ui/dialog';
 import { Spinner } from '@/components/ui/spinner';
 import { Textarea } from '@/components/ui/textarea';
+import { getMarkdownLinkPasteResult } from '@/lib/markdown-link-paste';
 import { createMarkdownComponents } from '@/lib/markdown-components';
 import { timeAgo } from '@/lib/time';
 import { cn } from '@/lib/utils';
@@ -276,6 +277,56 @@ export default function ThinkstreamShow({
                 onFinish: () => setEditSaving(false),
             },
         );
+    }
+
+    function handleThoughtPaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
+        const pasteResult = getMarkdownLinkPasteResult({
+            currentValue: e.currentTarget.value,
+            pastedText: e.clipboardData.getData('text/plain'),
+            selectionStart: e.currentTarget.selectionStart,
+            selectionEnd: e.currentTarget.selectionEnd,
+        });
+
+        if (!pasteResult) {
+            return;
+        }
+
+        e.preventDefault();
+        setData('content', pasteResult.nextValue);
+
+        const textarea = e.currentTarget;
+
+        setTimeout(() => {
+            textarea.setSelectionRange(
+                pasteResult.nextSelectionStart,
+                pasteResult.nextSelectionEnd,
+            );
+        }, 0);
+    }
+
+    function handleEditingPaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
+        const pasteResult = getMarkdownLinkPasteResult({
+            currentValue: e.currentTarget.value,
+            pastedText: e.clipboardData.getData('text/plain'),
+            selectionStart: e.currentTarget.selectionStart,
+            selectionEnd: e.currentTarget.selectionEnd,
+        });
+
+        if (!pasteResult) {
+            return;
+        }
+
+        e.preventDefault();
+        setEditingContent(pasteResult.nextValue);
+
+        const textarea = e.currentTarget;
+
+        setTimeout(() => {
+            textarea.setSelectionRange(
+                pasteResult.nextSelectionStart,
+                pasteResult.nextSelectionEnd,
+            );
+        }, 0);
     }
 
     return (
@@ -518,7 +569,11 @@ export default function ThinkstreamShow({
                                                                         .value,
                                                                 )
                                                             }
+                                                            onPaste={
+                                                                handleEditingPaste
+                                                            }
                                                             rows={12}
+                                                            data-test="thinkstream-edit-thought-textarea"
                                                             className="min-h-[24rem] resize-none px-4 py-3 text-[15px] leading-7 sm:min-h-[30rem]"
                                                             autoFocus
                                                         />
@@ -557,6 +612,7 @@ export default function ThinkstreamShow({
                                                                     type="button"
                                                                     size="sm"
                                                                     variant="outline"
+                                                                    data-test="thinkstream-edit-thought-button"
                                                                     className="h-7 px-2.5 text-xs"
                                                                     onClick={(
                                                                         e,
@@ -618,8 +674,10 @@ export default function ThinkstreamShow({
                                     onChange={(e) =>
                                         setData('content', e.target.value)
                                     }
+                                    onPaste={handleThoughtPaste}
                                     placeholder="Add the next thought..."
                                     rows={6}
+                                    data-test="thinkstream-new-thought-textarea"
                                     className="resize-none"
                                 />
                                 {errors.content && (

--- a/resources/js/pages/admin/thinkstream/show.tsx
+++ b/resources/js/pages/admin/thinkstream/show.tsx
@@ -4,6 +4,7 @@ import {
     setLayoutProps,
     useForm,
     useHttp,
+    usePage,
 } from '@inertiajs/react';
 import {
     BookmarkPlus,
@@ -19,7 +20,7 @@ import {
     Wand2,
     X,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
     destroyMany as thinkstreamDestroyMany,
     index as thinkstreamIndex,
@@ -29,6 +30,7 @@ import {
     store as thinkstreamStore,
     structureThoughts as thinkstreamStructureThoughts,
     update as thinkstreamUpdate,
+    uploadImage as thinkstreamUploadImage,
 } from '@/actions/App/Http/Controllers/Admin/ThinkstreamController';
 import MarkdownContent from '@/components/markdown-content';
 import { Button } from '@/components/ui/button';
@@ -45,8 +47,8 @@ import {
 } from '@/components/ui/dialog';
 import { Spinner } from '@/components/ui/spinner';
 import { Textarea } from '@/components/ui/textarea';
-import { getMarkdownLinkPasteResult } from '@/lib/markdown-link-paste';
 import { createMarkdownComponents } from '@/lib/markdown-components';
+import { getMarkdownLinkPasteResult } from '@/lib/markdown-link-paste';
 import { timeAgo } from '@/lib/time';
 import { cn } from '@/lib/utils';
 import { dashboard } from '@/routes';
@@ -64,6 +66,18 @@ type Page = {
     id: number;
     title: string;
     created_at: string;
+};
+
+type ThoughtImageUpload = {
+    key: string;
+    url: string;
+};
+
+type PendingImageUpload = {
+    key: string;
+    target: 'thought' | 'edit';
+    selectionStart: number;
+    selectionEnd: number;
 };
 
 function hasThoughtsProp(props: unknown): props is { thoughts: Thought[] } {
@@ -84,6 +98,17 @@ export default function ThinkstreamShow({
     thoughts: Thought[];
     aiEnabled: boolean;
 }) {
+    const { props } = usePage<{ thoughtImageUpload?: ThoughtImageUpload }>();
+    const thoughtTextareaRef = useRef<HTMLTextAreaElement>(null);
+    const editTextareaRef = useRef<HTMLTextAreaElement>(null);
+    const pendingImageUploadsRef = useRef<PendingImageUpload[]>([]);
+    const previousThoughtImageUploadKeyRef = useRef<string | undefined>(
+        undefined,
+    );
+    const nextUploadKeyRef = useRef(0);
+    const thoughtContentRef = useRef('');
+    const editingContentRef = useRef('');
+
     const [pageTitle, setPageTitle] = useState(page.title);
     const { data, setData, post, processing, errors, reset } = useForm({
         content: '',
@@ -105,6 +130,14 @@ export default function ThinkstreamShow({
     const [structuredExpanded, setStructuredExpanded] = useState(false);
     const [scrapUrl, setScrapUrl] = useState<string | null>(null);
     const [deleteCanvasOnSave, setDeleteCanvasOnSave] = useState(false);
+
+    useEffect(() => {
+        thoughtContentRef.current = data.content;
+    }, [data.content]);
+
+    useEffect(() => {
+        editingContentRef.current = editingContent;
+    }, [editingContent]);
 
     const {
         setData: setStructureData,
@@ -132,6 +165,121 @@ export default function ThinkstreamShow({
             { title: pageTitle, href: thinkstreamShow.url(page.id) },
         ],
     });
+
+    useEffect(() => {
+        if (
+            !props.thoughtImageUpload ||
+            props.thoughtImageUpload.key ===
+                previousThoughtImageUploadKeyRef.current
+        ) {
+            return;
+        }
+
+        previousThoughtImageUploadKeyRef.current = props.thoughtImageUpload.key;
+
+        const pendingUploadIndex = pendingImageUploadsRef.current.findIndex(
+            ({ key }) => key === props.thoughtImageUpload?.key,
+        );
+
+        if (pendingUploadIndex === -1) {
+            return;
+        }
+
+        const [pendingUpload] = pendingImageUploadsRef.current.splice(
+            pendingUploadIndex,
+            1,
+        );
+
+        if (!pendingUpload) {
+            return;
+        }
+
+        const markdown = `![image](${props.thoughtImageUpload.url})`;
+
+        if (pendingUpload.target === 'thought') {
+            setData(
+                'content',
+                thoughtContentRef.current.substring(
+                    0,
+                    pendingUpload.selectionStart,
+                ) +
+                    markdown +
+                    thoughtContentRef.current.substring(
+                        pendingUpload.selectionEnd,
+                    ),
+            );
+
+            setTimeout(() => {
+                const textarea = thoughtTextareaRef.current;
+
+                if (!textarea) {
+                    return;
+                }
+
+                const pos = pendingUpload.selectionStart + markdown.length;
+                textarea.setSelectionRange(pos, pos);
+                textarea.focus();
+            }, 0);
+        } else {
+            setEditingContent(
+                editingContentRef.current.substring(
+                    0,
+                    pendingUpload.selectionStart,
+                ) +
+                    markdown +
+                    editingContentRef.current.substring(
+                        pendingUpload.selectionEnd,
+                    ),
+            );
+
+            setTimeout(() => {
+                const textarea = editTextareaRef.current;
+
+                if (!textarea) {
+                    return;
+                }
+
+                const pos = pendingUpload.selectionStart + markdown.length;
+                textarea.setSelectionRange(pos, pos);
+                textarea.focus();
+            }, 0);
+        }
+    }, [props.thoughtImageUpload, setData]);
+
+    function handleImageUpload(file: File, target: 'thought' | 'edit') {
+        if (!file.type.startsWith('image/')) {
+            return;
+        }
+
+        const targetTextarea =
+            target === 'thought'
+                ? thoughtTextareaRef.current
+                : editTextareaRef.current;
+        const uploadKey = `thought-image-${nextUploadKeyRef.current++}`;
+
+        pendingImageUploadsRef.current.push({
+            key: uploadKey,
+            target,
+            selectionStart: targetTextarea?.selectionStart ?? 0,
+            selectionEnd: targetTextarea?.selectionEnd ?? 0,
+        });
+
+        router.post(
+            thinkstreamUploadImage.url(page.id),
+            { image: file, upload_key: uploadKey },
+            {
+                preserveState: true,
+                preserveScroll: true,
+                onError: (uploadErrors) => {
+                    pendingImageUploadsRef.current =
+                        pendingImageUploadsRef.current.filter(
+                            ({ key }) => key !== uploadKey,
+                        );
+                    alert(uploadErrors.image ?? 'Image upload failed.');
+                },
+            },
+        );
+    }
 
     function refineTitle() {
         refineTitlePost(thinkstreamRefineTitle.url(page.id), {
@@ -280,6 +428,21 @@ export default function ThinkstreamShow({
     }
 
     function handleThoughtPaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
+        const imageItem = Array.from(e.clipboardData.items).find((item) =>
+            item.type.startsWith('image/'),
+        );
+
+        if (imageItem) {
+            e.preventDefault();
+            const file = imageItem.getAsFile();
+
+            if (file) {
+                handleImageUpload(file, 'thought');
+            }
+
+            return;
+        }
+
         const pasteResult = getMarkdownLinkPasteResult({
             currentValue: e.currentTarget.value,
             pastedText: e.clipboardData.getData('text/plain'),
@@ -305,6 +468,21 @@ export default function ThinkstreamShow({
     }
 
     function handleEditingPaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
+        const imageItem = Array.from(e.clipboardData.items).find((item) =>
+            item.type.startsWith('image/'),
+        );
+
+        if (imageItem) {
+            e.preventDefault();
+            const file = imageItem.getAsFile();
+
+            if (file) {
+                handleImageUpload(file, 'edit');
+            }
+
+            return;
+        }
+
         const pasteResult = getMarkdownLinkPasteResult({
             currentValue: e.currentTarget.value,
             pastedText: e.clipboardData.getData('text/plain'),
@@ -560,6 +738,9 @@ export default function ThinkstreamShow({
                                                         }
                                                     >
                                                         <Textarea
+                                                            ref={
+                                                                editTextareaRef
+                                                            }
                                                             value={
                                                                 editingContent
                                                             }
@@ -571,6 +752,30 @@ export default function ThinkstreamShow({
                                                             }
                                                             onPaste={
                                                                 handleEditingPaste
+                                                            }
+                                                            onDrop={(e) => {
+                                                                e.preventDefault();
+                                                                const imageFile =
+                                                                    Array.from(
+                                                                        e
+                                                                            .dataTransfer
+                                                                            .files,
+                                                                    ).find(
+                                                                        (f) =>
+                                                                            f.type.startsWith(
+                                                                                'image/',
+                                                                            ),
+                                                                    );
+
+                                                                if (imageFile) {
+                                                                    handleImageUpload(
+                                                                        imageFile,
+                                                                        'edit',
+                                                                    );
+                                                                }
+                                                            }}
+                                                            onDragOver={(e) =>
+                                                                e.preventDefault()
                                                             }
                                                             rows={12}
                                                             data-test="thinkstream-edit-thought-textarea"
@@ -670,11 +875,28 @@ export default function ThinkstreamShow({
                         <CardContent className="p-4">
                             <form onSubmit={submit} className="space-y-3">
                                 <Textarea
+                                    ref={thoughtTextareaRef}
                                     value={data.content}
                                     onChange={(e) =>
                                         setData('content', e.target.value)
                                     }
                                     onPaste={handleThoughtPaste}
+                                    onDrop={(e) => {
+                                        e.preventDefault();
+                                        const imageFile = Array.from(
+                                            e.dataTransfer.files,
+                                        ).find((f) =>
+                                            f.type.startsWith('image/'),
+                                        );
+
+                                        if (imageFile) {
+                                            handleImageUpload(
+                                                imageFile,
+                                                'thought',
+                                            );
+                                        }
+                                    }}
+                                    onDragOver={(e) => e.preventDefault()}
                                     placeholder="Add the next thought..."
                                     rows={6}
                                     data-test="thinkstream-new-thought-textarea"

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -13,6 +13,10 @@ declare module '@inertiajs/core' {
                 }>;
             };
             sidebarOpen: boolean;
+            thoughtImageUpload?: {
+                key: string;
+                url: string;
+            };
             [key: string]: unknown;
         };
     }

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -18,6 +18,7 @@ Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () 
     Route::post('thinkstream/backup/restore/upload', [ThinkstreamController::class, 'backupRestoreUpload'])->name('thinkstream.backup.restore.upload');
     Route::delete('thinkstream/{page}', [ThinkstreamController::class, 'destroyPage'])->name('thinkstream.destroyPage');
     Route::get('thinkstream/{page}', [ThinkstreamController::class, 'show'])->name('thinkstream.show');
+    Route::post('thinkstream/{page}/image', [ThinkstreamController::class, 'uploadImage'])->name('thinkstream.uploadImage');
     Route::post('thinkstream/{page}', [ThinkstreamController::class, 'store'])->name('thinkstream.store');
     Route::post('thinkstream/{page}/refine-title', [ThinkstreamController::class, 'refineTitle'])->name('thinkstream.refineTitle');
     Route::patch('thinkstream/{page}/thoughts/{thought}', [ThinkstreamController::class, 'update'])->name('thinkstream.update');

--- a/tests-node/markdown/markdown-link-paste.test.ts
+++ b/tests-node/markdown/markdown-link-paste.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getMarkdownLinkPasteResult } from '../../resources/js/lib/markdown-link-paste.ts';
+
+test('getMarkdownLinkPasteResult wraps the selected text in a markdown link', () => {
+    assert.deepEqual(
+        getMarkdownLinkPasteResult({
+            currentValue: 'Read docs here.',
+            pastedText: ' https://example.com/docs ',
+            selectionStart: 5,
+            selectionEnd: 9,
+        }),
+        {
+            nextValue: 'Read [docs](https://example.com/docs) here.',
+            nextSelectionStart: 37,
+            nextSelectionEnd: 37,
+        },
+    );
+});
+
+test('getMarkdownLinkPasteResult ignores pastes without a selection', () => {
+    assert.equal(
+        getMarkdownLinkPasteResult({
+            currentValue: 'Read docs here.',
+            pastedText: 'https://example.com/docs',
+            selectionStart: 5,
+            selectionEnd: 5,
+        }),
+        null,
+    );
+});
+
+test('getMarkdownLinkPasteResult ignores non-absolute urls', () => {
+    assert.equal(
+        getMarkdownLinkPasteResult({
+            currentValue: 'Read docs here.',
+            pastedText: '/docs/internal',
+            selectionStart: 5,
+            selectionEnd: 9,
+        }),
+        null,
+    );
+});

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -3,6 +3,8 @@
 use App\Models\Post;
 use App\Models\PostNamespace;
 use App\Models\Tag;
+use App\Models\ThinkstreamPage;
+use App\Models\Thought;
 use App\Models\User;
 use App\Support\NamespaceBackupArchive;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -1354,6 +1356,124 @@ test('admin post edit pastes selected text as a markdown link', function () {
         'selectionCollapsed' => true,
     ]);
 
+});
+
+test('thinkstream textareas paste selected text as a markdown link', function () {
+    $user = User::factory()->create([
+        'email' => 'test@example.com',
+    ]);
+
+    $pageModel = ThinkstreamPage::factory()->for($user)->create([
+        'title' => 'Canvas',
+    ]);
+
+    Thought::factory()->for($user)->for($pageModel, 'page')->create([
+        'content' => 'Read docs here.',
+        'created_at' => now()->subHour(),
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.thinkstream.show', $pageModel, absolute: false))
+        ->resize(1440, 900);
+
+    $page->assertNoJavaScriptErrors();
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const textarea = document.querySelector('[data-test="thinkstream-new-thought-textarea"]');
+
+            if (! (textarea instanceof HTMLTextAreaElement) || typeof DataTransfer === 'undefined') {
+                return null;
+            }
+
+            const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+
+            if (! setter) {
+                return null;
+            }
+
+            setter.call(textarea, 'Read docs here.');
+            textarea.dispatchEvent(new Event('input', { bubbles: true }));
+            textarea.focus();
+            textarea.setSelectionRange(5, 9);
+
+            const clipboardData = new DataTransfer();
+            clipboardData.setData('text/plain', 'https://example.com/docs');
+
+            const event = new Event('paste', { bubbles: true, cancelable: true });
+            Object.defineProperty(event, 'clipboardData', { value: clipboardData });
+
+            textarea.dispatchEvent(event);
+
+            return event.defaultPrevented;
+        })()
+    JS))->toBeTrue();
+
+    $page->wait(0.2);
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const textarea = document.querySelector('[data-test="thinkstream-new-thought-textarea"]');
+
+            if (! (textarea instanceof HTMLTextAreaElement)) {
+                return null;
+            }
+
+            return {
+                value: textarea.value,
+                selectionCollapsed: textarea.selectionStart === textarea.selectionEnd,
+            };
+        })()
+    JS))->toBe([
+        'value' => 'Read [docs](https://example.com/docs) here.',
+        'selectionCollapsed' => true,
+    ]);
+
+    $page->click('[data-test="thinkstream-edit-thought-button"]')->wait(0.2);
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const textarea = document.querySelector('[data-test="thinkstream-edit-thought-textarea"]');
+
+            if (! (textarea instanceof HTMLTextAreaElement) || typeof DataTransfer === 'undefined') {
+                return null;
+            }
+
+            textarea.focus();
+            textarea.setSelectionRange(5, 9);
+
+            const clipboardData = new DataTransfer();
+            clipboardData.setData('text/plain', 'https://example.com/docs');
+
+            const event = new Event('paste', { bubbles: true, cancelable: true });
+            Object.defineProperty(event, 'clipboardData', { value: clipboardData });
+
+            textarea.dispatchEvent(event);
+
+            return event.defaultPrevented;
+        })()
+    JS))->toBeTrue();
+
+    $page->wait(0.2);
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const textarea = document.querySelector('[data-test="thinkstream-edit-thought-textarea"]');
+
+            if (! (textarea instanceof HTMLTextAreaElement)) {
+                return null;
+            }
+
+            return {
+                value: textarea.value,
+                selectionCollapsed: textarea.selectionStart === textarea.selectionEnd,
+            };
+        })()
+    JS))->toBe([
+        'value' => 'Read [docs](https://example.com/docs) here.',
+        'selectionCollapsed' => true,
+    ]);
 });
 
 test('admin post edit can collapse the metadata panel', function () {

--- a/tests/Feature/Admin/ThinkstreamImageUploadTest.php
+++ b/tests/Feature/Admin/ThinkstreamImageUploadTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Models\ThinkstreamPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+test('authenticated users can upload an image to a thinkstream page', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $image = UploadedFile::fake()->image('photo.jpg');
+
+    $this->actingAs($user)
+        ->post(route('admin.thinkstream.uploadImage', $page), ['image' => $image])
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('thoughtImageUrl', "/images/thoughts/{$page->id}/{$image->hashName()}")
+        ->assertRedirect(route('admin.thinkstream.show', $page));
+
+    Storage::disk('public')->assertExists("thoughts/{$page->id}/{$image->hashName()}");
+});
+
+test('guests cannot upload thinkstream images', function () {
+    $page = ThinkstreamPage::factory()->create();
+
+    $this->post(route('admin.thinkstream.uploadImage', $page), [])
+        ->assertRedirect(route('login'));
+});
+
+test('users cannot upload images to another users thinkstream page', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($otherUser)->create();
+    $image = UploadedFile::fake()->image('photo.jpg');
+
+    $this->actingAs($user)
+        ->post(route('admin.thinkstream.uploadImage', $page), ['image' => $image])
+        ->assertForbidden();
+
+    Storage::disk('public')->assertMissing("thoughts/{$page->id}/{$image->hashName()}");
+});
+
+test('thinkstream image upload rejects non-image files', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+
+    $this->actingAs($user)
+        ->post(route('admin.thinkstream.uploadImage', $page), [
+            'image' => UploadedFile::fake()->create('document.pdf', 100, 'application/pdf'),
+        ])
+        ->assertSessionHasErrors('image');
+});
+
+test('thinkstream image upload rejects files over 5MB', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+
+    $this->actingAs($user)
+        ->post(route('admin.thinkstream.uploadImage', $page), [
+            'image' => UploadedFile::fake()->image('large.jpg')->size(6000),
+        ])
+        ->assertSessionHasErrors('image');
+});

--- a/tsconfig.markdown-tests.json
+++ b/tsconfig.markdown-tests.json
@@ -13,6 +13,7 @@
     "include": [
         "resources/js/lib/markdown-card-href.ts",
         "resources/js/lib/delete-confirmation.ts",
+        "resources/js/lib/markdown-link-paste.ts",
         "resources/js/lib/markdown-syntax-manifest.ts",
         "resources/js/lib/markdown-syntax.ts",
         "resources/js/lib/remark-tabs-directive.ts",


### PR DESCRIPTION
## Summary
- extract markdown link paste logic into a shared helper used by the markdown editor and Thinkstream textareas
- add Thinkstream browser coverage for both new-thought and edit textareas
- add node coverage for the shared paste helper and include it in markdown test builds
