### PR TITLE
Fix markdown editor space scroll jump

### DIFF
--- a/resources/js/components/markdown-editor.tsx
+++ b/resources/js/components/markdown-editor.tsx
@@ -57,7 +57,6 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
             'write',
         );
         const valueRef = useRef(defaultValue);
-
         const lastSelectionRef = useRef<{
             text: string;
             start: number;
@@ -74,6 +73,12 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
                         : updater;
 
                 valueRef.current = nextValue;
+                if (
+                    textareaRef.current &&
+                    textareaRef.current.value !== nextValue
+                ) {
+                    textareaRef.current.value = nextValue;
+                }
                 setValue(nextValue);
             },
             [],
@@ -386,8 +391,11 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
                                 ref={textareaRef}
                                 id={name}
                                 name={name}
-                                value={value}
-                                onChange={(e) => updateValue(e.target.value)}
+                                defaultValue={defaultValue}
+                                onChange={(e) => {
+                                    valueRef.current = e.target.value;
+                                    setValue(e.target.value);
+                                }}
                                 onSelect={(e) => {
                                     const t = e.currentTarget;
                                     const has =

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -1358,6 +1358,104 @@ test('admin post edit pastes selected text as a markdown link', function () {
 
 });
 
+test('admin post edit keeps caret position when pressing space in a scrolled markdown textarea', function () {
+    $user = User::factory()->create([
+        'email' => 'test@example.com',
+    ]);
+
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+    ]);
+
+    $post = Post::factory()->for($namespace, 'namespace')->create([
+        'slug' => 'todo',
+        'title' => 'Todo',
+        'content' => str_repeat(
+            "X API bookmarks require bookmark.read, tweet.read, and users.read scopes.\n",
+            200,
+        ),
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.posts.edit', [
+        'namespace' => $namespace->id,
+        'post' => $post->slug,
+    ], absolute: false))->resize(1440, 900);
+
+    $page->assertNoJavaScriptErrors();
+
+    $page->script(<<<'JS'
+        (() => {
+            const textarea = document.querySelector('textarea[name="content"]');
+
+            if (! (textarea instanceof HTMLTextAreaElement)) {
+                return false;
+            }
+
+            window.scrollTo(0, 0);
+            textarea.scrollTop = 2400;
+
+            return true;
+        })()
+    JS);
+
+    $page->page()->locator('textarea[name="content"]')->click([
+        'position' => [
+            'x' => 320,
+            'y' => 420,
+        ],
+    ]);
+
+    $before = $page->script(<<<'JS'
+        (() => {
+            const textarea = document.querySelector('textarea[name="content"]');
+
+            if (! (textarea instanceof HTMLTextAreaElement)) {
+                return null;
+            }
+
+            return {
+                selectionStart: textarea.selectionStart,
+                selectionEnd: textarea.selectionEnd,
+                scrollTop: textarea.scrollTop,
+                contentLength: textarea.value.length,
+            };
+        })()
+    JS);
+
+    $page->page()->keyDown('Space');
+    $page->page()->keyUp('Space');
+    $page->wait(0.2);
+
+    $after = $page->script(<<<'JS'
+        (() => {
+            const textarea = document.querySelector('textarea[name="content"]');
+
+            if (! (textarea instanceof HTMLTextAreaElement)) {
+                return null;
+            }
+
+            return {
+                selectionStart: textarea.selectionStart,
+                selectionEnd: textarea.selectionEnd,
+                scrollTop: textarea.scrollTop,
+                contentLength: textarea.value.length,
+            };
+        })()
+    JS);
+
+    expect($before)->toBeArray()
+        ->and($before['selectionStart'])->toBeLessThan($before['contentLength'] - 100)
+        ->and($before['selectionStart'])->toBe($before['selectionEnd'])
+        ->and($before['scrollTop'])->toBe(2400)
+        ->and($after)->toBeArray()
+        ->and($after['selectionStart'])->toBe($before['selectionStart'] + 1)
+        ->and($after['selectionEnd'])->toBe($before['selectionEnd'] + 1)
+        ->and($after['scrollTop'])->toBe(2400);
+});
+
 test('thinkstream textareas paste selected text as a markdown link', function () {
     $user = User::factory()->create([
         'email' => 'test@example.com',


### PR DESCRIPTION
## Summary
- keep the admin post markdown textarea effectively uncontrolled so Chrome no longer jumps the caret and textarea scroll to the end on Space
- keep imperative editor operations synchronized by updating both the DOM textarea value and the mirrored preview state
- add a browser regression test covering a raw Space keypress inside a scrolled markdown textarea

## Notes
- verified against the old controlled implementation: the new regression test fails there because the caret jumps to the end
- this change fixes the Space-triggered caret/textarea-bottom jump
- it does not claim to fix the separate small click-time window scroll adjustment noted during investigation

## Validation
```bash
./vendor/bin/sail npm run build
./vendor/bin/sail artisan test --compact tests/Browser/SmokeTest.php --filter='keeps caret position when pressing space in a scrolled markdown textarea|admin post edit pastes selected text as a markdown link'
./vendor/bin/sail npm run types:check
./vendor/bin/sail bin pint --dirty --format agent
```