### PR TITLE
Add AI actions for thinkstream thought edits

### DIFF
--- a/app/Http/Controllers/Admin/ThinkstreamController.php
+++ b/app/Http/Controllers/Admin/ThinkstreamController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Ai\Agents\MarkdownStructureAgent;
 use App\Ai\Agents\ThinkstreamStructureAgent;
 use App\Ai\Agents\ThinkstreamTitleAgent;
+use App\Ai\Agents\TranslateSelectionAgent;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\UploadThoughtImageRequest;
 use App\Models\Post;
@@ -423,6 +425,72 @@ class ThinkstreamController extends Controller
 
         return response()->json([
             'title' => $agentResponse['title'],
+            'content' => $agentResponse['content'],
+            'message' => $message,
+        ]);
+    }
+
+    public function structureThought(Request $request, ThinkstreamPage $page, Thought $thought): JsonResponse
+    {
+        abort_unless(config('thinkstream.ai.enabled'), 403);
+        $this->authorizeThought($request, $page, $thought);
+
+        $validated = $request->validate([
+            'content' => ['required', 'string', 'max:200000'],
+        ]);
+
+        $agentResponse = (new MarkdownStructureAgent)->prompt($validated['content']);
+
+        $cost = AiCostCalculator::forText($agentResponse->meta, $agentResponse->usage);
+
+        Log::info('Thought structured with AI', [
+            'page_id' => $page->id,
+            'thought_id' => $thought->id,
+            'agent_model' => $agentResponse->meta->model,
+            'agent_usage' => $agentResponse->usage->toArray(),
+            'cost_usd' => $cost,
+        ]);
+
+        $message = $cost !== null
+            ? __('Content structured. (cost: $:cost)', ['cost' => number_format($cost, 4)])
+            : __('Content structured.');
+
+        return response()->json([
+            'content' => $agentResponse['content'],
+            'message' => $message,
+        ]);
+    }
+
+    public function translateThought(Request $request, ThinkstreamPage $page, Thought $thought): JsonResponse
+    {
+        abort_unless(config('thinkstream.ai.enabled'), 403);
+        $this->authorizeThought($request, $page, $thought);
+
+        $validated = $request->validate([
+            'content' => ['required', 'string', 'max:200000'],
+        ]);
+
+        $locale = (string) config('app.locale', 'en');
+        $targetLanguage = \Locale::getDisplayLanguage($locale, 'en') ?: $locale;
+
+        $agentResponse = (new TranslateSelectionAgent($targetLanguage))->prompt($validated['content']);
+
+        $cost = AiCostCalculator::forText($agentResponse->meta, $agentResponse->usage);
+
+        Log::info('Thought translated with AI', [
+            'page_id' => $page->id,
+            'thought_id' => $thought->id,
+            'target_language' => $targetLanguage,
+            'agent_model' => $agentResponse->meta->model,
+            'agent_usage' => $agentResponse->usage->toArray(),
+            'cost_usd' => $cost,
+        ]);
+
+        $message = $cost !== null
+            ? __('Translated to :language. (cost: $:cost)', ['language' => $targetLanguage, 'cost' => number_format($cost, 4)])
+            : __('Translated to :language.', ['language' => $targetLanguage]);
+
+        return response()->json([
             'content' => $agentResponse['content'],
             'message' => $message,
         ]);

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -132,6 +132,7 @@ export default function Edit({
                     selection.end,
                     content,
                 );
+                setHasUnsavedChanges(true);
                 toast.success(message);
             },
             onError: (errors: Record<string, string>) => {
@@ -465,6 +466,7 @@ export default function Edit({
                                                             type="button"
                                                             variant="outline"
                                                             size="sm"
+                                                            data-test="post-structure-selection-button"
                                                             disabled={
                                                                 !hasSelection ||
                                                                 structuring ||
@@ -492,6 +494,7 @@ export default function Edit({
                                                             type="button"
                                                             variant="outline"
                                                             size="sm"
+                                                            data-test="post-translate-selection-button"
                                                             disabled={
                                                                 !hasSelection ||
                                                                 structuring ||

--- a/resources/js/pages/admin/thinkstream/show.tsx
+++ b/resources/js/pages/admin/thinkstream/show.tsx
@@ -10,6 +10,7 @@ import {
     BookmarkPlus,
     Brain,
     ExternalLink,
+    Languages,
     ListChecks,
     PanelRightClose,
     PanelRightOpen,
@@ -28,7 +29,9 @@ import {
     saveToScrap as thinkstreamSaveToScrap,
     show as thinkstreamShow,
     store as thinkstreamStore,
+    structureThought as thinkstreamStructureThought,
     structureThoughts as thinkstreamStructureThoughts,
+    translateThought as thinkstreamTranslateThought,
     update as thinkstreamUpdate,
     uploadImage as thinkstreamUploadImage,
 } from '@/actions/App/Http/Controllers/Admin/ThinkstreamController';
@@ -156,6 +159,18 @@ export default function ThinkstreamShow({
         delete_canvas: false,
         page_id: null as number | null,
     });
+
+    const {
+        post: structureThoughtPost,
+        processing: structuringThought,
+        transform: transformStructureThought,
+    } = useHttp({ content: '' });
+
+    const {
+        post: translateThoughtPost,
+        processing: translatingThought,
+        transform: transformTranslateThought,
+    } = useHttp({ content: '' });
 
     setLayoutProps({
         breadcrumbs: [
@@ -364,6 +379,51 @@ export default function ThinkstreamShow({
                 }
             },
         });
+    }
+
+    function runThoughtAiAction(
+        thought: Thought,
+        post: (url: string, options: object) => Promise<unknown>,
+        transform: (fn: () => { content: string }) => void,
+        url: string,
+        errorMessage: string,
+    ) {
+        transform(() => ({ content: editingContent }));
+        post(url, {
+            onSuccess: (response: unknown) => {
+                const { content, message } = response as {
+                    content: string;
+                    message: string;
+                };
+                setEditingContent(content);
+                if (message) {
+                    toast.success(message);
+                }
+            },
+            onError: () => {
+                toast.error(errorMessage);
+            },
+        });
+    }
+
+    function structureThought(thought: Thought) {
+        runThoughtAiAction(
+            thought,
+            structureThoughtPost,
+            transformStructureThought,
+            thinkstreamStructureThought.url([page.id, thought.id]),
+            'Failed to structure content.',
+        );
+    }
+
+    function translateThought(thought: Thought) {
+        runThoughtAiAction(
+            thought,
+            translateThoughtPost,
+            transformTranslateThought,
+            thinkstreamTranslateThought.url([page.id, thought.id]),
+            'Failed to translate content.',
+        );
     }
 
     function toggleSelected(id: number) {
@@ -752,52 +812,104 @@ export default function ThinkstreamShow({
                                                             e.stopPropagation()
                                                         }
                                                     >
-                                                        <div
-                                                            aria-label="Edit mode"
-                                                            className="flex w-fit gap-1 rounded-lg bg-muted/50 p-0.5"
-                                                        >
-                                                            <button
-                                                                type="button"
-                                                                onClick={() =>
-                                                                    setEditPreviewMode(
-                                                                        false,
-                                                                    )
-                                                                }
-                                                                aria-label="Write mode"
-                                                                aria-pressed={
-                                                                    !editPreviewMode
-                                                                }
-                                                                data-test="thinkstream-edit-write-tab"
-                                                                className={cn(
-                                                                    'rounded-md px-3 py-1.5 text-xs font-medium transition-all',
-                                                                    !editPreviewMode
-                                                                        ? 'bg-card text-foreground shadow-sm'
-                                                                        : 'text-muted-foreground hover:text-foreground',
-                                                                )}
+                                                        <div className="flex items-center justify-between gap-2">
+                                                            <div
+                                                                aria-label="Edit mode"
+                                                                className="flex w-fit gap-1 rounded-lg bg-muted/50 p-0.5"
                                                             >
-                                                                Write
-                                                            </button>
-                                                            <button
-                                                                type="button"
-                                                                onClick={() =>
-                                                                    setEditPreviewMode(
-                                                                        true,
-                                                                    )
-                                                                }
-                                                                aria-label="Preview mode"
-                                                                aria-pressed={
-                                                                    editPreviewMode
-                                                                }
-                                                                data-test="thinkstream-edit-preview-tab"
-                                                                className={cn(
-                                                                    'rounded-md px-3 py-1.5 text-xs font-medium transition-all',
-                                                                    editPreviewMode
-                                                                        ? 'bg-card text-foreground shadow-sm'
-                                                                        : 'text-muted-foreground hover:text-foreground',
-                                                                )}
-                                                            >
-                                                                Preview
-                                                            </button>
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() =>
+                                                                        setEditPreviewMode(
+                                                                            false,
+                                                                        )
+                                                                    }
+                                                                    aria-label="Write mode"
+                                                                    aria-pressed={
+                                                                        !editPreviewMode
+                                                                    }
+                                                                    data-test="thinkstream-edit-write-tab"
+                                                                    className={cn(
+                                                                        'rounded-md px-3 py-1.5 text-xs font-medium transition-all',
+                                                                        !editPreviewMode
+                                                                            ? 'bg-card text-foreground shadow-sm'
+                                                                            : 'text-muted-foreground hover:text-foreground',
+                                                                    )}
+                                                                >
+                                                                    Write
+                                                                </button>
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() =>
+                                                                        setEditPreviewMode(
+                                                                            true,
+                                                                        )
+                                                                    }
+                                                                    aria-label="Preview mode"
+                                                                    aria-pressed={
+                                                                        editPreviewMode
+                                                                    }
+                                                                    data-test="thinkstream-edit-preview-tab"
+                                                                    className={cn(
+                                                                        'rounded-md px-3 py-1.5 text-xs font-medium transition-all',
+                                                                        editPreviewMode
+                                                                            ? 'bg-card text-foreground shadow-sm'
+                                                                            : 'text-muted-foreground hover:text-foreground',
+                                                                    )}
+                                                                >
+                                                                    Preview
+                                                                </button>
+                                                            </div>
+                                                            {aiEnabled && (
+                                                                <div className="flex items-center gap-1.5">
+                                                                    <Button
+                                                                        type="button"
+                                                                        variant="outline"
+                                                                        size="sm"
+                                                                        disabled={
+                                                                            structuringThought ||
+                                                                            translatingThought
+                                                                        }
+                                                                        onClick={() =>
+                                                                            structureThought(
+                                                                                thought,
+                                                                            )
+                                                                        }
+                                                                    >
+                                                                        {structuringThought ? (
+                                                                            <Spinner className="mr-1.5" />
+                                                                        ) : (
+                                                                            <Sparkles className="mr-1.5 size-3.5" />
+                                                                        )}
+                                                                        {structuringThought
+                                                                            ? 'Structuring…'
+                                                                            : 'Structure'}
+                                                                    </Button>
+                                                                    <Button
+                                                                        type="button"
+                                                                        variant="outline"
+                                                                        size="sm"
+                                                                        disabled={
+                                                                            structuringThought ||
+                                                                            translatingThought
+                                                                        }
+                                                                        onClick={() =>
+                                                                            translateThought(
+                                                                                thought,
+                                                                            )
+                                                                        }
+                                                                    >
+                                                                        {translatingThought ? (
+                                                                            <Spinner className="mr-1.5" />
+                                                                        ) : (
+                                                                            <Languages className="mr-1.5 size-3.5" />
+                                                                        )}
+                                                                        {translatingThought
+                                                                            ? 'Translating…'
+                                                                            : 'Translate'}
+                                                                    </Button>
+                                                                </div>
+                                                            )}
                                                         </div>
                                                         {editPreviewMode ? (
                                                             <div
@@ -865,6 +977,10 @@ export default function ThinkstreamShow({
                                                                 rows={12}
                                                                 data-test="thinkstream-edit-thought-textarea"
                                                                 className="min-h-[24rem] resize-none px-4 py-3 text-[15px] leading-7 sm:min-h-[30rem]"
+                                                                disabled={
+                                                                    structuringThought ||
+                                                                    translatingThought
+                                                                }
                                                                 autoFocus
                                                             />
                                                         )}
@@ -872,6 +988,10 @@ export default function ThinkstreamShow({
                                                             <Button
                                                                 size="sm"
                                                                 variant="secondary"
+                                                                disabled={
+                                                                    structuringThought ||
+                                                                    translatingThought
+                                                                }
                                                                 onClick={() => {
                                                                     setEditPreviewMode(
                                                                         false,
@@ -886,7 +1006,9 @@ export default function ThinkstreamShow({
                                                             <Button
                                                                 size="sm"
                                                                 disabled={
-                                                                    editSaving
+                                                                    editSaving ||
+                                                                    structuringThought ||
+                                                                    translatingThought
                                                                 }
                                                                 onClick={() =>
                                                                     saveEdit(

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -24,6 +24,8 @@ Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () 
     Route::patch('thinkstream/{page}/thoughts/{thought}', [ThinkstreamController::class, 'update'])->name('thinkstream.update');
     Route::post('thinkstream/{page}/delete', [ThinkstreamController::class, 'destroyMany'])->name('thinkstream.destroyMany');
     Route::post('thinkstream/{page}/structure', [ThinkstreamController::class, 'structureThoughts'])->name('thinkstream.structureThoughts');
+    Route::post('thinkstream/{page}/thoughts/{thought}/structure', [ThinkstreamController::class, 'structureThought'])->name('thinkstream.structureThought');
+    Route::post('thinkstream/{page}/thoughts/{thought}/translate', [ThinkstreamController::class, 'translateThought'])->name('thinkstream.translateThought');
 
     Route::patch('namespaces/reorder', [NamespaceController::class, 'reorder'])->name('namespaces.reorder');
     Route::resource('namespaces', NamespaceController::class)->except(['index', 'show']);

--- a/tests/Feature/Admin/ThinkstreamControllerTest.php
+++ b/tests/Feature/Admin/ThinkstreamControllerTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use App\Ai\Agents\MarkdownStructureAgent;
 use App\Ai\Agents\ThinkstreamStructureAgent;
 use App\Ai\Agents\ThinkstreamTitleAgent;
+use App\Ai\Agents\TranslateSelectionAgent;
 use App\Models\Post;
 use App\Models\PostNamespace;
 use App\Models\ThinkstreamPage;
@@ -364,6 +366,245 @@ test('users cannot structure another users thoughts with AI', function () {
             'ids' => $thoughts->pluck('id')->all(),
         ])
         ->assertForbidden();
+});
+
+// StructureThought
+
+test('authenticated users can structure a thought draft with AI', function () {
+    MarkdownStructureAgent::fake([
+        ['content' => "## Structured note\n\nCleaned up."],
+    ]);
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create([
+        'content' => 'Original thought.',
+    ]);
+
+    $response = $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.structureThought', [$page, $thought]), [
+            'content' => 'messy draft content',
+        ]);
+
+    $response
+        ->assertOk()
+        ->assertJson([
+            'content' => "## Structured note\n\nCleaned up.",
+            'message' => 'Content structured. (cost: $0.0000)',
+        ]);
+
+    MarkdownStructureAgent::assertPrompted('messy draft content');
+    expect($thought->fresh()->content)->toBe('Original thought.');
+});
+
+test('authenticated users can structure a long thought draft with AI', function () {
+    MarkdownStructureAgent::fake([
+        ['content' => "## Structured note\n\nCleaned up."],
+    ]);
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create();
+    $content = str_repeat('Long thought. ', 4_500);
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.structureThought', [$page, $thought]), [
+            'content' => $content,
+        ])
+        ->assertOk()
+        ->assertJsonPath('content', "## Structured note\n\nCleaned up.");
+});
+
+test('structure thought returns 403 when AI is disabled', function () {
+    config()->set('thinkstream.ai.enabled', false);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.structureThought', [$page, $thought]), [
+            'content' => 'Some content.',
+        ])
+        ->assertForbidden();
+});
+
+test('structure thought is scoped to the current canvas', function () {
+    MarkdownStructureAgent::fake([
+        ['content' => 'Structured'],
+    ]);
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $page1 = ThinkstreamPage::factory()->for($user)->create();
+    $page2 = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page2, 'page')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.structureThought', [$page1, $thought]), [
+            'content' => 'Some content.',
+        ])
+        ->assertForbidden();
+});
+
+test('structure thought validates content is required', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.structureThought', [$page, $thought]), [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['content']);
+});
+
+test('structure thought validates content max length', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.structureThought', [$page, $thought]), [
+            'content' => str_repeat('a', 200001),
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['content']);
+});
+
+test('guests cannot structure a thought draft', function () {
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create();
+
+    $this->postJson(route('admin.thinkstream.structureThought', [$page, $thought]), [
+        'content' => 'Some content.',
+    ])->assertUnauthorized();
+});
+
+// TranslateThought
+
+test('authenticated users can translate a thought draft with AI', function () {
+    TranslateSelectionAgent::fake([
+        ['content' => 'こんにちは世界'],
+    ]);
+    config()->set('thinkstream.ai.enabled', true);
+    config()->set('app.locale', 'ja');
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create([
+        'content' => 'Original thought.',
+    ]);
+
+    $response = $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.translateThought', [$page, $thought]), [
+            'content' => 'Hello world',
+        ]);
+
+    $response
+        ->assertOk()
+        ->assertJsonPath('content', 'こんにちは世界')
+        ->assertJsonPath('message', fn (string $message): bool => str_contains($message, 'Japanese'));
+
+    TranslateSelectionAgent::assertPrompted('Hello world');
+    expect($thought->fresh()->content)->toBe('Original thought.');
+});
+
+test('authenticated users can translate a long thought draft with AI', function () {
+    TranslateSelectionAgent::fake([
+        ['content' => 'こんにちは世界'],
+    ]);
+    config()->set('thinkstream.ai.enabled', true);
+    config()->set('app.locale', 'ja');
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create();
+    $content = str_repeat('Hello world. ', 4_500);
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.translateThought', [$page, $thought]), [
+            'content' => $content,
+        ])
+        ->assertOk()
+        ->assertJsonPath('content', 'こんにちは世界');
+});
+
+test('translate thought returns 403 when AI is disabled', function () {
+    config()->set('thinkstream.ai.enabled', false);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.translateThought', [$page, $thought]), [
+            'content' => 'Hello',
+        ])
+        ->assertForbidden();
+});
+
+test('translate thought is scoped to the current canvas', function () {
+    TranslateSelectionAgent::fake([
+        ['content' => 'こんにちは'],
+    ]);
+    config()->set('thinkstream.ai.enabled', true);
+    config()->set('app.locale', 'ja');
+
+    $user = User::factory()->create();
+    $page1 = ThinkstreamPage::factory()->for($user)->create();
+    $page2 = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page2, 'page')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.translateThought', [$page1, $thought]), [
+            'content' => 'Hello',
+        ])
+        ->assertForbidden();
+});
+
+test('translate thought validates content is required', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.translateThought', [$page, $thought]), [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['content']);
+});
+
+test('translate thought validates content max length', function () {
+    config()->set('thinkstream.ai.enabled', true);
+
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create();
+
+    $this->actingAs($user)
+        ->postJson(route('admin.thinkstream.translateThought', [$page, $thought]), [
+            'content' => str_repeat('a', 200001),
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['content']);
+});
+
+test('guests cannot translate a thought draft', function () {
+    $user = User::factory()->create();
+    $page = ThinkstreamPage::factory()->for($user)->create();
+    $thought = Thought::factory()->for($user)->for($page, 'page')->create();
+
+    $this->postJson(route('admin.thinkstream.translateThought', [$page, $thought]), [
+        'content' => 'Hello',
+    ])->assertUnauthorized();
 });
 
 // RefineTitle


### PR DESCRIPTION
## Summary
- add per-thought structure and translate AI actions to Thinkstream edit mode
- cover the new endpoints with feature tests and align long-thought validation with supported thought length
- keep post edit AI selection coverage stable by relying on the existing unsaved-changes browser flow

## Testing
- vendor/bin/sail artisan wayfinder:generate --with-form --no-interaction
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail npm run types:check
- vendor/bin/sail artisan test --compact tests/Feature/Admin/ThinkstreamControllerTest.php tests/Feature/Admin/PostControllerStructureMarkdownTest.php tests/Feature/Admin/PostControllerTranslateMarkdownTest.php
- rm -f public/hot && vendor/bin/sail artisan test --compact tests/Browser/SmokeTest.php --filter="admin post edit warns before leaving with unsaved changes|thinkstream edit switches between write and preview without losing content"