### PR TITLE
chore: normalize frontend formatting imports

### DIFF
--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -36,6 +36,7 @@ import { remarkBadgeDirective } from '@/lib/remark-badge-directive';
 import { remarkCardDirective } from '@/lib/remark-card-directive';
 import { remarkCodeGroupDirective } from '@/lib/remark-code-group-directive';
 import { remarkCodeMeta } from '@/lib/remark-code-meta';
+import { remarkFixUrlPorts } from '@/lib/remark-fix-url-ports';
 import { remarkLinkifyToCard } from '@/lib/remark-linkify-to-card';
 import { remarkMark } from '@/lib/remark-mark';
 import { remarkStepsDirective } from '@/lib/remark-steps-directive';
@@ -43,7 +44,6 @@ import { remarkTabsDirective } from '@/lib/remark-tabs-directive';
 import { remarkTooltipDirective } from '@/lib/remark-tooltip-directive';
 import { remarkTreeDirective } from '@/lib/remark-tree-directive';
 import { remarkUpdateDirective } from '@/lib/remark-update-directive';
-import { remarkFixUrlPorts } from '@/lib/remark-fix-url-ports';
 import { remarkZennDirective } from '@/lib/remark-zenn-directive';
 import { cn } from '@/lib/utils';
 

--- a/resources/js/pages/admin/namespaces/edit.tsx
+++ b/resources/js/pages/admin/namespaces/edit.tsx
@@ -194,8 +194,10 @@ export default function Edit({
                                 onKeyDown={(e) => {
                                     if (e.key === 'Enter') {
                                         e.preventDefault();
-                                        if (!generating && !processing)
+
+                                        if (!generating && !processing) {
                                             handleGenerateClick();
+                                        }
                                     }
                                 }}
                                 placeholder="Optional: add style guidance, colors, mood… (any language)"

--- a/resources/js/pages/admin/thinkstream/index.tsx
+++ b/resources/js/pages/admin/thinkstream/index.tsx
@@ -10,6 +10,16 @@ import {
     Trash2,
 } from 'lucide-react';
 import { useRef, useState } from 'react';
+import {
+    backup as thinkstreamBackup,
+    backupDownload as thinkstreamBackupDownload,
+    backupRestore as thinkstreamBackupRestore,
+    backupRestoreUpload as thinkstreamBackupRestoreUpload,
+    destroyPage as thinkstreamDestroyPage,
+    index as thinkstreamIndex,
+    show as thinkstreamShow,
+    storePage as thinkstreamStorePage,
+} from '@/actions/App/Http/Controllers/Admin/ThinkstreamController';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import {
@@ -27,16 +37,6 @@ import { Textarea } from '@/components/ui/textarea';
 import { matchesDeleteConfirmation } from '@/lib/delete-confirmation';
 import { timeAgo } from '@/lib/time';
 import { dashboard } from '@/routes';
-import {
-    backup as thinkstreamBackup,
-    backupDownload as thinkstreamBackupDownload,
-    backupRestore as thinkstreamBackupRestore,
-    backupRestoreUpload as thinkstreamBackupRestoreUpload,
-    destroyPage as thinkstreamDestroyPage,
-    index as thinkstreamIndex,
-    show as thinkstreamShow,
-    storePage as thinkstreamStorePage,
-} from '@/actions/App/Http/Controllers/Admin/ThinkstreamController';
 
 type Page = {
     id: number;
@@ -131,6 +131,7 @@ function RestoreDialog({ backup }: { backup: LatestBackup | null }) {
     function resetState() {
         setSavedConfirmation('');
         uploadForm.reset();
+
         if (fileInputRef.current) {
             fileInputRef.current.value = '';
         }
@@ -148,7 +149,10 @@ function RestoreDialog({ backup }: { backup: LatestBackup | null }) {
             open={open}
             onOpenChange={(v) => {
                 setOpen(v);
-                if (!v) resetState();
+
+                if (!v) {
+                    resetState();
+                }
             }}
         >
             <DialogTrigger asChild>

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -46,11 +46,23 @@ type TopReferrer = {
 function formatRelativeTime(isoString: string): string {
     const diff = Date.now() - new Date(isoString).getTime();
     const minutes = Math.floor(diff / 60000);
-    if (minutes < 60) return `${minutes}m ago`;
+
+    if (minutes < 60) {
+        return `${minutes}m ago`;
+    }
+
     const hours = Math.floor(minutes / 60);
-    if (hours < 24) return `${hours}h ago`;
+
+    if (hours < 24) {
+        return `${hours}h ago`;
+    }
+
     const days = Math.floor(hours / 24);
-    if (days < 30) return `${days}d ago`;
+
+    if (days < 30) {
+        return `${days}d ago`;
+    }
+
     return new Date(isoString).toLocaleDateString();
 }
 

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -1,5 +1,4 @@
 import { Head, Link, usePage } from '@inertiajs/react';
-import { timeAgo } from '@/lib/time';
 import {
     AlertTriangle,
     BookOpen,
@@ -23,6 +22,7 @@ import {
 } from '@/components/ui/sheet';
 import { useBelowDesktop } from '@/hooks/use-below-desktop';
 import { useCurrentUrl } from '@/hooks/use-current-url';
+import { timeAgo } from '@/lib/time';
 import { namespace as adminNamespaceRoute } from '@/routes/admin/posts';
 import { path as contentPath } from '@/routes/posts';
 import { markdown as contentPathMarkdown } from '@/routes/posts/path';

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -1,5 +1,4 @@
 import { Head, Link, router, usePage } from '@inertiajs/react';
-import { timeAgo } from '@/lib/time';
 import {
     AlertTriangle,
     BookOpen,
@@ -29,6 +28,7 @@ import {
 import { useBelowDesktop } from '@/hooks/use-below-desktop';
 import { useCurrentUrl } from '@/hooks/use-current-url';
 import { useMarkdownToc } from '@/hooks/use-markdown-toc';
+import { timeAgo } from '@/lib/time';
 import {
     edit as adminPostEdit,
     show as adminPostShow,


### PR DESCRIPTION
## Summary
- normalize import ordering in the touched frontend files
- apply prettier-style brace wrapping to single-line conditionals in the touched pages
- keep the change set limited to the six requested files

## Testing
- vendor/bin/sail npm run format:check
- vendor/bin/sail npm run types:check
- targeted eslint on the six changed files
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm run build