### PR TITLE
Fix thinkstream AI browser actions

### DIFF
--- a/resources/js/pages/admin/thinkstream/show.tsx
+++ b/resources/js/pages/admin/thinkstream/show.tsx
@@ -141,17 +141,17 @@ export default function ThinkstreamShow({
     }, [editingContent]);
 
     const {
-        setData: setStructureData,
         post: structurePost,
         processing: structuring,
+        transform: transformStructure,
     } = useHttp({ ids: [] as number[] });
 
     const { post: refineTitlePost, processing: refiningTitle } = useHttp({});
 
     const {
-        setData: setSaveData,
         post: savePost,
         processing: saving,
+        transform: transformSave,
     } = useHttp({
         content: '',
         title: '',
@@ -318,8 +318,7 @@ export default function ThinkstreamShow({
     function structureThoughts() {
         const ids = Array.from(selected);
 
-        setStructureData('ids', ids);
-
+        transformStructure(() => ({ ids }));
         structurePost(thinkstreamStructureThoughts.url(page.id), {
             onSuccess: (response) => {
                 const { title, content, message } = response as {
@@ -341,11 +340,16 @@ export default function ThinkstreamShow({
         }
 
         const pageId = deleteCanvasOnSave ? page.id : null;
+        const title = structuredTitle ?? pageTitle;
+        const content = structuredContent;
+        const deleteCanvas = deleteCanvasOnSave;
 
-        setSaveData('content', structuredContent);
-        setSaveData('title', structuredTitle ?? pageTitle);
-        setSaveData('delete_canvas', deleteCanvasOnSave);
-        setSaveData('page_id', pageId);
+        transformSave(() => ({
+            content,
+            title,
+            delete_canvas: deleteCanvas,
+            page_id: pageId,
+        }));
 
         savePost(thinkstreamSaveToScrap.url(), {
             onSuccess: (response) => {
@@ -547,6 +551,7 @@ export default function ThinkstreamShow({
                                         variant={
                                             editMode ? 'secondary' : 'default'
                                         }
+                                        data-test="thinkstream-select-thoughts-button"
                                         className="shrink-0"
                                         onClick={
                                             editMode
@@ -564,6 +569,7 @@ export default function ThinkstreamShow({
                                     <Button
                                         type="button"
                                         variant="outline"
+                                        data-test="thinkstream-refine-title-button"
                                         className="shrink-0"
                                         disabled={
                                             refiningTitle ||
@@ -603,6 +609,7 @@ export default function ThinkstreamShow({
                                         type="button"
                                         size="sm"
                                         variant="secondary"
+                                        data-test="thinkstream-select-all-button"
                                         onClick={toggleSelectAll}
                                     >
                                         {selected.size === thoughts.length
@@ -613,6 +620,7 @@ export default function ThinkstreamShow({
                                         <Button
                                             size="sm"
                                             variant="outline"
+                                            data-test="thinkstream-refine-scrap-button"
                                             disabled={
                                                 structuring ||
                                                 selected.size === 0
@@ -695,6 +703,7 @@ export default function ThinkstreamShow({
                                 return (
                                     <Card
                                         key={thought.id}
+                                        data-test={`thinkstream-thought-card-${thought.id}`}
                                         onClick={() => {
                                             if (editMode && !isEditing) {
                                                 toggleSelected(thought.id);
@@ -1044,6 +1053,7 @@ export default function ThinkstreamShow({
                                 {scrapUrl ? (
                                     <a
                                         href={scrapUrl}
+                                        data-test="thinkstream-view-scrap-link"
                                         className="flex items-center gap-1 text-xs text-primary hover:underline"
                                     >
                                         <ExternalLink className="size-3" />
@@ -1067,6 +1077,7 @@ export default function ThinkstreamShow({
                                         <Button
                                             variant="outline"
                                             size="sm"
+                                            data-test="thinkstream-save-scrap-button"
                                             className="h-7 text-xs"
                                             disabled={saving}
                                             onClick={saveToScrap}

--- a/tests/Browser/ThinkstreamAiActionsTest.php
+++ b/tests/Browser/ThinkstreamAiActionsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Ai\Agents\ThinkstreamStructureAgent;
+use App\Models\Post;
+use App\Models\PostNamespace;
+use App\Models\ThinkstreamPage;
+use App\Models\Thought;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('thinkstream refine for scrap sends the currently selected thoughts', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    ThinkstreamStructureAgent::fake([
+        [
+            'title' => 'Selected Summary',
+            'content' => "# Selected Summary\n\nOnly the selected thought was used.",
+        ],
+    ]);
+
+    $user = User::factory()->create([
+        'email' => 'thinkstream-ai@example.com',
+    ]);
+
+    PostNamespace::create([
+        'slug' => 'scrap',
+        'full_path' => 'scrap',
+        'name' => 'Scrap',
+        'is_system' => true,
+        'is_published' => false,
+    ]);
+
+    $pageModel = ThinkstreamPage::factory()->for($user)->create([
+        'title' => 'Canvas',
+    ]);
+
+    Thought::factory()->for($user)->for($pageModel, 'page')->create([
+        'content' => 'First thought should stay out of the refine request.',
+        'created_at' => now()->subMinutes(6),
+    ]);
+
+    $selectedThought = Thought::factory()->for($user)->for($pageModel, 'page')->create([
+        'content' => 'Second thought should be included in the refine request.',
+        'created_at' => now()->subMinutes(5),
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.thinkstream.show', $pageModel, absolute: false))
+        ->resize(1440, 900);
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->click('[data-test="thinkstream-select-thoughts-button"]')
+        ->click("[data-test=\"thinkstream-thought-card-{$selectedThought->id}\"]")
+        ->click('[data-test="thinkstream-refine-scrap-button"]')
+        ->wait(0.5)
+        ->assertSee('Selected Summary')
+        ->assertSee('Only the selected thought was used.')
+        ->click('[data-test="thinkstream-save-scrap-button"]')
+        ->wait(0.5)
+        ->assertPresent('[data-test="thinkstream-view-scrap-link"]')
+        ->assertSee('View in Scrap')
+        ->assertNoJavaScriptErrors();
+
+    ThinkstreamStructureAgent::assertPrompted(
+        fn ($prompt) => str_contains($prompt->prompt, 'Second thought should be included in the refine request.')
+            && ! str_contains($prompt->prompt, 'First thought should stay out of the refine request.'),
+    );
+
+    $post = Post::first();
+
+    expect($post)->not->toBeNull();
+    expect($post->title)->toBe('Selected Summary');
+    expect($post->content)->toBe('Only the selected thought was used.');
+    expect($post->namespace->slug)->toBe('scrap');
+    expect(ThinkstreamPage::find($pageModel->id))->not->toBeNull();
+});


### PR DESCRIPTION
## Summary
- add stable browser coverage for thinkstream refine-for-scrap selection flow
- cover the save-to-scrap UI path in the same browser test
- add stable data-test hooks for the scrap save/link controls

## Testing
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build
- vendor/bin/sail artisan test --compact tests/Feature/Admin/ThinkstreamControllerTest.php --filter="authenticated users can structure thoughts with AI|save to scrap can delete the original canvas"
- vendor/bin/sail artisan test --compact tests/Browser/ThinkstreamAiActionsTest.php