### PR TITLE
Add markdown quiz syntax directive support

### DIFF
--- a/database/seeders/SyntaxSeeder.php
+++ b/database/seeders/SyntaxSeeder.php
@@ -1528,6 +1528,56 @@ Thinkstream includes a few authoring shortcuts on top of standard Markdown, Zenn
 
 ---
 
+## Quiz Fence
+
+Thinkstream supports a lightweight `quiz` fenced code block for single-question multiple-choice prompts.
+
+Live example:
+
+```quiz
+question: How does Next.js optimize fonts?
+correct: D
+
+A: It causes additional network requests which improve performance.
+B: It disables all custom fonts.
+C: It preloads all fonts at runtime.
+D: It hosts font files with other static assets so that there are no additional network requests.
+
+hint: Additional requests can impact performance.
+incorrect: Not Quite
+correctMessage: Correct
+explanation: Next.js can self-host optimized font assets so the browser avoids extra third-party font requests.
+```
+
+Source:
+
+````md
+```quiz
+question: How does Next.js optimize fonts?
+correct: D
+
+A: It causes additional network requests which improve performance.
+B: It disables all custom fonts.
+C: It preloads all fonts at runtime.
+D: It hosts font files with other static assets so that there are no additional network requests.
+
+hint: Additional requests can impact performance.
+incorrect: Not Quite
+correctMessage: Correct
+explanation: Next.js can self-host optimized font assets so the browser avoids extra third-party font requests.
+```
+````
+
+Notes:
+
+- `question:` defines the prompt shown above the answers.
+- `correct:` points to the correct choice using `A`, `B`, `C`, or `D`.
+- Choices use `A:` style labels so the block stays easy to type in plain Markdown.
+- `hint:` and `incorrect:` can drive the retry state shown after a wrong answer.
+- `correctMessage:` and `explanation:` customize the successful result state.
+
+---
+
 ## Tree Fence
 
 Use a `tree` fenced code block when you want to paste a file tree directly from your terminal. Thinkstream converts it into the interactive tree renderer automatically.

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -20,6 +20,7 @@ import {
     MarkdownCardGroup,
 } from '@/components/markdown-card-group';
 import { MarkdownCodeGroup } from '@/components/markdown-code-group';
+import { MarkdownQuiz } from '@/components/markdown-quiz';
 import { MarkdownStep, MarkdownSteps } from '@/components/markdown-steps';
 import { MarkdownTab, MarkdownTabs } from '@/components/markdown-tabs';
 import { MarkdownTooltip } from '@/components/markdown-tooltip';
@@ -39,6 +40,7 @@ import { remarkCodeMeta } from '@/lib/remark-code-meta';
 import { remarkFixUrlPorts } from '@/lib/remark-fix-url-ports';
 import { remarkLinkifyToCard } from '@/lib/remark-linkify-to-card';
 import { remarkMark } from '@/lib/remark-mark';
+import { remarkQuizDirective } from '@/lib/remark-quiz-directive';
 import { remarkStepsDirective } from '@/lib/remark-steps-directive';
 import { remarkTabsDirective } from '@/lib/remark-tabs-directive';
 import { remarkTooltipDirective } from '@/lib/remark-tooltip-directive';
@@ -244,9 +246,16 @@ export default function MarkdownContent({
             const embedUrl = (props as Record<string, unknown>)[
                 'data-embed-url'
             ] as string | undefined;
+            const quizJson = (props as Record<string, unknown>)['data-quiz'] as
+                | string
+                | undefined;
 
             if (embedType && embedUrl) {
                 return <EmbedCard type={embedType} url={embedUrl} />;
+            }
+
+            if (quizJson) {
+                return <MarkdownQuiz data-quiz={quizJson} />;
             }
 
             return <div {...props} />;
@@ -272,6 +281,7 @@ export default function MarkdownContent({
                     remarkTooltipDirective,
                     remarkUpdateDirective,
                     remarkTreeDirective,
+                    remarkQuizDirective,
                     remarkCodeGroupDirective,
                     remarkLinkifyToCard,
                     remarkSupersub,

--- a/resources/js/components/markdown-quiz.tsx
+++ b/resources/js/components/markdown-quiz.tsx
@@ -1,0 +1,183 @@
+import { CircleCheck, CircleX } from 'lucide-react';
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+
+type QuizOption = {
+    label: string;
+    text: string;
+};
+
+type QuizContent = {
+    question: string;
+    correct: string;
+    options: QuizOption[];
+    hint?: string;
+    incorrect?: string;
+    correctMessage?: string;
+    explanation?: string;
+};
+
+function parseQuiz(json: string | undefined): QuizContent | null {
+    try {
+        if (!json) {
+            return null;
+        }
+
+        const quiz = JSON.parse(json) as QuizContent;
+
+        if (
+            !quiz.question ||
+            !quiz.correct ||
+            !Array.isArray(quiz.options) ||
+            quiz.options.length < 2
+        ) {
+            return null;
+        }
+
+        return quiz;
+    } catch {
+        return null;
+    }
+}
+
+interface MarkdownQuizProps {
+    'data-quiz'?: string;
+}
+
+export function MarkdownQuiz({ 'data-quiz': json }: MarkdownQuizProps) {
+    const quiz = parseQuiz(json);
+    const [selectedLabel, setSelectedLabel] = useState<string | null>(null);
+    const [submittedLabel, setSubmittedLabel] = useState<string | null>(null);
+
+    if (quiz === null) {
+        return null;
+    }
+
+    const selectedOption = quiz.options.find(
+        (option) => option.label === selectedLabel,
+    );
+    const submittedOption = quiz.options.find(
+        (option) => option.label === submittedLabel,
+    );
+    const isSubmitted = submittedLabel !== null;
+    const isCorrect = submittedLabel === quiz.correct;
+    const statusLabel = isCorrect
+        ? (quiz.correctMessage ?? 'Correct')
+        : (quiz.incorrect ?? 'Not Quite');
+
+    return (
+        <div
+            className="not-prose my-6 overflow-hidden rounded-2xl border border-border bg-background"
+            data-test="markdown-quiz"
+        >
+            <div className="border-b border-border/70 px-6 py-6 text-center">
+                <h3 className="text-xl font-semibold text-foreground">
+                    {quiz.question}
+                </h3>
+            </div>
+
+            {isSubmitted && submittedOption ? (
+                <div className="px-6 py-8">
+                    <div className="rounded-xl border border-border/70 px-6 py-8 text-center">
+                        <div className="mx-auto flex w-fit items-center justify-center rounded-full bg-muted px-4 py-2">
+                            <span className="text-sm font-semibold text-muted-foreground">
+                                {submittedOption.label}
+                            </span>
+                        </div>
+                        <p className="mt-5 text-lg font-semibold text-foreground">
+                            {submittedOption.text}
+                        </p>
+                        <div
+                            className={cn(
+                                'mt-5 inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium',
+                                isCorrect
+                                    ? 'bg-green-50 text-green-700 dark:bg-green-950/40 dark:text-green-300'
+                                    : 'bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300',
+                            )}
+                        >
+                            {isCorrect ? (
+                                <CircleCheck className="h-4 w-4" />
+                            ) : (
+                                <CircleX className="h-4 w-4" />
+                            )}
+                            {statusLabel}
+                        </div>
+                        {!isCorrect && quiz.hint ? (
+                            <p className="mt-6 text-base text-muted-foreground">
+                                Hint: {quiz.hint}
+                            </p>
+                        ) : null}
+                        {isCorrect && quiz.explanation ? (
+                            <p className="mt-6 text-base text-muted-foreground">
+                                {quiz.explanation}
+                            </p>
+                        ) : null}
+                    </div>
+                    <div className="mt-6 flex justify-center">
+                        <button
+                            type="button"
+                            onClick={() => {
+                                setSelectedLabel(null);
+                                setSubmittedLabel(null);
+                            }}
+                            className="inline-flex items-center rounded-lg border border-border px-5 py-3 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+                        >
+                            Try Again
+                        </button>
+                    </div>
+                </div>
+            ) : (
+                <div className="px-6 py-5">
+                    <div className="overflow-hidden rounded-xl border border-border/70">
+                        {quiz.options.map((option) => {
+                            const isSelected = selectedLabel === option.label;
+
+                            return (
+                                <button
+                                    key={option.label}
+                                    type="button"
+                                    onClick={() =>
+                                        setSelectedLabel(option.label)
+                                    }
+                                    className={cn(
+                                        'flex w-full items-start gap-4 px-4 py-5 text-left transition-colors',
+                                        'hover:bg-muted/40 [&:not(:last-child)]:border-b [&:not(:last-child)]:border-border/70',
+                                        isSelected && 'bg-muted/50',
+                                    )}
+                                >
+                                    <span
+                                        className={cn(
+                                            'mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-semibold',
+                                            isSelected
+                                                ? 'bg-primary text-primary-foreground'
+                                                : 'bg-muted text-primary',
+                                        )}
+                                    >
+                                        {option.label}
+                                    </span>
+                                    <span className="text-base leading-7 text-foreground">
+                                        {option.text}
+                                    </span>
+                                </button>
+                            );
+                        })}
+                    </div>
+                    <div className="mt-6 flex justify-end">
+                        <button
+                            type="button"
+                            onClick={() => {
+                                if (selectedOption) {
+                                    setSubmittedLabel(selectedOption.label);
+                                }
+                            }}
+                            disabled={!selectedOption}
+                            className="rounded-lg bg-foreground px-5 py-3 text-sm font-semibold text-background transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                            Check Answer
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/resources/js/components/markdown-quiz.tsx
+++ b/resources/js/components/markdown-quiz.tsx
@@ -1,44 +1,7 @@
 import { CircleCheck, CircleX } from 'lucide-react';
 import { useState } from 'react';
+import { parseQuiz } from '@/lib/markdown-quiz';
 import { cn } from '@/lib/utils';
-
-type QuizOption = {
-    label: string;
-    text: string;
-};
-
-type QuizContent = {
-    question: string;
-    correct: string;
-    options: QuizOption[];
-    hint?: string;
-    incorrect?: string;
-    correctMessage?: string;
-    explanation?: string;
-};
-
-function parseQuiz(json: string | undefined): QuizContent | null {
-    try {
-        if (!json) {
-            return null;
-        }
-
-        const quiz = JSON.parse(json) as QuizContent;
-
-        if (
-            !quiz.question ||
-            !quiz.correct ||
-            !Array.isArray(quiz.options) ||
-            quiz.options.length < 2
-        ) {
-            return null;
-        }
-
-        return quiz;
-    } catch {
-        return null;
-    }
-}
 
 interface MarkdownQuizProps {
     'data-quiz'?: string;

--- a/resources/js/lib/markdown-quiz.ts
+++ b/resources/js/lib/markdown-quiz.ts
@@ -1,0 +1,63 @@
+export type QuizOption = {
+    label: string;
+    text: string;
+};
+
+export type QuizContent = {
+    question: string;
+    correct: string;
+    options: QuizOption[];
+    hint?: string;
+    incorrect?: string;
+    correctMessage?: string;
+    explanation?: string;
+};
+
+export function parseQuiz(json: string | undefined): QuizContent | null {
+    try {
+        if (!json) {
+            return null;
+        }
+
+        const quiz = JSON.parse(json) as QuizContent;
+        const normalizedCorrect = quiz.correct?.trim().toUpperCase();
+        const normalizedOptions = Array.isArray(quiz.options)
+            ? quiz.options
+                  .filter(
+                      (option): option is QuizOption =>
+                          typeof option.label === 'string' &&
+                          typeof option.text === 'string' &&
+                          option.label.trim() !== '' &&
+                          option.text.trim() !== '',
+                  )
+                  .map((option) => ({
+                      label: option.label.trim().toUpperCase(),
+                      text: option.text.trim(),
+                  }))
+            : [];
+
+        if (
+            !quiz.question ||
+            !normalizedCorrect ||
+            normalizedOptions.length < 2 ||
+            !normalizedOptions.some(
+                (option) => option.label === normalizedCorrect,
+            )
+        ) {
+            return null;
+        }
+
+        return {
+            ...quiz,
+            question: quiz.question.trim(),
+            correct: normalizedCorrect,
+            options: normalizedOptions,
+            hint: quiz.hint?.trim() || undefined,
+            incorrect: quiz.incorrect?.trim() || undefined,
+            correctMessage: quiz.correctMessage?.trim() || undefined,
+            explanation: quiz.explanation?.trim() || undefined,
+        };
+    } catch {
+        return null;
+    }
+}

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -24,6 +24,21 @@ type EncodedMetadata = {
     caption?: string;
 };
 
+type QuizOption = {
+    label: string;
+    text: string;
+};
+
+type QuizContent = {
+    question: string;
+    correct: string;
+    options: QuizOption[];
+    hint?: string;
+    incorrect?: string;
+    correctMessage?: string;
+    explanation?: string;
+};
+
 export function isAbsoluteUrl(url: string): boolean {
     return (
         url.startsWith('http://') ||
@@ -270,6 +285,11 @@ export function preprocessMintlifySyntax(markdown: string): string {
         fence: string;
         lines: string[];
     } | null = null;
+    let quizFence: {
+        openingLine: string;
+        fence: string;
+        lines: string[];
+    } | null = null;
     let mintlifyTabsDepth = 0;
     const mintlifyCalloutColonCounts: number[] = [];
     const mintlifyTagStack: Array<
@@ -342,12 +362,54 @@ export function preprocessMintlifySyntax(markdown: string): string {
             continue;
         }
 
+        if (quizFence !== null) {
+            const remainder = fenceMatch
+                ? trimmedLine.slice(fenceMatch[1].length)
+                : '';
+
+            if (
+                fenceMatch &&
+                fenceMatch[1][0] === quizFence.fence[0] &&
+                fenceMatch[1].length >= quizFence.fence.length &&
+                remainder.trim() === ''
+            ) {
+                const quiz = parseQuizContent(quizFence.lines);
+
+                if (quiz === null) {
+                    processedLines.push(
+                        quizFence.openingLine,
+                        ...quizFence.lines,
+                        line,
+                    );
+                } else {
+                    pushQuizDirective(
+                        processedLines,
+                        quiz,
+                        pushBlankLineIfNeeded,
+                        pushLine,
+                    );
+                }
+
+                quizFence = null;
+            } else {
+                quizFence.lines.push(line);
+            }
+
+            continue;
+        }
+
         if (fenceMatch && activeFence === null) {
             const fence = fenceMatch[1];
             const infoString = trimmedLine.slice(fence.length).trim();
 
             if (/^tree(?:\s|$)/.test(infoString)) {
                 treeFence = { openingLine: line, fence, lines: [] };
+
+                continue;
+            }
+
+            if (/^quiz(?:\s|$)/.test(infoString)) {
+                quizFence = { openingLine: line, fence, lines: [] };
 
                 continue;
             }
@@ -825,6 +887,10 @@ export function preprocessMintlifySyntax(markdown: string): string {
         processedLines.push(treeFence.openingLine, ...treeFence.lines);
     }
 
+    if (quizFence !== null) {
+        processedLines.push(quizFence.openingLine, ...quizFence.lines);
+    }
+
     return processedLines.join('\n');
 }
 
@@ -999,7 +1065,7 @@ function parseAsciiTreeContent(lines: string[]): TreeNode[] {
         }
 
         const branchMatch =
-            /^(?<prefix>(?:│   |    )*)(?:├── |└── )(?<value>.+)$/.exec(
+            /^(?<prefix>(?:│ {3}| {4})*)(?:├── |└── )(?<value>.+)$/.exec(
                 trimmed,
             );
 
@@ -1026,6 +1092,111 @@ function parseAsciiTreeContent(lines: string[]): TreeNode[] {
     return root;
 }
 
+function parseQuizContent(lines: string[]): QuizContent | null {
+    const options: QuizOption[] = [];
+    const fields: Partial<Omit<QuizContent, 'options'>> = {};
+    let activeOption: QuizOption | null = null;
+    let activeField:
+        | 'question'
+        | 'hint'
+        | 'incorrect'
+        | 'correctMessage'
+        | 'explanation'
+        | null = null;
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+
+        if (!trimmed) {
+            activeOption = null;
+            activeField = null;
+
+            continue;
+        }
+
+        const optionMatch = /^(?<label>[A-Z]):\s*(?<text>.+)$/.exec(trimmed);
+
+        if (optionMatch?.groups?.label && optionMatch.groups.text) {
+            const option: QuizOption = {
+                label: optionMatch.groups.label,
+                text: optionMatch.groups.text.trim(),
+            };
+
+            options.push(option);
+            activeOption = option;
+            activeField = null;
+
+            continue;
+        }
+
+        const fieldMatch =
+            /^(?<key>question|correct|hint|incorrect|correctMessage|explanation):\s*(?<value>.+)$/.exec(
+                trimmed,
+            );
+
+        if (fieldMatch?.groups?.key && fieldMatch.groups.value) {
+            const key = fieldMatch.groups.key as
+                | 'question'
+                | 'correct'
+                | 'hint'
+                | 'incorrect'
+                | 'correctMessage'
+                | 'explanation';
+            const value = fieldMatch.groups.value.trim();
+
+            if (key === 'correct') {
+                fields.correct = value.toUpperCase();
+                activeOption = null;
+                activeField = null;
+
+                continue;
+            }
+
+            fields[key] = value;
+            activeOption = null;
+            activeField = key;
+
+            continue;
+        }
+
+        if (activeOption !== null) {
+            activeOption.text += ` ${trimmed}`;
+
+            continue;
+        }
+
+        if (activeField !== null) {
+            fields[activeField] =
+                `${fields[activeField] ?? ''} ${trimmed}`.trim();
+
+            continue;
+        }
+
+        return null;
+    }
+
+    const question = fields.question?.trim();
+    const correct = fields.correct?.trim().toUpperCase();
+
+    if (!question || !correct || options.length < 2) {
+        return null;
+    }
+
+    if (!options.some((option) => option.label === correct)) {
+        return null;
+    }
+
+    return {
+        question,
+        correct,
+        options,
+        hint: fields.hint?.trim() || undefined,
+        incorrect: fields.incorrect?.trim() || undefined,
+        correctMessage: fields.correctMessage?.trim() || undefined,
+        explanation: fields.explanation?.trim() || undefined,
+    };
+}
+
 function pushTreeDirective(
     processedLines: string[],
     nodes: TreeNode[],
@@ -1036,6 +1207,23 @@ function pushTreeDirective(
 
     pushBlankLineIfNeeded();
     pushLine(':::tree');
+    pushLine('```json');
+    pushLine(json);
+    pushLine('```');
+    pushLine('');
+    pushLine(':::');
+}
+
+function pushQuizDirective(
+    processedLines: string[],
+    quiz: QuizContent,
+    pushBlankLineIfNeeded: () => void,
+    pushLine: (value: string) => void,
+): void {
+    const json = JSON.stringify(quiz);
+
+    pushBlankLineIfNeeded();
+    pushLine(':::quiz');
     pushLine('```json');
     pushLine(json);
     pushLine('```');

--- a/resources/js/lib/remark-quiz-directive.ts
+++ b/resources/js/lib/remark-quiz-directive.ts
@@ -1,0 +1,38 @@
+import type { Code, Root } from 'mdast';
+import type { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+interface ContainerDirectiveNode extends Node {
+    type: 'containerDirective';
+    name: string;
+    children: Node[];
+    data?: {
+        hName?: string;
+        hProperties?: Record<string, unknown>;
+    };
+}
+
+export function remarkQuizDirective() {
+    return (tree: Root) => {
+        visit(tree, (node: Node) => {
+            if (node.type !== 'containerDirective') {
+                return;
+            }
+
+            const directiveNode = node as ContainerDirectiveNode;
+
+            if (directiveNode.name !== 'quiz') {
+                return;
+            }
+
+            const codeChild = directiveNode.children.find(
+                (child) => child.type === 'code',
+            ) as Code | undefined;
+            const json = codeChild?.value ?? '{}';
+
+            directiveNode.data = directiveNode.data || {};
+            directiveNode.data.hName = 'div';
+            directiveNode.data.hProperties = { 'data-quiz': json };
+        });
+    };
+}

--- a/tests-node/markdown/markdown-quiz-parser.test.ts
+++ b/tests-node/markdown/markdown-quiz-parser.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseQuiz } from '../../resources/js/lib/markdown-quiz.ts';
+
+test('parseQuiz rejects quizzes whose correct answer is missing from the options', () => {
+    assert.equal(
+        parseQuiz(
+            JSON.stringify({
+                question: 'Example question',
+                correct: 'Z',
+                options: [
+                    { label: 'A', text: 'One' },
+                    { label: 'B', text: 'Two' },
+                ],
+            }),
+        ),
+        null,
+    );
+});
+
+test('parseQuiz normalizes valid quiz payloads', () => {
+    const quiz = parseQuiz(
+        JSON.stringify({
+            question: '  Example question  ',
+            correct: ' b ',
+            options: [
+                { label: ' a ', text: ' First answer ' },
+                { label: ' b ', text: ' Second answer ' },
+            ],
+            incorrect: '  Not quite  ',
+        }),
+    );
+
+    assert.deepEqual(quiz, {
+        question: 'Example question',
+        correct: 'B',
+        options: [
+            { label: 'A', text: 'First answer' },
+            { label: 'B', text: 'Second answer' },
+        ],
+        incorrect: 'Not quite',
+        hint: undefined,
+        correctMessage: undefined,
+        explanation: undefined,
+    });
+});

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -539,6 +539,63 @@ app/Ai
     assert.match(output, /└── Agents/);
 });
 
+test('preprocessMarkdownSyntax converts quiz fenced blocks to a quiz directive with JSON payload', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`quiz
+question: How does Next.js optimize fonts?
+correct: D
+
+A: It causes additional network requests which improve performance.
+B: It disables all custom fonts.
+C: It preloads all fonts at runtime.
+D: It hosts font files with other static assets so that there are no additional network requests.
+
+hint: Additional requests can impact performance.
+incorrect: Not Quite
+correctMessage: Correct
+explanation: Next.js can self-host optimized font assets so the browser avoids extra third-party font requests.
+\`\`\``);
+
+    assert.match(output, /:::quiz/);
+    assert.match(output, /```json/);
+    assert.match(output, /"question":"How does Next\.js optimize fonts\?"/);
+    assert.match(output, /"correct":"D"/);
+    assert.match(output, /"label":"A"/);
+    assert.match(output, /"label":"D"/);
+    assert.match(output, /"incorrect":"Not Quite"/);
+    assert.match(output, /"correctMessage":"Correct"/);
+    assert.match(output, /"explanation":"Next\.js can self-host optimized font assets so the browser avoids extra third-party font requests\."/);
+    assert.match(output, /^:::\s*$/m);
+});
+
+test('preprocessMarkdownSyntax leaves invalid quiz fenced blocks untouched', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`quiz
+question: Missing correct answer
+
+A: One
+B: Two
+\`\`\``);
+
+    assert.doesNotMatch(output, /:::quiz/);
+    assert.match(output, /```quiz/);
+    assert.match(output, /question: Missing correct answer/);
+});
+
+test('preprocessMarkdownSyntax leaves quiz fences untouched inside longer fenced code blocks', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`\`md
+\`\`\`quiz
+question: Example
+correct: A
+
+A: One
+B: Two
+\`\`\`
+\`\`\`\``);
+
+    assert.doesNotMatch(output, /:::quiz/);
+    assert.match(output, /```quiz/);
+    assert.match(output, /correct: A/);
+});
+
 test('preprocessMarkdownSyntax joins multiline Tree child tags before encoding JSON', () => {
     const output = preprocessMarkdownSyntax(`<Tree>
   <Tree.Folder

--- a/tests-node/markdown/remark-quiz-directive.test.ts
+++ b/tests-node/markdown/remark-quiz-directive.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { remarkQuizDirective } from '../../resources/js/lib/remark-quiz-directive.ts';
+
+test('remarkQuizDirective maps quiz container directives to renderable nodes', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'quiz',
+                children: [
+                    {
+                        type: 'code',
+                        lang: 'json',
+                        value: '{"question":"Example","correct":"A","options":[{"label":"A","text":"One"},{"label":"B","text":"Two"}]}',
+                    },
+                ],
+            },
+        ],
+    };
+
+    remarkQuizDirective()(tree as never);
+
+    const directiveNode = tree.children[0] as {
+        data?: {
+            hName?: string;
+            hProperties?: Record<string, unknown>;
+        };
+    };
+
+    assert.equal(directiveNode.data?.hName, 'div');
+    assert.deepEqual(directiveNode.data?.hProperties, {
+        'data-quiz':
+            '{"question":"Example","correct":"A","options":[{"label":"A","text":"One"},{"label":"B","text":"Two"}]}',
+    });
+});
+
+test('remarkQuizDirective falls back to an empty object payload when code payload is missing', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'quiz',
+                children: [],
+            },
+        ],
+    };
+
+    remarkQuizDirective()(tree as never);
+
+    const directiveNode = tree.children[0] as {
+        data?: {
+            hProperties?: Record<string, unknown>;
+        };
+    };
+
+    assert.deepEqual(directiveNode.data?.hProperties, {
+        'data-quiz': '{}',
+    });
+});
+
+test('remarkQuizDirective ignores unrelated directives', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'tree',
+                children: [],
+            },
+        ],
+    };
+
+    remarkQuizDirective()(tree as never);
+
+    const directiveNode = tree.children[0] as {
+        data?: unknown;
+    };
+
+    assert.equal(directiveNode.data, undefined);
+});

--- a/tests/Feature/SyntaxSeederTest.php
+++ b/tests/Feature/SyntaxSeederTest.php
@@ -153,6 +153,12 @@ test('syntax seeder creates the thinkstream syntax page', function () {
     expect($post)->not->toBeNull();
     expect($post->title)->toBe('Thinkstream Syntax');
     expect($post->content)->toContain('# Thinkstream Syntax');
+    expect($post->content)->toContain('```quiz');
+    expect($post->content)->toContain('question: How does Next.js optimize fonts?');
+    expect($post->content)->toContain('correct: D');
+    expect($post->content)->toContain('incorrect: Not Quite');
+    expect($post->content)->toContain('correctMessage: Correct');
+    expect($post->content)->toContain('explanation: Next.js can self-host optimized font assets so the browser avoids extra third-party font requests.');
     expect($post->content)->toContain('```tree');
     expect($post->content)->toContain('app/Ai');
     expect($post->content)->toContain('└── Agents');


### PR DESCRIPTION
## Summary
- add quiz fenced block preprocessing and a remark directive for rendering quiz payloads
- render quiz blocks in markdown content with a dedicated interactive component
- cover the new syntax seeder content and markdown transformation behavior with PHP and node tests