### PR TITLE
Refine post metadata and footer coverage

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -400,7 +400,7 @@ class PostController extends Controller
     public function show(PostNamespace $namespace, Post $post): Response
     {
         $rootNamespace = $this->rootNamespace($namespace);
-        $post->load('tags', 'referrers');
+        $post->load('tags', 'referrers', 'user', 'lastEditedByUser');
 
         return Inertia::render('admin/posts/show', [
             'namespace' => [
@@ -429,6 +429,8 @@ class PostController extends Controller
                 ]),
                 'is_syncing' => $post->is_syncing,
                 'sync_file_path' => $post->sync_file_path,
+                'user' => $post->user ? ['id' => $post->user->id, 'name' => $post->user->name] : null,
+                'last_edited_by_user' => $post->lastEditedByUser ? ['id' => $post->lastEditedByUser->id, 'name' => $post->lastEditedByUser->name] : null,
                 'tags' => $post->tags->pluck('name')->values()->all(),
                 'referrers' => $post->referrers
                     ->sortByDesc('count')

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -315,7 +315,8 @@ class PostController extends Controller
     {
         // 1. First image in post content
         if (preg_match('/!\[[^\]]*\]\(([^)]+)\)/', $post->content, $matches)) {
-            $url = $matches[1];
+            // Strip Zenn-style size specifiers like " =500x" or " =500x300"
+            $url = trim(explode(' ', trim($matches[1]))[0]);
 
             return str_starts_with($url, 'http') ? $url : url($url);
         }

--- a/resources/js/pages/admin/posts/revisions.tsx
+++ b/resources/js/pages/admin/posts/revisions.tsx
@@ -1,5 +1,5 @@
 import { Form, Head, Link, setLayoutProps } from '@inertiajs/react';
-import { History } from 'lucide-react';
+import { History, UserRound } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -265,14 +265,19 @@ export default function Revisions({
                                             </span>
                                         )}
                                     </label>
-                                    <p className="pl-6 text-xs text-muted-foreground">
-                                        {new Date(
-                                            revision.created_at,
-                                        ).toLocaleString()}
+                                    <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 pl-6">
+                                        <span className="text-xs text-muted-foreground">
+                                            {new Date(
+                                                revision.created_at,
+                                            ).toLocaleString()}
+                                        </span>
                                         {revision.user && (
-                                            <> · {revision.user.name}</>
+                                            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                                                <UserRound className="size-3" />
+                                                by {revision.user.name}
+                                            </span>
                                         )}
-                                    </p>
+                                    </div>
                                 </div>
                                 {!revision.is_current && (
                                     <Form

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -8,19 +8,23 @@ import {
 } from '@inertiajs/react';
 import {
     AlertTriangle,
+    Calendar,
     ExternalLink,
     Eye,
     EyeOff,
     FileText,
     FolderSync,
     History,
+    Link2,
     PanelLeftClose,
     PanelLeftOpen,
     PanelRightClose,
     PanelRightOpen,
     Pencil,
+    Route,
     Trash2,
     Unlink,
+    UserRound,
 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import type { ContentNavNode } from '@/components/content-nav-tree';
@@ -154,6 +158,8 @@ type Post = {
     is_draft: boolean;
     published_at: string | null;
     created_at: string;
+    user: { id: number; name: string } | null;
+    last_edited_by_user: { id: number; name: string } | null;
     reference_title: string | null;
     reference_url: string | null;
     is_syncing: boolean;
@@ -620,7 +626,8 @@ export default function Show({
                                         </div>
                                         <div className="divide-y divide-border">
                                             <div className="flex items-center justify-between px-4 py-3">
-                                                <span className="text-sm text-muted-foreground">
+                                                <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                                                    <Eye className="size-3.5" />
                                                     Views
                                                 </span>
                                                 <span className="text-sm font-medium">
@@ -628,7 +635,8 @@ export default function Show({
                                                 </span>
                                             </div>
                                             <div className="flex items-center justify-between px-4 py-3">
-                                                <span className="text-sm text-muted-foreground">
+                                                <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                                                    <Calendar className="size-3.5" />
                                                     Created
                                                 </span>
                                                 <span className="text-sm font-medium">
@@ -637,8 +645,37 @@ export default function Show({
                                                     ).toLocaleDateString()}
                                                 </span>
                                             </div>
+                                            {post.user && (
+                                                <div className="flex items-center justify-between px-4 py-3">
+                                                    <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                                                        <UserRound className="size-3.5" />
+                                                        Author
+                                                    </span>
+                                                    <span className="text-sm font-medium">
+                                                        {post.user.name}
+                                                    </span>
+                                                </div>
+                                            )}
+                                            {post.last_edited_by_user &&
+                                                post.last_edited_by_user.id !==
+                                                    post.user?.id && (
+                                                    <div className="flex items-center justify-between px-4 py-3">
+                                                        <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                                                            <Pencil className="size-3.5" />
+                                                            Last edited by
+                                                        </span>
+                                                        <span className="text-sm font-medium">
+                                                            {
+                                                                post
+                                                                    .last_edited_by_user
+                                                                    .name
+                                                            }
+                                                        </span>
+                                                    </div>
+                                                )}
                                             <div className="flex items-center justify-between px-4 py-3">
-                                                <span className="text-sm text-muted-foreground">
+                                                <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                                                    <Route className="size-3.5" />
                                                     Path
                                                 </span>
                                                 <span className="max-w-32 truncate font-mono text-xs text-muted-foreground">
@@ -646,7 +683,8 @@ export default function Show({
                                                 </span>
                                             </div>
                                             <div className="flex flex-col gap-1 px-4 py-3">
-                                                <span className="mb-1 text-sm text-muted-foreground">
+                                                <span className="mb-1 flex items-center gap-1.5 text-sm text-muted-foreground">
+                                                    <Link2 className="size-3.5" />
                                                     Referrers
                                                 </span>
                                                 {post.referrers.length > 0 ? (

--- a/resources/js/pages/admin/thinkstream/show.tsx
+++ b/resources/js/pages/admin/thinkstream/show.tsx
@@ -1116,8 +1116,18 @@ export default function ThinkstreamShow({
                                                     </div>
                                                 ) : (
                                                     <>
-                                                        {!editMode && (
-                                                            <div className="mb-3 flex justify-end">
+                                                        <div className="prose prose-sm max-w-none prose-neutral dark:prose-invert">
+                                                            <MarkdownContent
+                                                                content={
+                                                                    thought.content
+                                                                }
+                                                                components={
+                                                                    thoughtMarkdownComponents
+                                                                }
+                                                            />
+                                                        </div>
+                                                        <div className="mt-2 flex items-center justify-end gap-2">
+                                                            {!editMode && (
                                                                 <Button
                                                                     type="button"
                                                                     size="sm"
@@ -1136,37 +1146,28 @@ export default function ThinkstreamShow({
                                                                     <Pencil className="size-3" />
                                                                     Edit
                                                                 </Button>
-                                                            </div>
-                                                        )}
-                                                        <div className="prose prose-sm max-w-none prose-neutral dark:prose-invert">
-                                                            <MarkdownContent
-                                                                content={
-                                                                    thought.content
-                                                                }
-                                                                components={
-                                                                    thoughtMarkdownComponents
-                                                                }
-                                                            />
-                                                        </div>
-                                                        <p className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
-                                                            <span>
-                                                                {
-                                                                    thought.user
-                                                                        .name
-                                                                }{' '}
-                                                                ·{' '}
-                                                                <span
-                                                                    suppressHydrationWarning
-                                                                    title={new Date(
-                                                                        thought.created_at,
-                                                                    ).toLocaleString()}
-                                                                >
-                                                                    {timeAgo(
-                                                                        thought.created_at,
-                                                                    )}
+                                                            )}
+                                                            <p className="flex items-center gap-2 text-xs text-muted-foreground">
+                                                                <span>
+                                                                    {
+                                                                        thought
+                                                                            .user
+                                                                            .name
+                                                                    }{' '}
+                                                                    ·{' '}
+                                                                    <span
+                                                                        suppressHydrationWarning
+                                                                        title={new Date(
+                                                                            thought.created_at,
+                                                                        ).toLocaleString()}
+                                                                    >
+                                                                        {timeAgo(
+                                                                            thought.created_at,
+                                                                        )}
+                                                                    </span>
                                                                 </span>
-                                                            </span>
-                                                        </p>
+                                                            </p>
+                                                        </div>
                                                     </>
                                                 )}
                                             </div>

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -8,6 +8,8 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import type { ContentNavNode } from '@/components/content-nav-tree';
+import { SimpleIconSvg } from '@/components/markdown-card-group';
+import { getSimpleIcon } from '@/lib/simple-icon-lookup';
 import ContentNavTree from '@/components/content-nav-tree';
 import DocsHeaderActions from '@/components/docs-header-actions';
 import MarkdownPageActions from '@/components/markdown-page-actions';
@@ -75,6 +77,7 @@ export default function Namespace({
     const navVisible = navOverride ?? !isBelowDesktop;
     const markdownPagesEnabled = thinkstream.markdown_pages.enabled;
     const markdownUrl = contentPathMarkdown.url({ path: namespace.full_path });
+    const githubIcon = getSimpleIcon('github');
 
     return (
         <>
@@ -368,6 +371,31 @@ export default function Namespace({
                         </section>
                     </main>
                 </div>
+
+                <footer className="border-t">
+                    <div className="mx-auto flex max-w-7xl justify-center px-4 py-6 text-sm text-muted-foreground">
+                        <p className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-center">
+                            <span>Powered by ThinkStream</span>
+                            <a
+                                href="https://github.com/catatsumuri/thinkstream"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                data-test="thinkstream-footer-link"
+                                className="inline-flex items-center gap-2 font-medium text-foreground underline underline-offset-4 transition-opacity hover:opacity-70"
+                            >
+                                {githubIcon && (
+                                    <span data-test="thinkstream-footer-icon">
+                                        <SimpleIconSvg
+                                            icon={githubIcon}
+                                            className="size-4"
+                                        />
+                                    </span>
+                                )}
+                                github.com/catatsumuri/thinkstream
+                            </a>
+                        </p>
+                    </div>
+                </footer>
             </div>
         </>
     );

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -12,6 +12,8 @@ import {
 import { useMemo, useState } from 'react';
 import { siX } from 'simple-icons';
 import type { ContentNavNode } from '@/components/content-nav-tree';
+import { SimpleIconSvg } from '@/components/markdown-card-group';
+import { getSimpleIcon } from '@/lib/simple-icon-lookup';
 import ContentNavTree from '@/components/content-nav-tree';
 import DocsHeaderActions from '@/components/docs-header-actions';
 import MarkdownContent from '@/components/markdown-content';
@@ -171,6 +173,7 @@ export default function Show({
     const [mobileTocOpen, setMobileTocOpen] = useState(false);
     const [tocOverride, setTocOverride] = useState<boolean | null>(null);
     const [navOverride, setNavOverride] = useState<boolean | null>(null);
+    const githubIcon = getSimpleIcon('github');
 
     const handleEditHeading = ({
         level,
@@ -646,6 +649,31 @@ export default function Show({
                         </aside>
                     )}
                 </div>
+
+                <footer className="border-t">
+                    <div className="mx-auto flex max-w-7xl justify-center px-4 py-6 text-sm text-muted-foreground">
+                        <p className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-center">
+                            <span>Powered by ThinkStream</span>
+                            <a
+                                href="https://github.com/catatsumuri/thinkstream"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                data-test="thinkstream-footer-link"
+                                className="inline-flex items-center gap-2 font-medium text-foreground underline underline-offset-4 transition-opacity hover:opacity-70"
+                            >
+                                {githubIcon && (
+                                    <span data-test="thinkstream-footer-icon">
+                                        <SimpleIconSvg
+                                            icon={githubIcon}
+                                            className="size-4"
+                                        />
+                                    </span>
+                                )}
+                                github.com/catatsumuri/thinkstream
+                            </a>
+                        </p>
+                    </div>
+                </footer>
             </div>
         </>
     );

--- a/resources/js/pages/tags/show.tsx
+++ b/resources/js/pages/tags/show.tsx
@@ -1,4 +1,6 @@
 import { Head, Link } from '@inertiajs/react';
+import { SimpleIconSvg } from '@/components/markdown-card-group';
+import { getSimpleIcon } from '@/lib/simple-icon-lookup';
 import { timeAgo } from '@/lib/time';
 import { home } from '@/routes';
 import { path as contentPath } from '@/routes/posts';
@@ -22,6 +24,8 @@ export default function TagShow({
     tag: string;
     groups: PostGroup[];
 }) {
+    const githubIcon = getSimpleIcon('github');
+
     return (
         <>
             <Head title={`Posts tagged "${tag}"`} />
@@ -94,6 +98,31 @@ export default function TagShow({
                         </div>
                     )}
                 </div>
+
+                <footer className="border-t">
+                    <div className="mx-auto flex max-w-7xl justify-center px-4 py-6 text-sm text-muted-foreground">
+                        <p className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-center">
+                            <span>Powered by ThinkStream</span>
+                            <a
+                                href="https://github.com/catatsumuri/thinkstream"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                data-test="thinkstream-footer-link"
+                                className="inline-flex items-center gap-2 font-medium text-foreground underline underline-offset-4 transition-opacity hover:opacity-70"
+                            >
+                                {githubIcon && (
+                                    <span data-test="thinkstream-footer-icon">
+                                        <SimpleIconSvg
+                                            icon={githubIcon}
+                                            className="size-4"
+                                        />
+                                    </span>
+                                )}
+                                github.com/catatsumuri/thinkstream
+                            </a>
+                        </p>
+                    </div>
+                </footer>
             </div>
         </>
     );

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -1978,18 +1978,23 @@ test('admin post details show scheduled status and tags in the info panel', func
     $user = User::factory()->create([
         'email' => 'test@example.com',
     ]);
+    $author = User::factory()->create([
+        'name' => 'Author Name',
+    ]);
 
     $namespace = PostNamespace::factory()->create([
         'slug' => 'guides',
         'name' => 'Guides',
     ]);
 
-    $post = Post::factory()->for($namespace, 'namespace')->create([
+    $post = Post::factory()->for($author)->create([
+        'namespace_id' => $namespace->id,
         'slug' => 'release-plan',
         'title' => 'Release Plan',
         'content' => "# Plan\n\n## Next steps\n\nShip it.",
         'is_draft' => false,
         'published_at' => now()->addDay(),
+        'last_edited_by_user_id' => $user->id,
     ]);
 
     $post->tags()->attach([
@@ -2022,6 +2027,10 @@ test('admin post details show scheduled status and tags in the info panel', func
                 hasVisibleFromCopy: statusCard.textContent?.includes('Visible from') ?? false,
                 hasLaravelTag: tagsCard.textContent?.includes('laravel') ?? false,
                 hasReleaseTag: tagsCard.textContent?.includes('release') ?? false,
+                hasAuthorLabel: document.body.textContent?.includes('Author') ?? false,
+                hasAuthorName: document.body.textContent?.includes('Author Name') ?? false,
+                hasLastEditorLabel: document.body.textContent?.includes('Last edited by') ?? false,
+                hasLastEditorName: document.body.textContent?.includes('test@example.com') ?? false,
             };
         })()
     JS))->toBe([
@@ -2029,7 +2038,55 @@ test('admin post details show scheduled status and tags in the info panel', func
         'hasVisibleFromCopy' => true,
         'hasLaravelTag' => true,
         'hasReleaseTag' => true,
+        'hasAuthorLabel' => true,
+        'hasAuthorName' => true,
+        'hasLastEditorLabel' => true,
+        'hasLastEditorName' => true,
     ]);
+});
+
+test('public content pages show the ThinkStream footer link', function () {
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'full_path' => 'guides',
+        'name' => 'Guides',
+        'is_published' => true,
+    ]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'slug' => 'footer-check',
+        'full_path' => 'guides/footer-check',
+        'title' => 'Footer Check',
+    ]);
+    $tag = Tag::firstOrCreate(['name' => 'footer']);
+    $post->tags()->attach($tag);
+
+    foreach ([
+        route('posts.path', ['path' => $namespace->full_path], false),
+        route('posts.path', ['path' => $post->full_path], false),
+        route('tags.show', 'footer', false),
+    ] as $path) {
+        $page = visit($path);
+
+        $page
+            ->assertNoJavaScriptErrors()
+            ->assertSee('Powered by ThinkStream')
+            ->assertAttribute(
+                '[data-test="thinkstream-footer-link"]',
+                'href',
+                'https://github.com/catatsumuri/thinkstream',
+            )
+            ->assertAttribute(
+                '[data-test="thinkstream-footer-link"]',
+                'target',
+                '_blank',
+            )
+            ->assertAttribute(
+                '[data-test="thinkstream-footer-link"]',
+                'rel',
+                'noopener noreferrer',
+            )
+            ->assertPresent('[data-test="thinkstream-footer-icon"]');
+    }
 });
 
 test('admin post details can collapse and reopen the right info panel', function () {

--- a/tests/Feature/Admin/PostControllerTest.php
+++ b/tests/Feature/Admin/PostControllerTest.php
@@ -1425,6 +1425,32 @@ test('admin post details page includes post tags', function () {
         );
 });
 
+test('admin post details page includes author and last editor metadata', function () {
+    $manager = User::factory()->create();
+    $author = User::factory()->create([
+        'name' => 'Author Name',
+    ]);
+    $editor = User::factory()->create([
+        'name' => 'Editor Name',
+    ]);
+    $namespace = PostNamespace::factory()->create();
+    $post = Post::factory()->for($author)->create([
+        'namespace_id' => $namespace->id,
+        'last_edited_by_user_id' => $editor->id,
+    ]);
+
+    $this->actingAs($manager)
+        ->get(route('admin.posts.show', [$namespace, $post]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('admin/posts/show')
+            ->where('post.user.id', $author->id)
+            ->where('post.user.name', 'Author Name')
+            ->where('post.last_edited_by_user.id', $editor->id)
+            ->where('post.last_edited_by_user.name', 'Editor Name')
+        );
+});
+
 test('admin post details page includes admin navigation rooted at the top namespace', function () {
     $user = User::factory()->create();
     $root = PostNamespace::factory()->create([

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -827,3 +827,27 @@ test('post page social card image inherits grandparent cover image', function ()
             ->where('cardImage', fn ($url) => str_contains($url, 'grandparent.webp'))
         );
 });
+
+test('post page social card image strips zenn size specifiers from the first markdown image', function () {
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'full_path' => 'guides',
+        'is_published' => true,
+    ]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'slug' => 'zenn-card-image',
+        'full_path' => 'guides/zenn-card-image',
+        'content' => <<<'MARKDOWN'
+![Guide cover](/storage/namespaces/guide.png =250x)
+
+Body copy.
+MARKDOWN,
+    ]);
+
+    $this->get(route('posts.path', ['path' => $post->full_path]))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/show')
+            ->where('cardImage', url('/storage/namespaces/guide.png'))
+        );
+});


### PR DESCRIPTION
## Summary
- add author and last-editor metadata coverage for admin post details
- cover Zenn-style social card image parsing and public footer links
- preserve the staged UI refinements for admin/public post pages

## Validation
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail npm run types:check
- vendor/bin/sail artisan test --compact tests/Feature/PostControllerTest.php tests/Feature/Admin/PostControllerTest.php
- vendor/bin/sail artisan test --compact tests/Browser/SmokeTest.php --filter='thinkstream textareas paste selected text as a markdown link|thinkstream edit switches between write and preview without losing content|admin post details show scheduled status and tags in the info panel|public content pages show the ThinkStream footer link'
- vendor/bin/sail npm run build