### PR TITLE
Fix markdown browser coverage and hydration

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -19,6 +19,24 @@ on:
       - 'routes/**'
       - 'tests/Browser/**'
       - 'vite.config.ts'
+  pull_request:
+    branches:
+      - main
+      - master
+    paths:
+      - '.github/workflows/browser-tests.yml'
+      - 'app/**'
+      - 'bootstrap/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'config/**'
+      - 'database/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'resources/js/**'
+      - 'routes/**'
+      - 'tests/Browser/**'
+      - 'vite.config.ts'
   workflow_dispatch:
 
 jobs:
@@ -64,4 +82,4 @@ jobs:
         run: npm run build
 
       - name: Markdown Browser Tests
-        run: ./vendor/bin/pest --ci tests/Browser/ZennMarkdownRenderingTest.php tests/Browser/MintlifyTabsRenderingTest.php tests/Browser/CodeBlockHighlightingTest.php
+        run: ./vendor/bin/pest --ci tests/Browser/ZennMarkdownRenderingTest.php tests/Browser/MintlifyTabsRenderingTest.php tests/Browser/CodeBlockHighlightingTest.php tests/Browser/MarkdownEditorHeadingJumpTest.php

--- a/resources/js/components/code-block.tsx
+++ b/resources/js/components/code-block.tsx
@@ -57,6 +57,7 @@ function parseCodeMeta(
         filename = afterPrefix.slice(colonIdx + 1);
     } else if (metastring) {
         // Fallback: meta carries "lang[:filename]"
+        // Skip key=value tokens (e.g. tab=Pest) — they are metadata, not language names.
         const langPart = metastring.split(/\s+/)[0] ?? '';
 
         if (langPart.includes(':')) {
@@ -67,7 +68,7 @@ function parseCodeMeta(
 
             language = normalizeLanguage(metaLanguage);
             filename = metaFilename;
-        } else if (langPart) {
+        } else if (langPart && !langPart.includes('=')) {
             language = normalizeLanguage(langPart);
         }
     }
@@ -284,6 +285,7 @@ export function CodeBlock({
                                 : undefined
                         }
                         style={{ background: 'transparent' }}
+                        suppressHydrationWarning
                         dangerouslySetInnerHTML={{
                             __html:
                                 prismReady &&
@@ -353,6 +355,7 @@ export function CodeBlock({
                               }
                             : {}),
                     }}
+                    suppressHydrationWarning
                     dangerouslySetInnerHTML={{
                         __html:
                             prismReady &&

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -1,6 +1,6 @@
 import { AlertTriangle, CircleCheck, Info, Lightbulb } from 'lucide-react';
 import type { Components } from 'react-markdown';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import {
     defListHastHandlers,
     remarkDefinitionList,
@@ -37,6 +37,7 @@ import { remarkBadgeDirective } from '@/lib/remark-badge-directive';
 import { remarkCardDirective } from '@/lib/remark-card-directive';
 import { remarkCodeGroupDirective } from '@/lib/remark-code-group-directive';
 import { remarkCodeMeta } from '@/lib/remark-code-meta';
+import { remarkFallbackDirective } from '@/lib/remark-fallback-directive';
 import { remarkFixUrlPorts } from '@/lib/remark-fix-url-ports';
 import { remarkLinkifyToCard } from '@/lib/remark-linkify-to-card';
 import { remarkMark } from '@/lib/remark-mark';
@@ -46,7 +47,6 @@ import { remarkTabsDirective } from '@/lib/remark-tabs-directive';
 import { remarkTooltipDirective } from '@/lib/remark-tooltip-directive';
 import { remarkTreeDirective } from '@/lib/remark-tree-directive';
 import { remarkUpdateDirective } from '@/lib/remark-update-directive';
-import { remarkFallbackDirective } from '@/lib/remark-fallback-directive';
 import { remarkZennDirective } from '@/lib/remark-zenn-directive';
 import { cn } from '@/lib/utils';
 
@@ -303,6 +303,11 @@ export default function MarkdownContent({
                     } as any,
                 }}
                 components={markdownComponents}
+                urlTransform={(url, key) =>
+                    key === 'src' && url.startsWith('data:image/')
+                        ? url
+                        : defaultUrlTransform(url)
+                }
             >
                 {preprocessMarkdownContent(preprocessMarkdownSyntax(content))}
             </ReactMarkdown>

--- a/resources/js/components/markdown-editor.tsx
+++ b/resources/js/components/markdown-editor.tsx
@@ -73,12 +73,14 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
                         : updater;
 
                 valueRef.current = nextValue;
+
                 if (
                     textareaRef.current &&
                     textareaRef.current.value !== nextValue
                 ) {
                     textareaRef.current.value = nextValue;
                 }
+
                 setValue(nextValue);
             },
             [],
@@ -157,14 +159,32 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
             textarea.focus();
             textarea.setSelectionRange(clamped, selectionEnd);
 
-            const lineHeight =
-                Number.parseFloat(
-                    window.getComputedStyle(textarea).lineHeight,
-                ) || 20;
-            const lineIndex =
-                textarea.value.slice(0, clamped).split(/\r?\n/).length - 1;
+            // Mirror-div technique: measure actual pixel offset accounting for
+            // wrapped lines (simple lineIndex * lineHeight is wrong for CJK text).
+            const cs = window.getComputedStyle(textarea);
+            const lineHeight = Number.parseFloat(cs.lineHeight) || 20;
+            const mirror = document.createElement('div');
+            mirror.style.cssText = [
+                `font: ${cs.font}`,
+                `line-height: ${cs.lineHeight}`,
+                `padding: ${cs.padding}`,
+                `width: ${String(textarea.clientWidth)}px`,
+                `box-sizing: ${cs.boxSizing}`,
+                'white-space: pre-wrap',
+                'word-break: break-word',
+                'overflow-wrap: break-word',
+                'position: fixed',
+                'visibility: hidden',
+                'top: 0',
+                'left: -200%',
+                'height: auto',
+            ].join('; ');
+            mirror.textContent = textarea.value.slice(0, clamped);
+            document.body.appendChild(mirror);
+            const caretOffsetTop = mirror.scrollHeight;
+            document.body.removeChild(mirror);
             textarea.scrollTo({
-                top: Math.max(0, lineIndex * lineHeight - lineHeight * 2),
+                top: Math.max(0, caretOffsetTop - lineHeight * 2),
             });
 
             const line = textarea.value.slice(clamped, selectionEnd);

--- a/resources/js/lib/prism.ts
+++ b/resources/js/lib/prism.ts
@@ -2,6 +2,10 @@ import Prism from 'prismjs';
 
 let prismSetupPromise: Promise<typeof Prism> | null = null;
 
+// Prevent Prism from running highlightAll() on DOMContentLoaded, which would
+// mutate the DOM before React hydration and cause hydration mismatches.
+Prism.manual = true;
+
 function registerPrismGlobal(): void {
     (
         globalThis as typeof globalThis & {

--- a/tests/Browser/CodeBlockHighlightingTest.php
+++ b/tests/Browser/CodeBlockHighlightingTest.php
@@ -6,6 +6,41 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
 
+test('code blocks with tab metastring keep the real language for Prism highlighting', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Tab Metastring Highlighting
+
+```php tab=Pest
+test('example', function () {
+    expect(true)->toBeTrue();
+});
+```
+
+```php tab=PHPUnit
+/** @test */
+public function example(): void
+{
+    $this->assertTrue(true);
+}
+```
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('code.language-php')
+        ->wait(0.5);
+
+    expect($page->script('Boolean(window.Prism?.languages?.php)'))->toBeTrue();
+    expect($page->script(<<<'JS'
+        (() => document.querySelector('code.language-php')?.innerHTML.includes('token keyword') ?? false)()
+    JS))->toBeTrue();
+});
+
 test('code blocks with filenames keep Prism syntax highlighting', function () {
     $namespace = PostNamespace::factory()->create(['is_published' => true]);
     $post = Post::factory()->for($namespace, 'namespace')->published()->create([

--- a/tests/Browser/MarkdownEditorHeadingJumpTest.php
+++ b/tests/Browser/MarkdownEditorHeadingJumpTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('editor scrolls to the target heading and selects it on jump', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+
+    // Build content with the heading in the middle, flanked by enough text to
+    // push it out of the initial viewport and beyond the scrollable end.
+    $filler = implode("\n\n", array_fill(0, 30, str_repeat('Lorem ipsum dolor sit amet. ', 8)));
+    $heading = '### Target Heading';
+    $content = $filler."\n\n".$heading."\n\n".$filler;
+
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => $content,
+    ]);
+
+    $jumpOffset = strlen($filler) + 2; // +2 for the "\n\n" separator
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.posts.edit', ['namespace' => $namespace, 'post' => $post]).'?jump='.$jumpOffset);
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->wait(0.3);
+
+    // The textarea should have the heading text selected.
+    $selectionStart = $page->script('document.querySelector("textarea").selectionStart');
+    $selectedText = $page->script(<<<'JS'
+        (() => {
+            const ta = document.querySelector('textarea');
+            return ta.value.slice(ta.selectionStart, ta.selectionEnd);
+        })()
+    JS);
+
+    expect($selectionStart)->toBe($jumpOffset);
+    expect($selectedText)->toBe($heading);
+
+    // The textarea scroll should position the heading near the top — not at
+    // zero (would mean no scroll happened) and not still at the bottom.
+    $scrollTop = $page->script('document.querySelector("textarea").scrollTop');
+    $scrollHeight = $page->script('document.querySelector("textarea").scrollHeight');
+    $clientHeight = $page->script('document.querySelector("textarea").clientHeight');
+
+    expect($scrollTop)->toBeGreaterThan(0);
+    expect($scrollTop)->toBeLessThan($scrollHeight - $clientHeight);
+});

--- a/tests/Browser/ZennMarkdownRenderingTest.php
+++ b/tests/Browser/ZennMarkdownRenderingTest.php
@@ -218,3 +218,24 @@ MARKDOWN,
     $page->assertNoJavaScriptErrors()
         ->assertPresent('[data-test="embed-github"]');
 });
+
+test('data URI images render without triggering empty src warning', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Data Image
+
+![Example](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==)
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
+
+    $page->assertNoJavaScriptErrors();
+
+    $src = $page->script(<<<'JS'
+        (() => document.querySelector('img[alt="Example"]')?.getAttribute('src') ?? '')()
+    JS);
+
+    expect($src)->toStartWith('data:image/png;base64,');
+});


### PR DESCRIPTION
## Summary
- preserve Prism hydration safety and code block language detection for tab metadata
- improve markdown editor heading jump positioning and cover it with a browser test
- allow markdown browser tests to run on pull requests and include the new heading-jump case

## Testing
- vendor/bin/sail npm run build
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm exec eslint resources/js/components/code-block.tsx resources/js/components/markdown-content.tsx resources/js/components/markdown-editor.tsx resources/js/lib/prism.ts
- vendor/bin/sail ./vendor/bin/pest --ci tests/Browser/ZennMarkdownRenderingTest.php tests/Browser/MintlifyTabsRenderingTest.php tests/Browser/CodeBlockHighlightingTest.php tests/Browser/MarkdownEditorHeadingJumpTest.php
- vendor/bin/sail ./vendor/bin/pint --dirty --format=agent