### PR TITLE
Add Thinkstream tree fence syntax documentation

### DIFF
--- a/database/seeders/SyntaxSeeder.php
+++ b/database/seeders/SyntaxSeeder.php
@@ -29,7 +29,7 @@ class SyntaxSeeder extends Seeder
                 'name' => 'Syntax',
                 'description' => 'Practical syntax references, walkthroughs, and rendering notes for writing and publishing posts.',
                 'cover_image' => $coverImagePath,
-                'post_order' => ['index', 'extended-syntax', 'zenn-syntax', 'mintlify-syntax'],
+                'post_order' => ['index', 'extended-syntax', 'zenn-syntax', 'mintlify-syntax', 'thinkstream-syntax'],
             ],
         );
 
@@ -1512,6 +1512,145 @@ Initial launch of Thinkstream with support for Markdown, GFM, Zenn syntax, and c
 
 </Update>
 ```
+MD),
+                'published_at' => now(),
+            ]);
+
+        Post::updateOrCreate(
+            ['namespace_id' => $namespace->id, 'slug' => 'thinkstream-syntax'],
+            [
+                'user_id' => $user->id,
+                'title' => 'Thinkstream Syntax',
+                'content' => trim(<<<'MD'
+## Thinkstream Syntax
+
+Thinkstream includes a few authoring shortcuts on top of standard Markdown, Zenn syntax, and the supported Mintlify components. This page documents the Thinkstream-specific additions.
+
+---
+
+## Tree Fence
+
+Use a `tree` fenced code block when you want to paste a file tree directly from your terminal. Thinkstream converts it into the interactive tree renderer automatically.
+
+Live example:
+
+```tree
+app/Ai
+└── Agents
+    ├── CoverImagePromptAgent.php
+    ├── MarkdownStructureAgent.php
+    ├── ThinkstreamStructureAgent.php
+    ├── ThinkstreamTitleAgent.php
+    └── TranslateSelectionAgent.php
+```
+
+Source:
+
+````md
+```tree
+app/Ai
+└── Agents
+    ├── CoverImagePromptAgent.php
+    ├── MarkdownStructureAgent.php
+    ├── ThinkstreamStructureAgent.php
+    ├── ThinkstreamTitleAgent.php
+    └── TranslateSelectionAgent.php
+```
+````
+
+Notes:
+
+- `app/Ai` is split into nested folders.
+- Child rows using `├──` and `└──` become files or folders automatically.
+- Folders are expanded by default so pasted trees are readable immediately.
+
+---
+
+## Shared Indentation
+
+Indented tree blocks are also supported, which is useful when the snippet itself is nested inside a list item or blockquote in your source file.
+
+Live example:
+
+```tree
+  resources/js
+  └── components
+      ├── markdown-content.tsx
+      ├── markdown-tree.tsx
+      └── markdown-update.tsx
+```
+
+Source:
+
+````md
+```tree
+  resources/js
+  └── components
+      ├── markdown-content.tsx
+      ├── markdown-tree.tsx
+      └── markdown-update.tsx
+```
+````
+
+---
+
+## Folder Hints
+
+Add a trailing slash when you want to make a folder explicit even before children are listed.
+
+Live example:
+
+```tree
+app/
+└── Services/
+    └── SyncFileParser.php
+```
+
+Source:
+
+````md
+```tree
+app/
+└── Services/
+    └── SyncFileParser.php
+```
+````
+
+---
+
+## Ignored Summary Lines
+
+Output copied from the `tree` command often includes summary lines at the bottom. Thinkstream ignores them automatically.
+
+Live example:
+
+```tree
+.
+├── app
+│   └── Services
+│       └── SyncFileParser.php
+└── tests
+    └── Feature
+        └── SyntaxSeederTest.php
+
+4 directories, 2 files
+```
+
+Source:
+
+````md
+```tree
+.
+├── app
+│   └── Services
+│       └── SyncFileParser.php
+└── tests
+    └── Feature
+        └── SyntaxSeederTest.php
+
+4 directories, 2 files
+```
+````
 MD),
                 'published_at' => now(),
             ]);

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -265,6 +265,8 @@ export function preprocessMintlifySyntax(markdown: string): string {
     const processedLines: string[] = [];
     let activeFence: string | null = null;
     let activeFenceIndent = 0;
+    let treeFence: { openingLine: string; fence: string; lines: string[] } | null =
+        null;
     let mintlifyTabsDepth = 0;
     const mintlifyCalloutColonCounts: number[] = [];
     const mintlifyTagStack: Array<
@@ -312,6 +314,42 @@ export function preprocessMintlifySyntax(markdown: string): string {
                 : line;
         const fenceMatch = /^(`{3,}|~{3,})/.exec(trimmedLine);
 
+        if (treeFence !== null) {
+            const remainder = fenceMatch
+                ? trimmedLine.slice(fenceMatch[1].length)
+                : '';
+
+            if (
+                fenceMatch &&
+                fenceMatch[1][0] === treeFence.fence[0] &&
+                fenceMatch[1].length >= treeFence.fence.length &&
+                remainder.trim() === ''
+            ) {
+                pushTreeDirective(
+                    processedLines,
+                    parseAsciiTreeContent(treeFence.lines),
+                    pushBlankLineIfNeeded,
+                    pushLine,
+                );
+                treeFence = null;
+            } else {
+                treeFence.lines.push(line);
+            }
+
+            continue;
+        }
+
+        if (fenceMatch && activeFence === null) {
+            const fence = fenceMatch[1];
+            const infoString = trimmedLine.slice(fence.length).trim();
+
+            if (/^tree(?:\s|$)/.test(infoString)) {
+                treeFence = { openingLine: line, fence, lines: [] };
+
+                continue;
+            }
+        }
+
         if (fenceMatch) {
             const fence = fenceMatch[1];
             const remainder = trimmedLine.slice(fence.length);
@@ -343,16 +381,12 @@ export function preprocessMintlifySyntax(markdown: string): string {
 
         if (treeBuffer !== null) {
             if (trimmedLine === '</Tree>') {
-                const nodes = parseTreeContent(treeBuffer);
-                const json = JSON.stringify(nodes);
-
-                pushBlankLineIfNeeded();
-                pushLine(':::tree');
-                pushLine('```json');
-                pushLine(json);
-                pushLine('```');
-                pushLine('');
-                pushLine(':::');
+                pushTreeDirective(
+                    processedLines,
+                    parseTreeContent(treeBuffer),
+                    pushBlankLineIfNeeded,
+                    pushLine,
+                );
                 treeBuffer = null;
             } else {
                 treeBuffer.push(line);
@@ -784,6 +818,10 @@ export function preprocessMintlifySyntax(markdown: string): string {
         processedLines.push(line);
     }
 
+    if (treeFence !== null) {
+        processedLines.push(treeFence.openingLine, ...treeFence.lines);
+    }
+
     return processedLines.join('\n');
 }
 
@@ -849,6 +887,157 @@ interface TreeNode {
     defaultOpen?: boolean;
     openable?: boolean;
     children?: TreeNode[];
+}
+
+function createAsciiTreeFolderNode(name: string): TreeNode {
+    return {
+        type: 'folder',
+        name,
+        defaultOpen: true,
+        children: [],
+    };
+}
+
+function createAsciiTreeFileNode(name: string): TreeNode {
+    return {
+        type: 'file',
+        name,
+    };
+}
+
+function ensureTreeNodeIsFolder(node: TreeNode): TreeNode {
+    if (node.type === 'folder') {
+        node.children ??= [];
+
+        return node;
+    }
+
+    node.type = 'folder';
+    node.defaultOpen = true;
+    node.children = [];
+
+    return node;
+}
+
+function splitTreePathSegments(value: string): string[] {
+    return value
+        .split('/')
+        .map((segment) => segment.trim())
+        .filter(Boolean);
+}
+
+function parseAsciiTreeContent(lines: string[]): TreeNode[] {
+    const root: TreeNode[] = [];
+    const stack: TreeNode[] = [];
+    let rootBranchDepthOffset = 0;
+    const normalizedLines = (() => {
+        const nonEmptyLines = lines.filter((line) => line.trim() !== '');
+        const sharedIndent = nonEmptyLines.reduce<number>((minimum, line) => {
+            const leadingSpaces = line.match(/^ */)?.[0].length ?? 0;
+
+            return Math.min(minimum, leadingSpaces);
+        }, Number.POSITIVE_INFINITY);
+
+        if (!Number.isFinite(sharedIndent) || sharedIndent === 0) {
+            return lines;
+        }
+
+        return lines.map((line) => line.slice(sharedIndent));
+    })();
+
+    const appendPath = (depth: number, rawValue: string): void => {
+        const isFolderHint = rawValue.endsWith('/');
+        const segments = splitTreePathSegments(
+            isFolderHint ? rawValue.slice(0, -1) : rawValue,
+        );
+
+        if (segments.length === 0) {
+            return;
+        }
+
+        let children =
+            depth === 0 || stack[depth - 1] === undefined
+                ? root
+                : ensureTreeNodeIsFolder(stack[depth - 1]).children!;
+        let currentDepth = depth;
+
+        for (const [index, segment] of segments.entries()) {
+            const isLastSegment = index === segments.length - 1;
+            const node =
+                !isLastSegment || isFolderHint
+                    ? createAsciiTreeFolderNode(segment)
+                    : createAsciiTreeFileNode(segment);
+
+            children.push(node);
+            stack[currentDepth] = node;
+            stack.length = currentDepth + 1;
+
+            if (node.type === 'folder') {
+                children = node.children!;
+                currentDepth++;
+            }
+        }
+    };
+
+    for (const line of normalizedLines) {
+        const trimmed = line.trimEnd();
+
+        if (
+            trimmed === '' ||
+            /^\d+\s+director(?:y|ies)(?:,\s+\d+\s+files?)?$/.test(trimmed)
+        ) {
+            continue;
+        }
+
+        if (trimmed.trim() === '.') {
+            rootBranchDepthOffset = -1;
+
+            continue;
+        }
+
+        const branchMatch =
+            /^(?<prefix>(?:│   |    )*)(?:├── |└── )(?<value>.+)$/.exec(
+                trimmed,
+            );
+
+        if (!branchMatch?.groups?.value) {
+            const rawValue = trimmed.trim();
+            appendPath(0, rawValue);
+
+            rootBranchDepthOffset = Math.max(
+                0,
+                splitTreePathSegments(
+                    rawValue.endsWith('/') ? rawValue.slice(0, -1) : rawValue,
+                ).length - 1,
+            );
+            continue;
+        }
+
+        const depth =
+            Math.floor(branchMatch.groups.prefix.length / 4) +
+            1 +
+            rootBranchDepthOffset;
+        appendPath(depth, branchMatch.groups.value.trim());
+    }
+
+    return root;
+}
+
+function pushTreeDirective(
+    processedLines: string[],
+    nodes: TreeNode[],
+    pushBlankLineIfNeeded: () => void,
+    pushLine: (value: string) => void,
+): void {
+    const json = JSON.stringify(nodes);
+
+    pushBlankLineIfNeeded();
+    pushLine(':::tree');
+    pushLine('```json');
+    pushLine(json);
+    pushLine('```');
+    pushLine('');
+    pushLine(':::');
 }
 
 function joinMultilineTreeTags(lines: string[]): string[] {

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -265,8 +265,11 @@ export function preprocessMintlifySyntax(markdown: string): string {
     const processedLines: string[] = [];
     let activeFence: string | null = null;
     let activeFenceIndent = 0;
-    let treeFence: { openingLine: string; fence: string; lines: string[] } | null =
-        null;
+    let treeFence: {
+        openingLine: string;
+        fence: string;
+        lines: string[];
+    } | null = null;
     let mintlifyTabsDepth = 0;
     const mintlifyCalloutColonCounts: number[] = [];
     const mintlifyTagStack: Array<

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -430,6 +430,115 @@ test('preprocessMarkdownSyntax converts Mintlify Tree to a tree directive with J
     assert.match(output, /^:::\s*$/m);
 });
 
+test('preprocessMarkdownSyntax converts tree fenced blocks to a tree directive with inferred folders', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`tree
+app/Ai
+└── Agents
+    ├── CoverImagePromptAgent.php
+    ├── MarkdownStructureAgent.php
+    ├── ThinkstreamStructureAgent.php
+    ├── ThinkstreamTitleAgent.php
+    └── TranslateSelectionAgent.php
+\`\`\``);
+
+    assert.match(output, /:::tree/);
+    assert.match(output, /```json/);
+    assert.match(output, /"name":"app"/);
+    assert.match(output, /"name":"Ai"/);
+    assert.match(output, /"name":"Agents"/);
+    assert.match(output, /"defaultOpen":true/);
+    assert.match(output, /"name":"CoverImagePromptAgent\.php"/);
+    assert.match(output, /"name":"TranslateSelectionAgent\.php"/);
+    assert.match(output, /^:::\s*$/m);
+});
+
+test('preprocessMarkdownSyntax ignores tree summary lines and honors trailing slash folder hints', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`tree
+.
+app/
+└── Services/
+    └── SyncFileParser.php
+
+1 directory, 1 file
+\`\`\``);
+
+    assert.match(output, /"name":"app"/);
+    assert.match(output, /"name":"Services"/);
+    assert.match(output, /"name":"SyncFileParser\.php"/);
+    assert.doesNotMatch(output, /directory, 1 file/);
+});
+
+test('preprocessMarkdownSyntax handles tree command output rooted at dot', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`tree
+.
+├── app
+│   └── Services
+│       └── SyncFileParser.php
+└── tests
+    └── Feature
+        └── SyntaxSeederTest.php
+\`\`\``);
+
+    const json = /```json\n(?<payload>[\s\S]*?)\n```/.exec(output)?.groups
+        ?.payload;
+
+    assert.ok(json);
+
+    const tree = JSON.parse(json);
+
+    assert.equal(tree[0].name, 'app');
+    assert.equal(tree[0].children[0].name, 'Services');
+    assert.equal(tree[1].name, 'tests');
+    assert.equal(tree[1].children[0].name, 'Feature');
+});
+
+test('preprocessMarkdownSyntax handles tree fenced blocks with shared leading indentation', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`tree
+  app/Ai
+  └── Agents
+      └── TranslateSelectionAgent.php
+\`\`\``);
+
+    const json = /```json\n(?<payload>[\s\S]*?)\n```/.exec(output)?.groups
+        ?.payload;
+
+    assert.ok(json);
+
+    const tree = JSON.parse(json);
+
+    assert.equal(tree[0].name, 'app');
+    assert.equal(tree[0].children[0].name, 'Ai');
+    assert.equal(tree[0].children[0].children[0].name, 'Agents');
+    assert.equal(
+        tree[0].children[0].children[0].children[0].name,
+        'TranslateSelectionAgent.php',
+    );
+    assert.doesNotMatch(output, /"name":"└── Agents"/);
+});
+
+test('preprocessMarkdownSyntax leaves tree fences untouched inside longer fenced code blocks', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`\`md
+\`\`\`tree
+app/Ai
+└── Agents
+\`\`\`
+\`\`\`\``);
+
+    assert.doesNotMatch(output, /:::tree/);
+    assert.match(output, /```tree/);
+    assert.match(output, /└── Agents/);
+});
+
+test('preprocessMarkdownSyntax leaves unclosed tree fences untouched', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`tree
+app/Ai
+└── Agents`);
+
+    assert.doesNotMatch(output, /:::tree/);
+    assert.match(output, /```tree/);
+    assert.match(output, /└── Agents/);
+});
+
 test('preprocessMarkdownSyntax joins multiline Tree child tags before encoding JSON', () => {
     const output = preprocessMarkdownSyntax(`<Tree>
   <Tree.Folder

--- a/tests/Feature/SyntaxSeederTest.php
+++ b/tests/Feature/SyntaxSeederTest.php
@@ -135,6 +135,33 @@ test('syntax seeder creates the mintlify syntax page', function () {
     expect($post->published_at)->not->toBeNull();
 });
 
+test('syntax seeder creates the thinkstream syntax page', function () {
+    $this->seed(SyntaxSeeder::class);
+
+    $namespace = PostNamespace::query()
+        ->where('slug', 'syntax')
+        ->first();
+
+    expect($namespace)->not->toBeNull();
+    expect($namespace->post_order)->toContain('thinkstream-syntax');
+
+    $post = Post::query()
+        ->where('namespace_id', $namespace->id)
+        ->where('slug', 'thinkstream-syntax')
+        ->first();
+
+    expect($post)->not->toBeNull();
+    expect($post->title)->toBe('Thinkstream Syntax');
+    expect($post->content)->toContain('# Thinkstream Syntax');
+    expect($post->content)->toContain('```tree');
+    expect($post->content)->toContain('app/Ai');
+    expect($post->content)->toContain('└── Agents');
+    expect($post->content)->toContain('resources/js');
+    expect($post->content)->toContain('app/');
+    expect($post->content)->toContain('4 directories, 2 files');
+    expect($post->published_at)->not->toBeNull();
+});
+
 test('routing check seeder creates wildcard routing lookalike namespaces', function () {
     $this->seed(RoutingCheckSeeder::class);
 


### PR DESCRIPTION
## Summary
- add a Thinkstream syntax guide page covering pasted `tree` fences in the syntax seeder
- convert `tree` fenced code blocks into the existing tree directive payload during markdown preprocessing
- add node and feature coverage for the new syntax examples plus unclosed/singular-summary edge cases

## Testing
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm run types:check
- vendor/bin/sail artisan test --compact tests/Feature/SyntaxSeederTest.php
- vendor/bin/sail bin pint --dirty --format agent