### PR TITLE
Improve Thinkstream scrap structuring

### DIFF
--- a/app/Ai/Agents/ThinkstreamStructureAgent.php
+++ b/app/Ai/Agents/ThinkstreamStructureAgent.php
@@ -3,6 +3,7 @@
 namespace App\Ai\Agents;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Timeout;
 use Laravel\Ai\Attributes\UseSmartestModel;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasStructuredOutput;
@@ -10,6 +11,7 @@ use Laravel\Ai\Promptable;
 use Stringable;
 
 #[UseSmartestModel]
+#[Timeout(120)]
 class ThinkstreamStructureAgent implements Agent, HasStructuredOutput
 {
     use Promptable;
@@ -17,7 +19,7 @@ class ThinkstreamStructureAgent implements Agent, HasStructuredOutput
     public function instructions(): Stringable|string
     {
         return <<<'INSTRUCTIONS'
-You are an expert editor. You will receive a canvas title and a collection of raw, informal thought entries separated by "---".
+You are an expert editor. You will receive a canvas title and a collection of raw, informal thought entries separated by "---", along with a syntax guide for the markdown dialect used by this application.
 
 Your task is to proofread and restructure them into a single, coherent, well-formatted markdown document, and propose a Scrap title:
 - Fix grammar, spelling, punctuation, and awkward phrasing
@@ -28,6 +30,7 @@ Your task is to proofread and restructure them into a single, coherent, well-for
 - For the title, inherit the canvas title as much as possible while making it work as a concise Scrap note title
 - Keep the title natural and specific, not generic
 - Do not include a top-level `#` heading that simply repeats the title, since the Scrap note title is stored separately
+- Follow the attached syntax guide for formatting — in particular, NEVER place a URL inline with other text; always use `@[github]()`, `@[card]()`, or a standalone paragraph for any URL
 - Return structured output only
 INSTRUCTIONS;
     }

--- a/app/Http/Controllers/Admin/ThinkstreamController.php
+++ b/app/Http/Controllers/Admin/ThinkstreamController.php
@@ -23,6 +23,7 @@ use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 use JsonException;
+use Laravel\Ai\Files\Document;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\Yaml\Yaml;
@@ -396,8 +397,15 @@ class ThinkstreamController extends Controller
             'Thoughts:',
             $thoughts->map(fn ($t) => $t->content)->join("\n\n---\n\n"),
         ]);
+        $syntaxGuide = File::get(resource_path('ai/thinkstream-syntax-guide.md'));
 
-        $agentResponse = (new ThinkstreamStructureAgent)->prompt($combined);
+        $agentResponse = (new ThinkstreamStructureAgent)->prompt(
+            'Structure the attached thoughts into a coherent document.',
+            attachments: [
+                Document::fromString($combined, 'text/plain'),
+                Document::fromString($syntaxGuide, 'text/markdown'),
+            ],
+        );
 
         $cost = AiCostCalculator::forText($agentResponse->meta, $agentResponse->usage);
 

--- a/resources/ai/thinkstream-syntax-guide.md
+++ b/resources/ai/thinkstream-syntax-guide.md
@@ -1,0 +1,146 @@
+# Thinkstream Markdown Syntax Guide
+
+Use this guide when formatting Scrap note content. Prefer these constructs over plain prose where they add clarity.
+
+---
+
+## Critical Rule: URLs Must Be Standalone
+
+**Never place a URL on the same line or in the same paragraph as other text.**
+
+Wrong:
+
+```
+See the implementation here: https://github.com/owner/repo/blob/main/src/Foo.php#L10-L20
+```
+
+Wrong:
+
+```
+1. Step description. https://github.com/owner/repo/blob/main/src/Foo.php#L10-L20
+```
+
+Correct — use `@[github]()` on its own line:
+
+```
+@[github](https://github.com/owner/repo/blob/main/src/Foo.php#L10-L20)
+```
+
+Correct — or place the bare URL as a standalone paragraph (blank line before and after):
+
+```
+Step description.
+
+https://github.com/owner/repo/blob/main/src/Foo.php#L10-L20
+```
+
+---
+
+## Embeds
+
+### GitHub Code Embed
+
+Renders the file inline with syntax highlighting. Supports line ranges.
+
+```
+@[github](https://github.com/owner/repo/blob/branch/path/to/file.php)
+@[github](https://github.com/owner/repo/blob/branch/path/to/file.php#L42)
+@[github](https://github.com/owner/repo/blob/branch/path/to/file.php#L10-L30)
+```
+
+### Link Card
+
+Renders an OGP preview card for any URL.
+
+```
+@[card](https://example.com/some/page)
+```
+
+Any standalone `https://` URL (not GitHub) also becomes a link card automatically.
+
+### YouTube
+
+Place the YouTube URL alone on its own paragraph — it embeds automatically.
+
+```
+https://www.youtube.com/watch?v=dQw4w9WgXcQ
+```
+
+---
+
+## Callout Blocks
+
+```
+:::message
+Default info callout.
+:::
+
+:::message note
+Neutral note.
+:::
+
+:::message tip
+Helpful tip.
+:::
+
+:::message alert
+Warning or caution.
+:::
+
+:::message check
+Success or confirmation.
+:::
+```
+
+---
+
+## Collapsible Section
+
+```
+:::details Click to expand
+Hidden content goes here.
+:::
+```
+
+---
+
+## Code Blocks
+
+Standard with language:
+
+````
+```php
+echo "hello";
+```
+````
+
+With filename:
+
+````
+```php:src/Console/Add.php
+echo "hello";
+```
+````
+
+Diff (prefix lines with `+` added / `-` removed):
+
+````
+```diff php
+- old line
++ new line
+```
+````
+
+---
+
+## Standard Markdown
+
+Use standard GFM for everything else: headings (`##`, `###`), ordered/unordered lists, bold/italic, inline code, blockquotes, and tables.
+
+Tables:
+
+```
+| Column A | Column B |
+|----------|----------|
+| value    | value    |
+```

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -46,6 +46,7 @@ import { remarkTabsDirective } from '@/lib/remark-tabs-directive';
 import { remarkTooltipDirective } from '@/lib/remark-tooltip-directive';
 import { remarkTreeDirective } from '@/lib/remark-tree-directive';
 import { remarkUpdateDirective } from '@/lib/remark-update-directive';
+import { remarkFallbackDirective } from '@/lib/remark-fallback-directive';
 import { remarkZennDirective } from '@/lib/remark-zenn-directive';
 import { cn } from '@/lib/utils';
 
@@ -283,6 +284,7 @@ export default function MarkdownContent({
                     remarkTreeDirective,
                     remarkQuizDirective,
                     remarkCodeGroupDirective,
+                    remarkFallbackDirective,
                     remarkLinkifyToCard,
                     remarkSupersub,
                     remarkDefinitionList,

--- a/resources/js/lib/remark-fallback-directive.ts
+++ b/resources/js/lib/remark-fallback-directive.ts
@@ -1,0 +1,83 @@
+import type { Root, Text } from 'mdast';
+import type { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+interface TextDirectiveNode extends Node {
+    type: 'textDirective';
+    name: string;
+    attributes?: Record<string, string | boolean | undefined>;
+    children: Node[];
+    data?: { hName?: string };
+}
+
+interface ParentWithChildren extends Node {
+    children: Node[];
+}
+
+function hasChildren(node: Node): node is ParentWithChildren {
+    return 'children' in node && Array.isArray(node.children);
+}
+
+/**
+ * Converts unhandled textDirective nodes back to their original literal text.
+ * Must run after all directive-handling plugins so only genuinely unhandled
+ * directives are affected (i.e. those with no data.hName set).
+ *
+ * Without this, text like "lang:add" silently loses ":add" because
+ * remark-directive parses it as a textDirective that no plugin claims.
+ */
+export function remarkFallbackDirective() {
+    return (tree: Root) => {
+        visit(
+            tree,
+            'textDirective',
+            (
+                node: Node,
+                index: number | undefined,
+                parent: Node | undefined,
+            ) => {
+                const directive = node as TextDirectiveNode;
+
+                if (directive.data?.hName || index === undefined || !parent) {
+                    return;
+                }
+
+                if (!hasChildren(parent)) {
+                    return;
+                }
+
+                let text = `:${directive.name}`;
+
+                const childText = (
+                    directive.children as Array<{
+                        type: string;
+                        value?: string;
+                    }>
+                )
+                    .filter((c) => c.type === 'text')
+                    .map((c) => c.value ?? '')
+                    .join('');
+
+                if (childText) {
+                    text += `[${childText}]`;
+                }
+
+                const attrEntries = Object.entries(directive.attributes ?? {});
+
+                if (attrEntries.length > 0) {
+                    const attrs = attrEntries
+                        .map(([k, v]) =>
+                            v === '' || v === true ? k : `${k}="${v}"`,
+                        )
+                        .join(' ');
+                    text += `{${attrs}}`;
+                }
+
+                parent.children.splice(index, 1, {
+                    type: 'text',
+                    value: text,
+                } as Text);
+            },
+        );
+    };
+}

--- a/resources/js/pages/admin/thinkstream/show.tsx
+++ b/resources/js/pages/admin/thinkstream/show.tsx
@@ -52,6 +52,7 @@ import { getMarkdownLinkPasteResult } from '@/lib/markdown-link-paste';
 import { timeAgo } from '@/lib/time';
 import { cn } from '@/lib/utils';
 import { dashboard } from '@/routes';
+import { toast } from 'sonner';
 
 const thoughtMarkdownComponents = createMarkdownComponents();
 
@@ -123,9 +124,6 @@ export default function ThinkstreamShow({
     const [editSaving, setEditSaving] = useState(false);
     const [structuredTitle, setStructuredTitle] = useState<string | null>(null);
     const [structuredContent, setStructuredContent] = useState<string | null>(
-        null,
-    );
-    const [structuredMessage, setStructuredMessage] = useState<string | null>(
         null,
     );
     const [structuredExpanded, setStructuredExpanded] = useState(false);
@@ -328,8 +326,13 @@ export default function ThinkstreamShow({
                 };
                 setStructuredTitle(title);
                 setStructuredContent(content);
-                setStructuredMessage(message ?? null);
                 setScrapUrl(null);
+                if (message) {
+                    toast.success(message);
+                }
+            },
+            onError: () => {
+                toast.error('Failed to refine for Scrap. Please try again.');
             },
         });
     }
@@ -1098,7 +1101,6 @@ export default function ThinkstreamShow({
                                         setStructuredExpanded(false);
                                         setStructuredTitle(null);
                                         setStructuredContent(null);
-                                        setStructuredMessage(null);
                                         setScrapUrl(null);
                                     }}
                                 >
@@ -1109,11 +1111,6 @@ export default function ThinkstreamShow({
                         {structuredTitle && (
                             <p className="mb-2 text-sm font-medium">
                                 {structuredTitle}
-                            </p>
-                        )}
-                        {structuredMessage && (
-                            <p className="mb-3 text-xs text-muted-foreground">
-                                {structuredMessage}
                             </p>
                         )}
                         <div className="prose prose-sm max-w-none prose-neutral dark:prose-invert">

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -1,11 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import type { Root } from 'mdast';
 import { MARKDOWN_SYNTAX_MANIFEST } from '../../resources/js/lib/markdown-syntax-manifest.ts';
 import {
     parseMarkdownImageMetadata,
     preprocessMarkdownContent,
     preprocessMarkdownSyntax,
 } from '../../resources/js/lib/markdown-syntax.ts';
+import { remarkFallbackDirective } from '../../resources/js/lib/remark-fallback-directive.ts';
 
 test('preprocessMarkdownSyntax normalizes Zenn shorthand and Mintlify tabs', () => {
     const output = preprocessMarkdownSyntax(`:::message alert
@@ -137,6 +139,44 @@ test('preprocessMarkdownSyntax converts Mintlify callout tags to message directi
     assert.match(output, /:::message\n/);
     assert.match(output, /:::message\{\.alert\}/);
     assert.match(output, /:::message\{\.check\}/);
+});
+
+test('remarkFallbackDirective restores unhandled text directives to literal text', () => {
+    const tree: Root = {
+        type: 'root',
+        children: [
+            {
+                type: 'paragraph',
+                children: [
+                    { type: 'text', value: 'Use lang' },
+                    {
+                        type: 'textDirective',
+                        name: 'add',
+                        attributes: {},
+                        children: [],
+                        data: {},
+                    },
+                    { type: 'text', value: ' for additions.' },
+                ],
+            },
+        ],
+    };
+
+    remarkFallbackDirective()(tree);
+
+    assert.deepEqual(tree, {
+        type: 'root',
+        children: [
+            {
+                type: 'paragraph',
+                children: [
+                    { type: 'text', value: 'Use lang' },
+                    { type: 'text', value: ':add' },
+                    { type: 'text', value: ' for additions.' },
+                ],
+            },
+        ],
+    });
 });
 
 test('markdown syntax manifest freezes the supported extension surface', () => {

--- a/tests/Browser/ThinkstreamAiActionsTest.php
+++ b/tests/Browser/ThinkstreamAiActionsTest.php
@@ -66,8 +66,16 @@ test('thinkstream refine for scrap sends the currently selected thoughts', funct
         ->assertNoJavaScriptErrors();
 
     ThinkstreamStructureAgent::assertPrompted(
-        fn ($prompt) => str_contains($prompt->prompt, 'Second thought should be included in the refine request.')
-            && ! str_contains($prompt->prompt, 'First thought should stay out of the refine request.'),
+        fn ($prompt) => $prompt->prompt === 'Structure the attached thoughts into a coherent document.'
+            && $prompt->attachments->count() === 2
+            && str_contains(
+                (string) $prompt->attachments->first(),
+                'Second thought should be included in the refine request.',
+            )
+            && ! str_contains(
+                (string) $prompt->attachments->first(),
+                'First thought should stay out of the refine request.',
+            ),
     );
 
     $post = Post::first();

--- a/tests/Feature/Admin/ThinkstreamControllerTest.php
+++ b/tests/Feature/Admin/ThinkstreamControllerTest.php
@@ -7,9 +7,11 @@ use App\Models\PostNamespace;
 use App\Models\ThinkstreamPage;
 use App\Models\Thought;
 use App\Models\User;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\File;
+use Laravel\Ai\Files\Base64Document;
 use Symfony\Component\Yaml\Yaml;
 
 uses(RefreshDatabase::class);
@@ -284,7 +286,30 @@ test('authenticated users can structure thoughts with AI', function () {
             'ids' => $thoughts->pluck('id')->all(),
         ]);
 
-    $response->assertOk()->assertJsonStructure(['title', 'content', 'message']);
+    $response
+        ->assertOk()
+        ->assertJson([
+            'title' => 'Canvas Title Draft',
+            'content' => "# Canvas Title Draft\n\nContent here.",
+            'message' => 'Content structured. (cost: $0.0000)',
+        ]);
+
+    ThinkstreamStructureAgent::assertPrompted(function ($prompt) use ($page, $thoughts) {
+        $thoughtsAttachment = $prompt->attachments->first();
+        $guideAttachment = $prompt->attachments->last();
+
+        return $prompt->prompt === 'Structure the attached thoughts into a coherent document.'
+            && $prompt->attachments->count() === 2
+            && $thoughtsAttachment instanceof Base64Document
+            && $thoughtsAttachment->mimeType() === 'text/plain'
+            && str_contains($thoughtsAttachment->content(), 'Canvas title: '.$page->title)
+            && str_contains($thoughtsAttachment->content(), $thoughts[0]->content)
+            && str_contains($thoughtsAttachment->content(), $thoughts[1]->content)
+            && $guideAttachment instanceof Base64Document
+            && $guideAttachment->mimeType() === 'text/markdown'
+            && str_contains($guideAttachment->content(), '# Thinkstream Markdown Syntax Guide')
+            && str_contains($guideAttachment->content(), 'Critical Rule: URLs Must Be Standalone');
+    });
 });
 
 test('structure thoughts returns 403 when AI is disabled', function () {
@@ -299,6 +324,28 @@ test('structure thoughts returns 403 when AI is disabled', function () {
             'ids' => $thoughts->pluck('id')->all(),
         ])
         ->assertForbidden();
+});
+
+test('structure thoughts fails when the syntax guide cannot be read', function () {
+    ThinkstreamStructureAgent::fake()->preventStrayPrompts();
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create();
+
+    File::partialMock()
+        ->shouldReceive('get')
+        ->once()
+        ->with(resource_path('ai/thinkstream-syntax-guide.md'))
+        ->andThrow(new FileNotFoundException('Missing syntax guide.'));
+
+    $this->withoutExceptionHandling();
+
+    expect(fn () => $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.structureThoughts', $page), [
+            'ids' => [$thought->id],
+        ]))->toThrow(FileNotFoundException::class);
 });
 
 test('users cannot structure another users thoughts with AI', function () {


### PR DESCRIPTION
## Summary
- attach a Thinkstream markdown syntax guide when structuring selected thoughts for Scrap
- preserve unhandled markdown directives in the renderer and surface structuring feedback with toast notifications
- add feature, browser, and markdown regression coverage for the new AI attachment flow and directive fallback

## Validation
- vendor/bin/sail npm run build
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm run types:check
- vendor/bin/sail artisan test --compact tests/Feature/Admin/ThinkstreamControllerTest.php tests/Browser/ThinkstreamAiActionsTest.php