### PR TITLE
Improve GitHub embed scrolling

### DIFF
--- a/resources/js/components/github-embed.tsx
+++ b/resources/js/components/github-embed.tsx
@@ -257,8 +257,14 @@ export function GithubEmbed({ url }: GithubEmbedProps) {
                     {info.owner}/{info.repo}
                 </a>
             </div>
-            <div className="overflow-x-auto bg-[#282c34]">
-                <pre className="my-0 font-mono text-sm text-gray-200">
+            <div
+                className="max-h-[32rem] overflow-auto overscroll-contain bg-[#282c34]"
+                data-test="embed-github-scroll"
+            >
+                <pre
+                    className="my-0 min-w-max font-mono text-sm text-gray-200"
+                    data-test="embed-github-code"
+                >
                     <code>
                         {highlightedLines.map((html, index) => (
                             <div

--- a/tests/Browser/ZennMarkdownRenderingTest.php
+++ b/tests/Browser/ZennMarkdownRenderingTest.php
@@ -145,15 +145,45 @@ test('GitHub URL renders as github embed', function () {
         'content' => <<<'MARKDOWN'
 # GitHub
 
-https://github.com/zenn-dev/zenn-editor/blob/canary/lerna.json
+https://github.com/laravel/framework/blob/13.x/composer.json
 MARKDOWN,
     ]);
 
-    $page = visit(route('posts.path', ['path' => $post->full_path]));
+    $page = visit(route('posts.path', ['path' => $post->full_path]))->resize(390, 844);
 
     $page->assertNoJavaScriptErrors()
         ->assertPresent('[data-test="embed-github"]')
-        ->assertPresent('[data-test="embed-github"].bg-card');
+        ->assertPresent('[data-test="embed-github"].bg-card')
+        ->assertPresent('[data-test="embed-github-scroll"]')
+        ->assertPresent('[data-test="embed-github-code"]');
+
+    $scrollMetrics = $page->script(<<<'JS'
+        (() => {
+            const viewport = document.querySelector('[data-test="embed-github-scroll"]');
+
+            if (!viewport) {
+                return null;
+            }
+
+            const styles = window.getComputedStyle(viewport);
+
+            return {
+                overflowX: styles.overflowX,
+                overflowY: styles.overflowY,
+                maxHeight: styles.maxHeight,
+                hasHorizontalOverflow: viewport.scrollWidth > viewport.clientWidth,
+                hasVerticalOverflow: viewport.scrollHeight > viewport.clientHeight,
+            };
+        })()
+    JS);
+
+    expect($scrollMetrics)->toBe([
+        'overflowX' => 'auto',
+        'overflowY' => 'auto',
+        'maxHeight' => '512px',
+        'hasHorizontalOverflow' => true,
+        'hasVerticalOverflow' => true,
+    ]);
 
 });
 


### PR DESCRIPTION
## Summary\n- add a vertically constrained, bidirectional scroll viewport for GitHub embeds\n- expose stable test selectors for the scroll container and code block\n- strengthen the browser test to verify real horizontal and vertical overflow against a large GitHub fixture\n\n## Testing\n- vendor/bin/sail npm run types:check\n- vendor/bin/sail npm run build\n- vendor/bin/sail artisan test tests/Browser/ZennMarkdownRenderingTest.php\n- vendor/bin/sail bin pint --dirty --format agent\n- vendor/bin/sail artisan test tests/Browser/ZennMarkdownRenderingTest.php