### PR TITLE
Fix thinkstream edit preview

### DIFF
--- a/resources/js/pages/admin/thinkstream/show.tsx
+++ b/resources/js/pages/admin/thinkstream/show.tsx
@@ -119,6 +119,7 @@ export default function ThinkstreamShow({
     const [editMode, setEditMode] = useState(false);
     const [editingId, setEditingId] = useState<number | null>(null);
     const [editingContent, setEditingContent] = useState('');
+    const [editPreviewMode, setEditPreviewMode] = useState(false);
     const [editSaving, setEditSaving] = useState(false);
     const [structuredTitle, setStructuredTitle] = useState<string | null>(null);
     const [structuredContent, setStructuredContent] = useState<string | null>(
@@ -390,6 +391,7 @@ export default function ThinkstreamShow({
 
     function startEditing(thought: Thought, e: React.MouseEvent) {
         e.stopPropagation();
+        setEditPreviewMode(false);
         setEditingId(thought.id);
         setEditingContent(thought.content);
     }
@@ -419,6 +421,7 @@ export default function ThinkstreamShow({
                 },
                 preserveScroll: true,
                 onError: () => {
+                    setEditPreviewMode(false);
                     setEditingId(thought.id);
                     setEditingContent(contentToSave);
                 },
@@ -737,60 +740,134 @@ export default function ThinkstreamShow({
                                                             e.stopPropagation()
                                                         }
                                                     >
-                                                        <Textarea
-                                                            ref={
-                                                                editTextareaRef
-                                                            }
-                                                            value={
-                                                                editingContent
-                                                            }
-                                                            onChange={(e) =>
-                                                                setEditingContent(
-                                                                    e.target
-                                                                        .value,
-                                                                )
-                                                            }
-                                                            onPaste={
-                                                                handleEditingPaste
-                                                            }
-                                                            onDrop={(e) => {
-                                                                e.preventDefault();
-                                                                const imageFile =
-                                                                    Array.from(
-                                                                        e
-                                                                            .dataTransfer
-                                                                            .files,
-                                                                    ).find(
-                                                                        (f) =>
-                                                                            f.type.startsWith(
-                                                                                'image/',
-                                                                            ),
-                                                                    );
-
-                                                                if (imageFile) {
-                                                                    handleImageUpload(
-                                                                        imageFile,
-                                                                        'edit',
-                                                                    );
+                                                        <div
+                                                            aria-label="Edit mode"
+                                                            className="flex w-fit gap-1 rounded-lg bg-muted/50 p-0.5"
+                                                        >
+                                                            <button
+                                                                type="button"
+                                                                onClick={() =>
+                                                                    setEditPreviewMode(
+                                                                        false,
+                                                                    )
                                                                 }
-                                                            }}
-                                                            onDragOver={(e) =>
-                                                                e.preventDefault()
-                                                            }
-                                                            rows={12}
-                                                            data-test="thinkstream-edit-thought-textarea"
-                                                            className="min-h-[24rem] resize-none px-4 py-3 text-[15px] leading-7 sm:min-h-[30rem]"
-                                                            autoFocus
-                                                        />
+                                                                aria-label="Write mode"
+                                                                aria-pressed={
+                                                                    !editPreviewMode
+                                                                }
+                                                                data-test="thinkstream-edit-write-tab"
+                                                                className={cn(
+                                                                    'rounded-md px-3 py-1.5 text-xs font-medium transition-all',
+                                                                    !editPreviewMode
+                                                                        ? 'bg-card text-foreground shadow-sm'
+                                                                        : 'text-muted-foreground hover:text-foreground',
+                                                                )}
+                                                            >
+                                                                Write
+                                                            </button>
+                                                            <button
+                                                                type="button"
+                                                                onClick={() =>
+                                                                    setEditPreviewMode(
+                                                                        true,
+                                                                    )
+                                                                }
+                                                                aria-label="Preview mode"
+                                                                aria-pressed={
+                                                                    editPreviewMode
+                                                                }
+                                                                data-test="thinkstream-edit-preview-tab"
+                                                                className={cn(
+                                                                    'rounded-md px-3 py-1.5 text-xs font-medium transition-all',
+                                                                    editPreviewMode
+                                                                        ? 'bg-card text-foreground shadow-sm'
+                                                                        : 'text-muted-foreground hover:text-foreground',
+                                                                )}
+                                                            >
+                                                                Preview
+                                                            </button>
+                                                        </div>
+                                                        {editPreviewMode ? (
+                                                            <div
+                                                                data-test="thinkstream-edit-preview-panel"
+                                                                className="min-h-[24rem] overflow-y-auto rounded-md border px-4 py-3 sm:min-h-[30rem]"
+                                                            >
+                                                                <div className="prose prose-sm max-w-none text-[15px] leading-7 prose-neutral dark:prose-invert">
+                                                                    <MarkdownContent
+                                                                        content={
+                                                                            editingContent
+                                                                        }
+                                                                        components={
+                                                                            thoughtMarkdownComponents
+                                                                        }
+                                                                    />
+                                                                </div>
+                                                            </div>
+                                                        ) : (
+                                                            <Textarea
+                                                                ref={
+                                                                    editTextareaRef
+                                                                }
+                                                                value={
+                                                                    editingContent
+                                                                }
+                                                                onChange={(e) =>
+                                                                    setEditingContent(
+                                                                        e.target
+                                                                            .value,
+                                                                    )
+                                                                }
+                                                                onPaste={
+                                                                    handleEditingPaste
+                                                                }
+                                                                onDrop={(e) => {
+                                                                    e.preventDefault();
+                                                                    const imageFile =
+                                                                        Array.from(
+                                                                            e
+                                                                                .dataTransfer
+                                                                                .files,
+                                                                        ).find(
+                                                                            (
+                                                                                f,
+                                                                            ) =>
+                                                                                f.type.startsWith(
+                                                                                    'image/',
+                                                                                ),
+                                                                        );
+
+                                                                    if (
+                                                                        imageFile
+                                                                    ) {
+                                                                        handleImageUpload(
+                                                                            imageFile,
+                                                                            'edit',
+                                                                        );
+                                                                    }
+                                                                }}
+                                                                onDragOver={(
+                                                                    e,
+                                                                ) =>
+                                                                    e.preventDefault()
+                                                                }
+                                                                rows={12}
+                                                                data-test="thinkstream-edit-thought-textarea"
+                                                                className="min-h-[24rem] resize-none px-4 py-3 text-[15px] leading-7 sm:min-h-[30rem]"
+                                                                autoFocus
+                                                            />
+                                                        )}
                                                         <div className="flex justify-end gap-2 pt-2">
                                                             <Button
                                                                 size="sm"
                                                                 variant="secondary"
-                                                                onClick={() =>
+                                                                onClick={() => {
+                                                                    setEditPreviewMode(
+                                                                        false,
+                                                                    );
                                                                     setEditingId(
                                                                         null,
-                                                                    )
-                                                                }
+                                                                    );
+                                                                }}
                                                             >
                                                                 Cancel
                                                             </Button>

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -1476,6 +1476,84 @@ test('thinkstream textareas paste selected text as a markdown link', function ()
     ]);
 });
 
+test('thinkstream edit switches between write and preview without losing content', function () {
+    $user = User::factory()->create([
+        'email' => 'test@example.com',
+    ]);
+
+    $pageModel = ThinkstreamPage::factory()->for($user)->create([
+        'title' => 'Canvas',
+    ]);
+
+    Thought::factory()->for($user)->for($pageModel, 'page')->create([
+        'content' => 'Hello world',
+        'created_at' => now()->subHour(),
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.thinkstream.show', $pageModel, absolute: false))
+        ->resize(1440, 900);
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->click('[data-test="thinkstream-edit-thought-button"]')
+        ->wait(0.2);
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const textarea = document.querySelector('[data-test="thinkstream-edit-thought-textarea"]');
+
+            if (! (textarea instanceof HTMLTextAreaElement)) {
+                return null;
+            }
+
+            const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+
+            if (! setter) {
+                return null;
+            }
+
+            setter.call(textarea, '# Preview Title\n\n**Bold** text');
+            textarea.dispatchEvent(new Event('input', { bubbles: true }));
+
+            return textarea.value;
+        })()
+    JS))->toBe("# Preview Title\n\n**Bold** text");
+
+    $page
+        ->click('[data-test="thinkstream-edit-preview-tab"]')
+        ->wait(0.2);
+
+    expect($page->script(<<<'JS'
+        (() => ({
+            textareaPresent: document.querySelector('[data-test="thinkstream-edit-thought-textarea"]') !== null,
+            headingText: document.querySelector('[data-test="thinkstream-edit-preview-panel"] h1')?.textContent ?? null,
+            strongText: document.querySelector('[data-test="thinkstream-edit-preview-panel"] strong')?.textContent ?? null,
+        }))()
+    JS))->toBe([
+        'textareaPresent' => false,
+        'headingText' => 'Preview Title',
+        'strongText' => 'Bold',
+    ]);
+
+    $page
+        ->click('[data-test="thinkstream-edit-write-tab"]')
+        ->wait(0.2);
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const textarea = document.querySelector('[data-test="thinkstream-edit-thought-textarea"]');
+
+            if (! (textarea instanceof HTMLTextAreaElement)) {
+                return null;
+            }
+
+            return textarea.value;
+        })()
+    JS))->toBe("# Preview Title\n\n**Bold** text");
+});
+
 test('admin post edit can collapse the metadata panel', function () {
     $user = User::factory()->create([
         'email' => 'test@example.com',


### PR DESCRIPTION
## Summary
- fix the thinkstream edit write/preview UI so the textarea drag-and-drop handler is valid again
- add stable test hooks and accessibility state for the write/preview toggle
- add a browser regression test that switches between write and preview without losing content

## Testing
- vendor/bin/sail npm run format:check
- vendor/bin/sail npm run types:check
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail artisan test --compact tests/Browser/SmokeTest.php --filter="thinkstream (textareas paste selected text as a markdown link|edit switches between write and preview without losing content)"