### PR TITLE
Fix frontend hydration mismatches

### DIFF
--- a/resources/js/components/code-block.tsx
+++ b/resources/js/components/code-block.tsx
@@ -11,10 +11,6 @@ type CodeBlockProps = ComponentPropsWithoutRef<'code'> & ExtraProps;
 const escapeHtml = (value: string) =>
     value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
-const isMobileViewport = () =>
-    typeof window !== 'undefined' &&
-    window.matchMedia('(max-width: 767px)').matches;
-
 /**
  * Parses the fenced code block info string to extract language, filename, and
  * whether this is a diff block.
@@ -85,18 +81,12 @@ export function CodeBlock({
     node,
     metastring,
 }: CodeBlockProps & { metastring?: string }) {
-    const [wrap, setWrap] = useState(isMobileViewport);
+    const [wrap, setWrap] = useState(false);
     const [copied, setCopied] = useState(false);
-    const [prismReady, setPrismReady] = useState(() =>
-        Boolean(Prism.languages.php),
-    );
+    const [prismReady, setPrismReady] = useState(false);
     const [, copy] = useClipboard();
 
     useEffect(() => {
-        if (prismReady) {
-            return;
-        }
-
         let active = true;
 
         void ensurePrismLoaded().then(() => {
@@ -108,7 +98,7 @@ export function CodeBlock({
         return () => {
             active = false;
         };
-    }, [prismReady]);
+    }, []);
 
     const rawContent = String(children);
     const content = rawContent.replace(/\n$/, '');
@@ -283,8 +273,9 @@ export function CodeBlock({
                     </div>
                 </div>
                 <pre
-                    className={`px-4 py-3 font-mono text-sm text-gray-300 ${wrap ? 'break-words whitespace-pre-wrap' : 'overflow-x-auto'}`}
+                    className={`px-4 py-3 font-mono text-sm text-gray-300 ${wrap ? 'break-words whitespace-pre-wrap' : 'overflow-x-auto'}${className ? ` ${className}` : ''}`}
                     style={{ background: '#282c34' }}
+                    tabIndex={0}
                 >
                     <code
                         className={
@@ -345,8 +336,9 @@ export function CodeBlock({
                 </button>
             </div>
             <pre
-                className={`px-4 py-3 pr-20 font-mono text-sm text-gray-300 ${wrap ? 'break-words whitespace-pre-wrap' : 'overflow-x-auto'}`}
+                className={`px-4 py-3 pr-20 font-mono text-sm text-gray-300 ${wrap ? 'break-words whitespace-pre-wrap' : 'overflow-x-auto'}${className ? ` ${className}` : ''}`}
                 style={{ background: '#282c34' }}
+                tabIndex={0}
             >
                 <code
                     className={

--- a/resources/js/pages/admin/thinkstream/index.tsx
+++ b/resources/js/pages/admin/thinkstream/index.tsx
@@ -475,6 +475,7 @@ export default function ThinkstreamIndex({
                                             </span>
                                             <span>·</span>
                                             <span
+                                                suppressHydrationWarning
                                                 title={new Date(
                                                     page.created_at,
                                                 ).toLocaleString()}

--- a/resources/js/pages/admin/thinkstream/show.tsx
+++ b/resources/js/pages/admin/thinkstream/show.tsx
@@ -937,6 +937,7 @@ export default function ThinkstreamShow({
                                                                 }{' '}
                                                                 ·{' '}
                                                                 <span
+                                                                    suppressHydrationWarning
                                                                     title={new Date(
                                                                         thought.created_at,
                                                                     ).toLocaleString()}

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -347,6 +347,7 @@ export default function Namespace({
                                                 <div className="shrink-0 text-sm text-muted-foreground">
                                                     {post.published_at ? (
                                                         <span
+                                                            suppressHydrationWarning
                                                             title={new Date(
                                                                 post.published_at,
                                                             ).toLocaleDateString()}

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -616,6 +616,7 @@ export default function Show({
                                 >
                                     Last updated:{' '}
                                     <span
+                                        suppressHydrationWarning
                                         title={postDateFormatter.format(
                                             new Date(post.updated_at),
                                         )}

--- a/resources/js/pages/tags/show.tsx
+++ b/resources/js/pages/tags/show.tsx
@@ -76,6 +76,7 @@ export default function TagShow({
                                                     </span>
                                                     <span
                                                         className="shrink-0 text-xs text-muted-foreground"
+                                                        suppressHydrationWarning
                                                         title={new Date(
                                                             post.published_at,
                                                         ).toLocaleDateString()}


### PR DESCRIPTION
## Summary
- avoid client/server hydration mismatches in code blocks by deferring Prism readiness to mount
- pass through code block class names and make preformatted blocks keyboard focusable
- suppress expected hydration warnings on relative date labels across post, tag, and thinkstream pages

## Validation
- vendor/bin/sail npm run build
- vendor/bin/sail npm run types:check
- vendor/bin/sail ./vendor/bin/pint --dirty --format agent
- vendor/bin/sail artisan test --compact tests/Feature/SyntaxSeederTest.php tests/Feature/TagControllerTest.php tests/Feature/PostControllerTest.php tests/Browser/CodeBlockHighlightingTest.php tests/Browser/MarkdownPagesTest.php tests/Browser/ThinkstreamBackupsTest.php tests/Browser/ThinkstreamAiActionsTest.php