### PR TITLE
Refine admin backup and namespace workflows

### DIFF
--- a/app/Http/Controllers/Admin/BackupController.php
+++ b/app/Http/Controllers/Admin/BackupController.php
@@ -4,10 +4,12 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\PostNamespace;
+use App\Support\NamespaceBackupArchive;
 use App\Support\NamespaceBackupIndex;
 use App\Support\NamespaceRestoreArchive;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use Illuminate\Validation\Rule;
@@ -15,6 +17,9 @@ use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+use ZipArchive;
 
 class BackupController extends Controller
 {
@@ -59,6 +64,7 @@ class BackupController extends Controller
             'delete_backups_url' => route('admin.backups.destroyMany', absolute: false),
             'restore_backups_url' => route('admin.backups.restoreMany', absolute: false),
             'restore_upload_url' => route('admin.posts.restore.upload', absolute: false),
+            'upload_backup_url' => route('admin.backups.upload', absolute: false),
             'restore_preview' => $restorePreview,
             'backups' => $backups
                 ->map(fn (array $backup): array => [
@@ -203,6 +209,64 @@ class BackupController extends Controller
         abort_unless($backupRecord !== null && File::exists($backupRecord['path']), 404);
 
         return response()->download($backupRecord['path'], $backupRecord['filename']);
+    }
+
+    public function upload(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'backup' => ['required', 'file', 'extensions:zip', 'max:102400'],
+        ]);
+
+        /** @var UploadedFile $file */
+        $file = $data['backup'];
+        $directory = NamespaceBackupArchive::directory();
+
+        $zip = new ZipArchive;
+
+        if ($zip->open($file->getPathname()) !== true) {
+            throw ValidationException::withMessages([
+                'backup' => 'The uploaded file is not a valid ZIP archive.',
+            ]);
+        }
+
+        $namespaceYaml = $zip->getFromName(NamespaceBackupArchive::NAMESPACE_MANIFEST);
+        $zip->close();
+
+        $fullPath = null;
+
+        if (is_string($namespaceYaml) && $namespaceYaml !== '') {
+            try {
+                $metadata = Yaml::parse($namespaceYaml);
+                $rawPath = trim((string) (is_array($metadata) ? ($metadata['full_path'] ?? '') : ''), '/');
+
+                if ($rawPath !== '') {
+                    $fullPath = $rawPath;
+                }
+            } catch (ParseException) {
+                // fall back to original filename
+            }
+        }
+
+        if ($fullPath !== null) {
+            $filename = str_replace('/', '--', $fullPath).'-'.now()->format('Ymd-His').'.zip';
+        } else {
+            $sanitized = preg_replace('/[^a-zA-Z0-9._-]/', '-', $file->getClientOriginalName()) ?? 'backup.zip';
+            $filename = str_ends_with($sanitized, '.zip') ? $sanitized : $sanitized.'.zip';
+        }
+
+        $targetPath = $directory.'/'.$filename;
+
+        if (File::exists($targetPath)) {
+            $filename = str_replace('.zip', '-'.now()->format('Ymd-His').'.zip', $filename);
+            $targetPath = $directory.'/'.$filename;
+        }
+
+        File::ensureDirectoryExists($directory);
+        File::copy($file->getPathname(), $targetPath);
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => 'Backup uploaded.']);
+
+        return to_route('admin.backups.index');
     }
 
     public function restore(

--- a/app/Http/Controllers/Admin/NamespaceController.php
+++ b/app/Http/Controllers/Admin/NamespaceController.php
@@ -79,9 +79,17 @@ class NamespaceController extends Controller
 
     public function edit(PostNamespace $namespace): InertiaResponse
     {
+        $excludedIds = [$namespace->id, ...$namespace->descendantIds()];
+
+        $availableParents = PostNamespace::query()
+            ->whereNotIn('id', $excludedIds)
+            ->orderBy('full_path')
+            ->get(['id', 'name', 'full_path']);
+
         return Inertia::render('admin/namespaces/edit', [
             'ancestors' => $this->ancestorOptions($namespace),
             'namespace' => $namespace,
+            'availableParents' => $availableParents,
             'aiEnabled' => config('thinkstream.ai.enabled'),
         ]);
     }

--- a/app/Http/Requests/Admin/UpdateNamespaceRequest.php
+++ b/app/Http/Requests/Admin/UpdateNamespaceRequest.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Requests\Admin;
 
-use App\Models\PostNamespace;
 use App\Support\ContentPathConflict;
 use App\Support\ReservedContentPath;
 use Illuminate\Contracts\Validation\ValidationRule;
@@ -47,25 +46,6 @@ class UpdateNamespaceRequest extends FormRequest
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
      */
-    /**
-     * @return array<int, int>
-     */
-    private function descendantIds(int $namespaceId): array
-    {
-        $childIds = PostNamespace::query()
-            ->where('parent_id', $namespaceId)
-            ->pluck('id')
-            ->all();
-
-        $result = $childIds;
-
-        foreach ($childIds as $childId) {
-            $result = array_merge($result, $this->descendantIds($childId));
-        }
-
-        return $result;
-    }
-
     public function rules(): array
     {
         return [
@@ -79,7 +59,7 @@ class UpdateNamespaceRequest extends FormRequest
                         return;
                     }
 
-                    if (in_array((int) $value, $this->descendantIds($this->route('namespace')->getKey()), true)) {
+                    if (in_array((int) $value, $this->route('namespace')->descendantIds(), true)) {
                         $fail('The selected parent is a descendant of this namespace.');
                     }
                 },

--- a/app/Models/PostNamespace.php
+++ b/app/Models/PostNamespace.php
@@ -164,6 +164,33 @@ class PostNamespace extends Model
     }
 
     /**
+     * @return array<int, int>
+     */
+    public function descendantIds(): array
+    {
+        return self::collectDescendantIds($this->getKey());
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private static function collectDescendantIds(int $parentId): array
+    {
+        $childIds = static::query()
+            ->where('parent_id', $parentId)
+            ->pluck('id')
+            ->all();
+
+        $result = $childIds;
+
+        foreach ($childIds as $childId) {
+            $result = array_merge($result, self::collectDescendantIds($childId));
+        }
+
+        return $result;
+    }
+
+    /**
      * @return Collection<int, PostNamespace>
      */
     public function ancestors(): Collection

--- a/resources/js/pages/admin/backups/index.tsx
+++ b/resources/js/pages/admin/backups/index.tsx
@@ -421,6 +421,180 @@ function RestorePreviewPanel({
     );
 }
 
+function UploadBackupDialog({ uploadBackupUrl }: { uploadBackupUrl: string }) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [isDragging, setIsDragging] = useState(false);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const dragCounterRef = useRef(0);
+    const uploadForm = useForm<{ backup: File | null }>({ backup: null });
+
+    function handleFile(file: File | null) {
+        if (!file) {
+            return;
+        }
+
+        const isZip =
+            file.type === 'application/zip' || file.name.endsWith('.zip');
+
+        if (!isZip) {
+            return;
+        }
+
+        uploadForm.setData('backup', file);
+
+        if (inputRef.current) {
+            const transfer = new DataTransfer();
+            transfer.items.add(file);
+            inputRef.current.files = transfer.files;
+        }
+    }
+
+    function handleDragEnter(event: React.DragEvent<HTMLDivElement>) {
+        event.preventDefault();
+        dragCounterRef.current++;
+        setIsDragging(true);
+    }
+
+    function handleDragLeave() {
+        dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
+
+        if (dragCounterRef.current === 0) {
+            setIsDragging(false);
+        }
+    }
+
+    function handleDrop(event: React.DragEvent<HTMLDivElement>) {
+        event.preventDefault();
+        dragCounterRef.current = 0;
+        setIsDragging(false);
+        handleFile(event.dataTransfer.files[0] ?? null);
+    }
+
+    function handleSubmit(event: React.FormEvent) {
+        event.preventDefault();
+        uploadForm.post(uploadBackupUrl, {
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                setIsOpen(false);
+                uploadForm.reset('backup');
+            },
+        });
+    }
+
+    return (
+        <Dialog open={isOpen} onOpenChange={setIsOpen}>
+            <DialogTrigger asChild>
+                <Button variant="outline" size="sm">
+                    <Upload className="size-4" />
+                    Upload Backup
+                </Button>
+            </DialogTrigger>
+            <DialogContent>
+                <DialogTitle>Upload Backup ZIP</DialogTitle>
+                <DialogDescription>
+                    Upload a backup ZIP to add it to the backup list without
+                    immediately restoring it.
+                </DialogDescription>
+                <form onSubmit={handleSubmit} className="space-y-4">
+                    <div
+                        onClick={() => inputRef.current?.click()}
+                        onDragEnter={handleDragEnter}
+                        onDragOver={(event) => event.preventDefault()}
+                        onDragLeave={handleDragLeave}
+                        onDrop={handleDrop}
+                        className={cn(
+                            'cursor-pointer rounded-lg border border-dashed p-8 transition-colors',
+                            isDragging
+                                ? 'border-ring bg-ring/8'
+                                : 'border-input bg-muted/30 hover:border-ring/60 hover:bg-muted/50',
+                        )}
+                    >
+                        <div className="flex flex-col items-center gap-3 text-center">
+                            <div
+                                className={cn(
+                                    'rounded-full border-2 border-dashed p-4 transition-colors',
+                                    isDragging
+                                        ? 'border-ring text-ring'
+                                        : 'border-muted-foreground/30 text-muted-foreground',
+                                )}
+                            >
+                                <Upload className="size-8" />
+                            </div>
+                            <div className="space-y-1">
+                                <p className="text-sm font-medium">
+                                    {isDragging
+                                        ? 'Drop zip to upload'
+                                        : uploadForm.data.backup
+                                          ? uploadForm.data.backup.name
+                                          : 'Drop zip here'}
+                                </p>
+                                <p className="text-xs text-muted-foreground">
+                                    {uploadForm.data.backup
+                                        ? 'Click or drop another zip to replace.'
+                                        : 'or click to browse for a backup zip'}
+                                </p>
+                            </div>
+                            <p className="text-xs text-muted-foreground/80">
+                                ZIP archive only
+                            </p>
+                        </div>
+                    </div>
+                    <input
+                        ref={inputRef}
+                        type="file"
+                        name="backup"
+                        accept=".zip,application/zip"
+                        className="sr-only"
+                        onChange={(event) =>
+                            handleFile(event.currentTarget.files?.[0] ?? null)
+                        }
+                    />
+                    {uploadForm.progress && (
+                        <p className="text-sm text-muted-foreground">
+                            Uploading... {uploadForm.progress.percentage}%
+                        </p>
+                    )}
+                    {uploadForm.data.backup && (
+                        <button
+                            type="button"
+                            onClick={() => {
+                                uploadForm.setData('backup', null);
+
+                                if (inputRef.current) {
+                                    inputRef.current.files =
+                                        new DataTransfer().files;
+                                }
+                            }}
+                            className="text-xs text-muted-foreground hover:text-destructive"
+                        >
+                            Clear selection
+                        </button>
+                    )}
+                    {uploadForm.errors.backup && (
+                        <InputError message={uploadForm.errors.backup} />
+                    )}
+                    <DialogFooter className="gap-2">
+                        <DialogClose asChild>
+                            <Button variant="secondary">Cancel</Button>
+                        </DialogClose>
+                        <Button
+                            type="submit"
+                            disabled={
+                                uploadForm.processing ||
+                                uploadForm.data.backup === null
+                            }
+                        >
+                            <Upload className="size-4" />
+                            Upload Backup
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
 function RestoreNamespacesDialog({
     restoreUploadUrl,
     restorePreview,
@@ -648,6 +822,7 @@ export default function AdminBackupsIndex({
     delete_backups_url,
     restore_backups_url,
     restore_upload_url,
+    upload_backup_url,
     restore_preview,
 }: {
     namespaces: NamespaceSummary[];
@@ -656,6 +831,7 @@ export default function AdminBackupsIndex({
     delete_backups_url: string;
     restore_backups_url: string;
     restore_upload_url: string;
+    upload_backup_url: string;
     restore_preview: RestorePreview | null;
 }) {
     const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
@@ -1035,6 +1211,10 @@ export default function AdminBackupsIndex({
                             </div>
 
                             <div className="flex flex-wrap items-center gap-2">
+                                <UploadBackupDialog
+                                    uploadBackupUrl={upload_backup_url}
+                                />
+
                                 <RestoreNamespacesDialog
                                     restoreUploadUrl={restore_upload_url}
                                     restorePreview={restore_preview}

--- a/resources/js/pages/admin/namespaces/edit.tsx
+++ b/resources/js/pages/admin/namespaces/edit.tsx
@@ -1,5 +1,5 @@
 import { Head, router, setLayoutProps, useForm } from '@inertiajs/react';
-import { Sparkles } from 'lucide-react';
+import { ExternalLink, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import CoverImageDropzone from '@/components/cover-image-dropzone';
@@ -15,6 +15,13 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
 import { Spinner } from '@/components/ui/spinner';
 import { dashboard } from '@/routes';
 import {
@@ -29,20 +36,30 @@ type Ancestor = {
 
 type Namespace = {
     id: number;
+    parent_id: number | null;
     slug: string;
+    full_path: string;
     name: string;
     description: string | null;
     is_published: boolean;
     cover_image_url: string | null;
 };
 
+type AvailableParent = {
+    id: number;
+    name: string;
+    full_path: string;
+};
+
 export default function Edit({
     ancestors,
     namespace,
+    availableParents,
     aiEnabled,
 }: {
     ancestors: Ancestor[];
     namespace: Namespace;
+    availableParents: AvailableParent[];
     aiEnabled: boolean;
 }) {
     setLayoutProps({
@@ -84,6 +101,7 @@ export default function Edit({
 
     const { data, setData, post, processing, errors } = useForm<{
         _method: string;
+        parent_id: number | null;
         name: string;
         slug: string;
         description: string;
@@ -91,6 +109,7 @@ export default function Edit({
         cover_image: File | null;
     }>({
         _method: 'put',
+        parent_id: namespace.parent_id,
         name: namespace.name,
         slug: namespace.slug,
         description: namespace.description ?? '',
@@ -116,6 +135,41 @@ export default function Edit({
                 </div>
 
                 <form onSubmit={submit} className="space-y-6">
+                    <div className="grid gap-2">
+                        <Label htmlFor="parent_id">Parent Namespace</Label>
+                        <Select
+                            value={
+                                data.parent_id === null
+                                    ? 'none'
+                                    : String(data.parent_id)
+                            }
+                            onValueChange={(v) =>
+                                setData(
+                                    'parent_id',
+                                    v === 'none' ? null : Number(v),
+                                )
+                            }
+                        >
+                            <SelectTrigger id="parent_id" className="w-full">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="none">
+                                    — None (root level) —
+                                </SelectItem>
+                                {availableParents.map((parent) => (
+                                    <SelectItem
+                                        key={parent.id}
+                                        value={String(parent.id)}
+                                    >
+                                        {parent.full_path}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <InputError message={errors.parent_id} />
+                    </div>
+
                     <div className="grid gap-2">
                         <Label htmlFor="name">Name</Label>
                         <Input
@@ -217,17 +271,34 @@ export default function Edit({
                         </p>
                     </div>
 
-                    <div className="flex items-center gap-2">
-                        <input
-                            type="checkbox"
-                            id="is_published"
-                            checked={data.is_published}
-                            onChange={(e) =>
-                                setData('is_published', e.target.checked)
-                            }
-                            className="h-4 w-4 rounded border-input"
-                        />
-                        <Label htmlFor="is_published">Published</Label>
+                    <div className="flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2">
+                            <input
+                                type="checkbox"
+                                id="is_published"
+                                checked={data.is_published}
+                                onChange={(e) =>
+                                    setData('is_published', e.target.checked)
+                                }
+                                className="h-4 w-4 rounded border-input"
+                            />
+                            <Label htmlFor="is_published">Published</Label>
+                        </div>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            asChild
+                        >
+                            <a
+                                href={`/${namespace.full_path}`}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                <ExternalLink className="size-3.5" />
+                                View Site
+                            </a>
+                        </Button>
                     </div>
 
                     <div className="flex gap-3">

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -571,7 +571,7 @@ export default function Show({
                                                 Status
                                             </h3>
                                         </div>
-                                        <div className="p-4">
+                                        <div className="flex items-center justify-between p-4">
                                             <div className="flex items-center gap-3">
                                                 <div
                                                     className={cn(
@@ -615,6 +615,17 @@ export default function Show({
                                                     </p>
                                                 </div>
                                             </div>
+                                            {!post.is_draft && (
+                                                <a
+                                                    href={`/${post.full_path}`}
+                                                    target="_blank"
+                                                    rel="noreferrer"
+                                                    className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm transition-colors hover:bg-accent"
+                                                >
+                                                    <ExternalLink className="size-4 text-muted-foreground" />
+                                                    <span>View Site</span>
+                                                </a>
+                                            )}
                                         </div>
                                     </div>
 
@@ -842,15 +853,6 @@ export default function Show({
                                                     <span>Start Sync</span>
                                                 </button>
                                             )}
-                                            <a
-                                                href={`/${post.full_path}`}
-                                                target="_blank"
-                                                rel="noreferrer"
-                                                className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors hover:bg-accent"
-                                            >
-                                                <ExternalLink className="size-4 text-muted-foreground" />
-                                                <span>View Site</span>
-                                            </a>
                                             <Link
                                                 data-test="manage-post-revisions-link"
                                                 href={revisions.url({

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -35,6 +35,7 @@ Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () 
     Route::post('backups/create', [BackupController::class, 'storeMany'])->name('backups.storeMany');
     Route::post('backups/delete', [BackupController::class, 'destroyMany'])->name('backups.destroyMany');
     Route::post('backups/restore', [BackupController::class, 'restoreMany'])->name('backups.restoreMany');
+    Route::post('backups/upload', [BackupController::class, 'upload'])->name('backups.upload');
     Route::get('backups/{backup}', [BackupController::class, 'download'])->name('backups.download');
     Route::post('backups/{backup}/restore', [BackupController::class, 'restore'])->name('backups.restore');
 

--- a/tests/Feature/Admin/BackupControllerTest.php
+++ b/tests/Feature/Admin/BackupControllerTest.php
@@ -4,6 +4,7 @@ use App\Models\PostNamespace;
 use App\Models\User;
 use App\Support\NamespaceBackupArchive;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\File;
 use Symfony\Component\Yaml\Yaml;
 
@@ -139,6 +140,7 @@ test('authenticated users can view the backups index', function () {
                 ->where('delete_backups_url', route('admin.backups.destroyMany', absolute: false))
                 ->where('create_backups_url', route('admin.backups.storeMany', absolute: false))
                 ->where('restore_upload_url', route('admin.posts.restore.upload', absolute: false))
+                ->where('upload_backup_url', route('admin.backups.upload', absolute: false))
                 ->where('restore_preview', null)
             );
     });
@@ -451,4 +453,187 @@ test('bulk restore rejects selecting multiple backups for the same namespace', f
     } finally {
         File::delete([$firstPath, $secondPath]);
     }
+});
+
+test('guests are redirected from the backup upload endpoint', function () {
+    $this->post(route('admin.backups.upload'))->assertRedirect(route('login'));
+});
+
+test('authenticated users can upload a backup zip and it is stored in the backup directory', function () {
+    withinIsolatedAdminBackupDirectory(function (string $backupDirectory): void {
+        $user = User::factory()->create();
+        $tmpZip = tempnam(sys_get_temp_dir(), 'backup-upload-test').'.zip';
+
+        createBackupControllerNamespaceBackupZip($tmpZip, [
+            'name' => 'Uploaded Namespace',
+            'slug' => 'uploaded-namespace',
+            'full_path' => 'uploaded-namespace',
+        ]);
+
+        $uploadedFile = new UploadedFile($tmpZip, 'uploaded-namespace.zip', 'application/zip', null, true);
+
+        try {
+            $this->actingAs($user)
+                ->post(route('admin.backups.upload'), ['backup' => $uploadedFile])
+                ->assertRedirect(route('admin.backups.index'));
+
+            $files = glob($backupDirectory.'/*.zip') ?: [];
+            expect($files)->toHaveCount(1);
+            expect(basename($files[0]))->toStartWith('uploaded-namespace-');
+        } finally {
+            @unlink($tmpZip);
+        }
+    });
+});
+
+test('uploaded backup zip with nested namespace path uses double-dash prefix', function () {
+    withinIsolatedAdminBackupDirectory(function (string $backupDirectory): void {
+        $user = User::factory()->create();
+        $tmpZip = tempnam(sys_get_temp_dir(), 'backup-upload-test').'.zip';
+
+        createBackupControllerNamespaceBackupZip($tmpZip, [
+            'name' => 'Child Namespace',
+            'slug' => 'child',
+            'full_path' => 'parent/child',
+        ]);
+
+        $uploadedFile = new UploadedFile($tmpZip, 'child.zip', 'application/zip', null, true);
+
+        try {
+            $this->actingAs($user)
+                ->post(route('admin.backups.upload'), ['backup' => $uploadedFile])
+                ->assertRedirect(route('admin.backups.index'));
+
+            $files = glob($backupDirectory.'/*.zip') ?: [];
+            expect($files)->toHaveCount(1);
+            expect(basename($files[0]))->toStartWith('parent--child-');
+        } finally {
+            @unlink($tmpZip);
+        }
+    });
+});
+
+test('backup upload uses original filename when zip has no namespace manifest', function () {
+    withinIsolatedAdminBackupDirectory(function (string $backupDirectory): void {
+        $user = User::factory()->create();
+        $tmpZip = tempnam(sys_get_temp_dir(), 'backup-upload-test').'.zip';
+
+        $zip = new ZipArchive;
+        $zip->open($tmpZip, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFromString('some-file.txt', 'content');
+        $zip->close();
+
+        $uploadedFile = new UploadedFile($tmpZip, 'my-custom-backup.zip', 'application/zip', null, true);
+
+        try {
+            $this->actingAs($user)
+                ->post(route('admin.backups.upload'), ['backup' => $uploadedFile])
+                ->assertRedirect(route('admin.backups.index'));
+
+            $files = glob($backupDirectory.'/*.zip') ?: [];
+            expect($files)->toHaveCount(1);
+            expect(basename($files[0]))->toBe('my-custom-backup.zip');
+        } finally {
+            @unlink($tmpZip);
+        }
+    });
+});
+
+test('backup upload uses original filename when namespace manifest is invalid', function () {
+    withinIsolatedAdminBackupDirectory(function (string $backupDirectory): void {
+        $user = User::factory()->create();
+        $tmpZip = tempnam(sys_get_temp_dir(), 'backup-upload-test').'.zip';
+
+        $zip = new ZipArchive;
+        $zip->open($tmpZip, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFromString('_namespace.yaml', "full_path: [broken\n");
+        $zip->close();
+
+        $uploadedFile = new UploadedFile($tmpZip, 'broken-manifest.zip', 'application/zip', null, true);
+
+        try {
+            $this->actingAs($user)
+                ->post(route('admin.backups.upload'), ['backup' => $uploadedFile])
+                ->assertRedirect(route('admin.backups.index'));
+
+            $files = glob($backupDirectory.'/*.zip') ?: [];
+            expect($files)->toHaveCount(1);
+            expect(basename($files[0]))->toBe('broken-manifest.zip');
+        } finally {
+            @unlink($tmpZip);
+        }
+    });
+});
+
+test('backup upload rejects files with a zip extension that are not valid zip archives', function () {
+    $user = User::factory()->create();
+    $tmpFile = tempnam(sys_get_temp_dir(), 'backup-upload-test').'.zip';
+    file_put_contents($tmpFile, 'not a valid zip archive');
+
+    $uploadedFile = new UploadedFile($tmpFile, 'broken.zip', 'application/zip', null, true);
+
+    try {
+        $this->actingAs($user)
+            ->post(route('admin.backups.upload'), ['backup' => $uploadedFile])
+            ->assertSessionHasErrors(['backup' => 'The uploaded file is not a valid ZIP archive.']);
+    } finally {
+        @unlink($tmpFile);
+    }
+});
+
+test('backup upload requires a zip file', function () {
+    $user = User::factory()->create();
+    $tmpFile = tempnam(sys_get_temp_dir(), 'backup-upload-test').'.txt';
+    file_put_contents($tmpFile, 'not a zip');
+
+    $uploadedFile = new UploadedFile($tmpFile, 'backup.txt', 'text/plain', null, true);
+
+    try {
+        $this->actingAs($user)
+            ->post(route('admin.backups.upload'), ['backup' => $uploadedFile])
+            ->assertSessionHasErrors('backup');
+    } finally {
+        @unlink($tmpFile);
+    }
+});
+
+test('backup upload requires a file to be present', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('admin.backups.upload'))
+        ->assertSessionHasErrors('backup');
+});
+
+test('backup upload does not overwrite an existing file with the same name', function () {
+    withinIsolatedAdminBackupDirectory(function (string $backupDirectory): void {
+        $user = User::factory()->create();
+        $tmpZip = tempnam(sys_get_temp_dir(), 'backup-upload-test').'.zip';
+
+        $zip = new ZipArchive;
+        $zip->open($tmpZip, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFromString('some-file.txt', 'content');
+        $zip->close();
+
+        $originalFile = $backupDirectory.'/my-backup.zip';
+        File::copy($tmpZip, $originalFile);
+
+        $uploadedFile = new UploadedFile($tmpZip, 'my-backup.zip', 'application/zip', null, true);
+
+        try {
+            $this->actingAs($user)
+                ->post(route('admin.backups.upload'), ['backup' => $uploadedFile])
+                ->assertRedirect(route('admin.backups.index'));
+
+            $files = glob($backupDirectory.'/*.zip') ?: [];
+            expect($files)->toHaveCount(2);
+            expect($files)->toContain($originalFile);
+            expect(collect($files)->first(fn (string $file) => $file !== $originalFile))
+                ->not->toBe($originalFile)
+                ->and(collect($files)->first(fn (string $file) => $file !== $originalFile))
+                ->toMatch('/my-backup-\d{8}-\d{6}\.zip$/');
+        } finally {
+            @unlink($tmpZip);
+        }
+    });
 });

--- a/tests/Feature/Admin/NamespaceControllerTest.php
+++ b/tests/Feature/Admin/NamespaceControllerTest.php
@@ -230,6 +230,23 @@ test('authenticated users can view the edit form', function () {
     $this->actingAs($user)->get(route('admin.namespaces.edit', $namespace))->assertOk();
 });
 
+test('edit form includes available parents excluding self and descendants', function () {
+    $user = User::factory()->create();
+    $parent = PostNamespace::factory()->create(['slug' => 'parent']);
+    $namespace = PostNamespace::factory()->create(['slug' => 'current']);
+    $child = PostNamespace::factory()->create(['parent_id' => $namespace->id, 'slug' => 'child']);
+    $sibling = PostNamespace::factory()->create(['slug' => 'sibling']);
+
+    $this->actingAs($user)
+        ->get(route('admin.namespaces.edit', $namespace))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->has('availableParents', 2)
+            ->where('availableParents.0.id', $parent->id)
+            ->where('availableParents.1.id', $sibling->id)
+        );
+});
+
 test('edit form includes ancestor namespaces', function () {
     $user = User::factory()->create();
     $root = PostNamespace::factory()->create([
@@ -336,6 +353,27 @@ test('updating a namespace accepts a valid parent namespace', function () {
 
     expect($namespace->fresh()->parent_id)->toBe($parent->id);
     expect($namespace->fresh()->full_path)->toBe('parent/child');
+});
+
+test('updating a namespace can move it back to the root level', function () {
+    $user = User::factory()->create();
+    $parent = PostNamespace::factory()->create(['slug' => 'parent']);
+    $namespace = PostNamespace::factory()->create([
+        'parent_id' => $parent->id,
+        'slug' => 'child',
+        'full_path' => 'parent/child',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.namespaces.update', $namespace), [
+            'parent_id' => null,
+            'slug' => $namespace->slug,
+            'name' => $namespace->name,
+        ])
+        ->assertRedirect(route('admin.posts.namespace', $namespace));
+
+    expect($namespace->fresh()->parent_id)->toBeNull();
+    expect($namespace->fresh()->full_path)->toBe('child');
 });
 
 test('updating a namespace rejects setting a descendant as its parent', function () {


### PR DESCRIPTION
## Summary
- expand the admin backups dashboard with upload flows and bulk backup/restore coverage
- allow namespace parent selection in the edit form and reuse model descendant traversal for validation
- surface external links in admin namespace/post screens and add focused regression tests

## Testing
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail artisan test --compact tests/Feature/Admin/BackupControllerTest.php tests/Feature/Admin/NamespaceControllerTest.php
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build