### PR TITLE
Improve admin breadcrumbs and dashboard insights

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -128,6 +128,7 @@ class PostController extends Controller
                 'slug' => $namespace->slug,
                 'full_path' => $namespace->full_path,
                 'backup_count' => $backupIndex->countForNamespace($namespace),
+                'ancestors' => $namespace->ancestors()->map(fn (PostNamespace $ns) => ['id' => $ns->id, 'name' => $ns->name])->values()->all(),
             ],
             'create_backup_url' => route('admin.posts.backups.store', $namespace, absolute: false),
             'delete_backups_url' => route('admin.posts.backups.destroyMany', $namespace, absolute: false),
@@ -306,7 +307,14 @@ class PostController extends Controller
     public function create(PostNamespace $namespace): Response
     {
         return Inertia::render('admin/posts/create', [
-            'namespace' => $namespace,
+            'namespace' => [
+                'id' => $namespace->id,
+                'name' => $namespace->name,
+                'slug' => $namespace->slug,
+                'full_path' => $namespace->full_path,
+                'is_system' => (bool) $namespace->is_system,
+                'ancestors' => $namespace->ancestors()->map(fn (PostNamespace $ns) => ['id' => $ns->id, 'name' => $ns->name])->values()->all(),
+            ],
             'availableTags' => Tag::orderBy('name')->pluck('name')->all(),
             'slugPrefix' => trim($namespace->full_path, '/').'/',
         ]);
@@ -398,6 +406,7 @@ class PostController extends Controller
                 'slug' => $namespace->slug,
                 'full_path' => $namespace->full_path,
                 'is_system' => (bool) $namespace->is_system,
+                'ancestors' => $namespace->ancestors()->map(fn (PostNamespace $ns) => ['id' => $ns->id, 'name' => $ns->name])->values()->all(),
             ],
             'availableMoveNamespaces' => $this->availableMoveNamespaces($namespace),
             'navRoot' => $this->buildNavigationTree($rootNamespace),
@@ -620,7 +629,14 @@ class PostController extends Controller
         $post->load('tags');
 
         return Inertia::render('admin/posts/edit', [
-            'namespace' => $namespace,
+            'namespace' => [
+                'id' => $namespace->id,
+                'name' => $namespace->name,
+                'slug' => $namespace->slug,
+                'full_path' => $namespace->full_path,
+                'is_system' => (bool) $namespace->is_system,
+                'ancestors' => $namespace->ancestors()->map(fn (PostNamespace $ns) => ['id' => $ns->id, 'name' => $ns->name])->values()->all(),
+            ],
             'post' => [
                 ...$post->only([
                     'id',
@@ -715,7 +731,13 @@ class PostController extends Controller
         ];
 
         return Inertia::render('admin/posts/revisions', [
-            'namespace' => $namespace,
+            'namespace' => [
+                'id' => $namespace->id,
+                'name' => $namespace->name,
+                'slug' => $namespace->slug,
+                'full_path' => $namespace->full_path,
+                'ancestors' => $namespace->ancestors()->map(fn (PostNamespace $ns) => ['id' => $ns->id, 'name' => $ns->name])->values()->all(),
+            ],
             'post' => $post->only(['id', 'slug', 'title']),
             'revisions' => $revisions->prepend($currentRevision)->values(),
         ]);

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Post;
 use App\Models\PostReferrer;
+use App\Models\Tag;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -90,10 +91,25 @@ class DashboardController extends Controller
             ->values()
             ->all();
 
+        $tags = Tag::query()
+            ->withCount('posts')
+            ->whereHas('posts')
+            ->orderByDesc('posts_count')
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->map(fn (Tag $tag): array => [
+                'id' => $tag->id,
+                'name' => $tag->name,
+                'posts_count' => $tag->posts_count,
+            ])
+            ->values()
+            ->all();
+
         return Inertia::render('dashboard', [
             'recent_posts' => $recentPosts,
             'top_posts' => $topPosts,
             'top_referrers' => $topReferrers,
+            'tags' => $tags,
         ]);
     }
 }

--- a/resources/js/components/breadcrumbs.tsx
+++ b/resources/js/components/breadcrumbs.tsx
@@ -25,14 +25,17 @@ export function Breadcrumbs({
 
                             return (
                                 <Fragment key={index}>
-                                    <BreadcrumbItem>
+                                    <BreadcrumbItem className="min-w-0">
                                         {isLast || !item.href ? (
-                                            <BreadcrumbPage>
+                                            <BreadcrumbPage className="max-w-[200px] truncate">
                                                 {item.title}
                                             </BreadcrumbPage>
                                         ) : (
                                             <BreadcrumbLink asChild>
-                                                <Link href={item.href}>
+                                                <Link
+                                                    href={item.href}
+                                                    className="max-w-[200px] truncate"
+                                                >
                                                     {item.title}
                                                 </Link>
                                             </BreadcrumbLink>

--- a/resources/js/pages/admin/posts/backups.tsx
+++ b/resources/js/pages/admin/posts/backups.tsx
@@ -28,6 +28,7 @@ type Namespace = {
     slug: string;
     full_path: string;
     backup_count: number;
+    ancestors: { id: number; name: string }[];
 };
 
 type Backup = {
@@ -169,6 +170,10 @@ export default function Backups({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
             { title: 'Namespaces', href: index.url() },
+            ...namespace.ancestors.map((ancestor) => ({
+                title: ancestor.name,
+                href: namespaceRoute.url(ancestor.id),
+            })),
             { title: namespace.name, href: namespaceRoute.url(namespace.id) },
             { title: 'Backups', href: backupsRoute.url(namespace.id) },
         ],

--- a/resources/js/pages/admin/posts/create.tsx
+++ b/resources/js/pages/admin/posts/create.tsx
@@ -23,6 +23,7 @@ type Namespace = {
     slug: string;
     full_path: string;
     name: string;
+    ancestors: { id: number; name: string }[];
 };
 
 function toSlug(value: string): string {
@@ -52,6 +53,10 @@ export default function Create({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
             { title: 'Namespaces', href: index.url() },
+            ...namespace.ancestors.map((ancestor) => ({
+                title: ancestor.name,
+                href: namespaceRoute.url(ancestor.id),
+            })),
             { title: namespace.name, href: namespaceRoute.url(namespace.id) },
             { title: 'New Post', href: create.url(namespace.id) },
         ],

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -43,6 +43,7 @@ type Namespace = {
     full_path: string;
     name: string;
     is_system: boolean;
+    ancestors: { id: number; name: string }[];
 };
 
 type Post = {
@@ -210,6 +211,10 @@ export default function Edit({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
             { title: 'Namespaces', href: index.url() },
+            ...namespace.ancestors.map((ancestor) => ({
+                title: ancestor.name,
+                href: namespaceRoute.url(ancestor.id),
+            })),
             { title: namespace.name, href: namespaceRoute.url(namespace.id) },
             {
                 title: post.title,

--- a/resources/js/pages/admin/posts/revisions.tsx
+++ b/resources/js/pages/admin/posts/revisions.tsx
@@ -16,6 +16,7 @@ type Namespace = {
     id: number;
     slug: string;
     name: string;
+    ancestors: { id: number; name: string }[];
 };
 
 type Post = {
@@ -104,6 +105,10 @@ export default function Revisions({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
             { title: 'Namespaces', href: index.url() },
+            ...namespace.ancestors.map((ancestor) => ({
+                title: ancestor.name,
+                href: namespaceRoute.url(ancestor.id),
+            })),
             { title: namespace.name, href: namespaceRoute.url(namespace.id) },
             {
                 title: post.title,

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -129,6 +129,7 @@ type Namespace = {
     slug: string;
     full_path: string;
     is_system: boolean;
+    ancestors: { id: number; name: string }[];
 };
 
 type MoveNamespaceOption = {
@@ -259,6 +260,10 @@ export default function Show({
         breadcrumbs: [
             { title: 'Dashboard', href: dashboard() },
             { title: 'Namespaces', href: index.url() },
+            ...namespace.ancestors.map((ancestor) => ({
+                title: ancestor.name,
+                href: namespaceRoute.url(ancestor.id),
+            })),
             { title: namespace.name, href: namespaceRoute.url(namespace.id) },
             {
                 title: post.title,

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -6,6 +6,7 @@ import {
     Eye,
     FileText,
     Globe,
+    Tag,
 } from 'lucide-react';
 import {
     Card,
@@ -16,6 +17,7 @@ import {
 } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { dashboard } from '@/routes';
+import { show as tagShow } from '@/routes/tags';
 
 type RecentPost = {
     id: number;
@@ -41,6 +43,12 @@ type TopReferrer = {
     host: string;
     post_count: number;
     total_views: number;
+};
+
+type TagStat = {
+    id: number;
+    name: string;
+    posts_count: number;
 };
 
 function formatRelativeTime(isoString: string): string {
@@ -70,10 +78,12 @@ export default function Dashboard({
     recent_posts,
     top_posts,
     top_referrers,
+    tags,
 }: {
     recent_posts: RecentPost[];
     top_posts: TopPost[];
     top_referrers: TopReferrer[];
+    tags: TagStat[];
 }) {
     const totalViews = top_posts.reduce(
         (sum, post) => sum + post.page_views,
@@ -100,7 +110,7 @@ export default function Dashboard({
                         </CardContent>
                     </Card>
 
-                    <Card className="shadow-none">
+                    <Card className="min-w-0 overflow-hidden shadow-none">
                         <Tabs defaultValue="recent">
                             <CardHeader>
                                 <div className="flex items-center justify-between gap-4">
@@ -148,7 +158,7 @@ export default function Dashboard({
                                                                 href={
                                                                     post.admin_url
                                                                 }
-                                                                className="inline-flex items-center gap-2 font-medium hover:underline"
+                                                                className="inline-flex max-w-full items-center gap-2 overflow-hidden font-medium hover:underline"
                                                             >
                                                                 <FileText className="size-4 shrink-0 text-muted-foreground" />
                                                                 <span className="truncate">
@@ -212,7 +222,7 @@ export default function Dashboard({
                                                                 href={
                                                                     post.admin_url
                                                                 }
-                                                                className="inline-flex items-center gap-2 font-medium hover:underline"
+                                                                className="inline-flex max-w-full items-center gap-2 overflow-hidden font-medium hover:underline"
                                                             >
                                                                 <FileText className="size-4 shrink-0 text-muted-foreground" />
                                                                 <span className="truncate">
@@ -292,6 +302,34 @@ export default function Dashboard({
                         </Tabs>
                     </Card>
                 </div>
+
+                {tags.length > 0 && (
+                    <Card className="shadow-none">
+                        <CardHeader>
+                            <CardDescription>Tags</CardDescription>
+                            <CardTitle>All Tags</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <div className="flex flex-wrap gap-2">
+                                {tags.map((tag) => (
+                                    <Link
+                                        key={tag.id}
+                                        href={tagShow(tag.name).url}
+                                        className="inline-flex items-center gap-1.5 rounded-full border bg-muted/50 px-3 py-1.5 text-sm transition-colors hover:bg-muted"
+                                    >
+                                        <Tag className="size-3 shrink-0 text-muted-foreground" />
+                                        <span className="font-medium">
+                                            {tag.name}
+                                        </span>
+                                        <span className="rounded-full bg-background px-1.5 py-0.5 text-xs font-semibold text-muted-foreground tabular-nums">
+                                            {tag.posts_count}
+                                        </span>
+                                    </Link>
+                                ))}
+                            </div>
+                        </CardContent>
+                    </Card>
+                )}
             </div>
         </>
     );

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -185,6 +185,26 @@ test('create form includes available tags', function () {
         );
 });
 
+test('create form exposes namespace ancestors for breadcrumb', function () {
+    $user = User::factory()->create();
+    $root = PostNamespace::factory()->create(['name' => 'Guides']);
+    $child = PostNamespace::factory()->create([
+        'name' => 'Laravel',
+        'parent_id' => $root->id,
+        'full_path' => 'guides/laravel',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.create', $child))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/create')
+            ->has('namespace.ancestors', 1)
+            ->where('namespace.ancestors.0.id', $root->id)
+            ->where('namespace.ancestors.0.name', 'Guides')
+        );
+});
+
 test('uploading a restore zip from the backups index returns a restore preview', function () {
     $user = User::factory()->create();
     $existingNamespace = PostNamespace::factory()->create([
@@ -461,6 +481,35 @@ test('authenticated users can view the namespace backup management page', functi
                     'namespace' => $namespace,
                     'backup' => basename($latestBackup),
                 ], false))
+            );
+    } finally {
+        File::delete(File::glob($backupDirectory.'/'.$backupPrefix.'-*.zip'));
+    }
+});
+
+test('namespace backup management page exposes namespace ancestors for breadcrumb', function () {
+    $user = User::factory()->create();
+    $root = PostNamespace::factory()->create(['name' => 'Guides']);
+    $child = PostNamespace::factory()->create([
+        'name' => 'Laravel',
+        'parent_id' => $root->id,
+        'full_path' => 'guides/laravel',
+    ]);
+
+    $backupDirectory = NamespaceBackupArchive::directory();
+    $backupPrefix = NamespaceBackupArchive::currentPrefix($child);
+    File::ensureDirectoryExists($backupDirectory);
+    File::delete(File::glob($backupDirectory.'/'.$backupPrefix.'-*.zip'));
+
+    try {
+        $this->actingAs($user)
+            ->get(route('admin.posts.backups', $child))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('admin/posts/backups')
+                ->has('namespace.ancestors', 1)
+                ->where('namespace.ancestors.0.id', $root->id)
+                ->where('namespace.ancestors.0.name', 'Guides')
             );
     } finally {
         File::delete(File::glob($backupDirectory.'/'.$backupPrefix.'-*.zip'));
@@ -1202,6 +1251,75 @@ test('authenticated users can view the edit form', function () {
     $this->actingAs($user)
         ->get(route('admin.posts.edit', [$namespace, $post]))
         ->assertOk();
+});
+
+test('edit form exposes namespace ancestors for breadcrumb', function () {
+    $user = User::factory()->create();
+    $root = PostNamespace::factory()->create(['name' => 'Guides']);
+    $child = PostNamespace::factory()->create(['name' => 'Laravel', 'parent_id' => $root->id]);
+    $post = Post::factory()->for($user)->create(['namespace_id' => $child->id]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.edit', [$child, $post]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/edit')
+            ->has('namespace.ancestors', 1)
+            ->where('namespace.ancestors.0.id', $root->id)
+            ->where('namespace.ancestors.0.name', 'Guides')
+        );
+});
+
+test('post details page exposes namespace ancestors for breadcrumb', function () {
+    $user = User::factory()->create();
+    $root = PostNamespace::factory()->create(['name' => 'Guides']);
+    $child = PostNamespace::factory()->create(['name' => 'Laravel', 'parent_id' => $root->id]);
+    $post = Post::factory()->for($user)->create(['namespace_id' => $child->id]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.show', [$child, $post]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/show')
+            ->has('namespace.ancestors', 1)
+            ->where('namespace.ancestors.0.id', $root->id)
+            ->where('namespace.ancestors.0.name', 'Guides')
+        );
+});
+
+test('post details page has empty ancestors for root namespace', function () {
+    $user = User::factory()->create();
+    $root = PostNamespace::factory()->create(['name' => 'Guides']);
+    $post = Post::factory()->for($user)->create(['namespace_id' => $root->id]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.show', [$root, $post]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/show')
+            ->where('namespace.ancestors', [])
+        );
+});
+
+test('revision history page exposes namespace ancestors for breadcrumb', function () {
+    $user = User::factory()->create();
+    $root = PostNamespace::factory()->create(['name' => 'Guides']);
+    $child = PostNamespace::factory()->create([
+        'name' => 'Laravel',
+        'parent_id' => $root->id,
+        'full_path' => 'guides/laravel',
+    ]);
+    $post = Post::factory()->for($user)->create(['namespace_id' => $child->id]);
+
+    $this->actingAs($user)
+        ->get(route('admin.posts.revisions', [$child, $post]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/revisions')
+            ->has('namespace.ancestors', 1)
+            ->where('namespace.ancestors.0.id', $root->id)
+            ->where('namespace.ancestors.0.name', 'Guides')
+        );
 });
 
 test('authenticated users can view a post details page', function () {

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -3,6 +3,7 @@
 use App\Models\Post;
 use App\Models\PostNamespace;
 use App\Models\PostReferrer;
+use App\Models\Tag;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -23,6 +24,7 @@ test('authenticated users can visit the dashboard', function () {
             ->component('dashboard')
             ->where('top_posts', [])
             ->where('top_referrers', [])
+            ->where('tags', [])
         );
 });
 
@@ -54,6 +56,35 @@ test('dashboard shows top 10 posts ordered by page views', function () {
             ->where('top_posts.0.canonical_url', route('posts.path', ['path' => $topPosts->last()->full_path], false))
             ->where('top_posts.9.title', $topPosts->get(2)->title)
             ->where('top_posts.9.page_views', 30)
+        );
+});
+
+test('dashboard shows all tags ordered by post count descending', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'full_path' => 'guides',
+    ]);
+
+    $tagA = Tag::create(['name' => 'laravel']);
+    $tagB = Tag::create(['name' => 'php']);
+    $tagC = Tag::create(['name' => 'unused']);
+
+    $posts = Post::factory()->count(3)->for($user)->for($namespace, 'namespace')->create();
+
+    $tagA->posts()->attach($posts->pluck('id'));
+    $tagB->posts()->attach($posts->first()->id);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('dashboard')
+            ->has('tags', 2)
+            ->where('tags.0.name', 'laravel')
+            ->where('tags.0.posts_count', 3)
+            ->where('tags.1.name', 'php')
+            ->where('tags.1.posts_count', 1)
         );
 });
 


### PR DESCRIPTION
## Summary
- add ancestor breadcrumb data across nested admin post pages
- improve dashboard analytics with tag counts and safer truncation for long labels
- extend feature coverage for dashboard data and nested breadcrumb props

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/Admin/PostControllerTest.php tests/Feature/DashboardTest.php
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build
- vendor/bin/sail bin pint --dirty --format agent