### PR TITLE
Add namespace blog mode and wikilinks

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -150,15 +150,34 @@ class PostController extends Controller
             ->withCount(['posts' => fn (Builder $query) => $this->applyPublishedPostScope($query)])
             ->get(['id', 'name', 'slug', 'full_path', 'description', 'cover_image']);
 
-        $posts = $namespace->posts()
-            ->tap(fn (Builder $query) => $this->applyPublishedPostScope($query))
-            ->orderBy('published_at')
-            ->orderBy('id')
-            ->get(['id', 'slug', 'full_path', 'title', 'published_at']);
-
         $resolvedCoverImageUrl = $namespace->resolvedCoverImageUrl($ancestors);
+        $isBlogMode = $namespace->display_mode === 'blog';
+
+        if ($isBlogMode) {
+            $blogPosts = $namespace->posts()
+                ->tap(fn (Builder $query) => $this->applyPublishedPostScope($query))
+                ->with('tags')
+                ->orderByDesc('published_at')
+                ->get(['id', 'slug', 'full_path', 'title', 'published_at', 'content']);
+
+            $postsData = $blogPosts->map(fn (Post $post): array => [
+                ...$post->only(['id', 'slug', 'full_path', 'title', 'published_at']),
+                'excerpt' => $this->extractExcerpt($post->content),
+                'card_image' => $this->resolveCardImage($post, $namespace, $ancestors),
+                'tags' => $post->tags->map(fn ($tag) => ['name' => $tag->name])->values()->all(),
+            ])->values()->all();
+        } else {
+            $posts = $namespace->posts()
+                ->tap(fn (Builder $query) => $this->applyPublishedPostScope($query))
+                ->orderBy('published_at')
+                ->orderBy('id')
+                ->get(['id', 'slug', 'full_path', 'title', 'published_at']);
+
+            $postsData = $namespace->sortPosts($posts);
+        }
 
         return Inertia::render('posts/namespace', [
+            'blog_mode' => $isBlogMode,
             'breadcrumbs' => $this->breadcrumbs($ancestors),
             'children' => $namespace->sortNamespaces($children)->map(fn (PostNamespace $child): array => [
                 ...$child->only(['id', 'name', 'slug', 'full_path', 'description']),
@@ -170,7 +189,7 @@ class PostController extends Controller
                 ...$namespace->only(['id', 'slug', 'full_path', 'name', 'description', 'is_published']),
                 'cover_image_url' => $resolvedCoverImageUrl,
             ],
-            'posts' => $namespace->sortPosts($posts),
+            'posts' => $postsData,
             'preview' => $preview,
         ]);
     }
@@ -306,6 +325,22 @@ class PostController extends Controller
         }
 
         return false;
+    }
+
+    private function extractExcerpt(string $content, int $maxLength = 160): string
+    {
+        $text = preg_replace('/```[\s\S]*?```/', '', $content) ?? '';
+        $text = preg_replace('/^#{1,6}\s+/m', '', $text) ?? '';
+        $text = preg_replace('/!\[[^\]]*\]\([^)]*\)/', '', $text) ?? '';
+        $text = preg_replace('/\[([^\]]+)\]\([^)]*\)/', '$1', $text) ?? '';
+        $text = preg_replace('/[*_]{1,3}([^*_]+)[*_]{1,3}/', '$1', $text) ?? '';
+        $text = trim(preg_replace('/\s+/', ' ', $text) ?? '');
+
+        if (mb_strlen($text) <= $maxLength) {
+            return $text;
+        }
+
+        return mb_substr($text, 0, $maxLength).'…';
     }
 
     /**

--- a/app/Http/Requests/Admin/StoreNamespaceRequest.php
+++ b/app/Http/Requests/Admin/StoreNamespaceRequest.php
@@ -41,6 +41,12 @@ class StoreNamespaceRequest extends FormRequest
                 'is_published' => $this->boolean('is_published'),
             ]);
         }
+
+        if ($this->input('display_mode') === '') {
+            $this->merge([
+                'display_mode' => null,
+            ]);
+        }
     }
 
     /**
@@ -70,6 +76,7 @@ class StoreNamespaceRequest extends FormRequest
                 Rule::dimensions()->ratio(16 / 9),
             ],
             'is_published' => ['boolean'],
+            'display_mode' => ['nullable', 'string', Rule::in(['blog'])],
         ];
     }
 

--- a/app/Http/Requests/Admin/UpdateNamespaceRequest.php
+++ b/app/Http/Requests/Admin/UpdateNamespaceRequest.php
@@ -41,6 +41,10 @@ class UpdateNamespaceRequest extends FormRequest
                 'is_published' => $this->boolean('is_published'),
             ]);
         }
+
+        if ($this->input('display_mode') === '') {
+            $this->merge(['display_mode' => null]);
+        }
     }
 
     /**
@@ -86,6 +90,7 @@ class UpdateNamespaceRequest extends FormRequest
                 Rule::dimensions()->ratio(16 / 9),
             ],
             'is_published' => ['boolean'],
+            'display_mode' => ['nullable', 'string', Rule::in(['blog'])],
         ];
     }
 

--- a/app/Models/PostNamespace.php
+++ b/app/Models/PostNamespace.php
@@ -29,6 +29,7 @@ class PostNamespace extends Model
         'is_published',
         'is_system',
         'post_order',
+        'display_mode',
     ];
 
     protected $appends = ['cover_image_url'];

--- a/database/migrations/2026_04_10_225618_create_namespaces_table.php
+++ b/database/migrations/2026_04_10_225618_create_namespaces_table.php
@@ -23,6 +23,7 @@ return new class extends Migration
             $table->text('description')->nullable();
             $table->string('cover_image')->nullable();
             $table->boolean('is_published')->default(true);
+            $table->string('display_mode')->nullable();
             $table->boolean('is_system')->default(false);
             $table->json('post_order')->nullable();
             $table->unsignedInteger('sort_order')->nullable();

--- a/database/migrations/2026_05_12_095421_add_display_mode_to_namespaces_table.php
+++ b/database/migrations/2026_05_12_095421_add_display_mode_to_namespaces_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasColumn('namespaces', 'display_mode')) {
+            return;
+        }
+
+        Schema::table('namespaces', function (Blueprint $table): void {
+            $table->string('display_mode')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (! Schema::hasColumn('namespaces', 'display_mode')) {
+            return;
+        }
+
+        Schema::table('namespaces', function (Blueprint $table): void {
+            $table->dropColumn('display_mode');
+        });
+    }
+};

--- a/database/seeders/SyntaxSeeder.php
+++ b/database/seeders/SyntaxSeeder.php
@@ -1701,6 +1701,42 @@ Source:
 4 directories, 2 files
 ```
 ````
+
+---
+
+## Wikilinks
+
+Wikilinks are a Thinkstream-specific syntax for linking to other posts by their `full_path`. Unlike standard Markdown links, they are path-independent and can be detected programmatically (e.g. to find broken links after a rename).
+
+#### Basic Wikilink
+
+Use `[[full_path]]` to link to a post. The display text defaults to the last segment of the path.
+
+[[syntax/wikilinks]]
+
+Source:
+
+```md
+[[syntax/wikilinks]]
+```
+
+#### Wikilink with Label
+
+Use `[[full_path|label]]` to set custom display text.
+
+[[syntax/wikilinks|this page]]
+
+Source:
+
+```md
+[[syntax/wikilinks|this page]]
+```
+
+Notes:
+
+- `full_path` is the namespace path plus slug, e.g. `blog/my-post`.
+- Wikilinks always resolve to `/{full_path}` on the public site.
+- Existing `[label](/path)` Markdown links continue to work alongside wikilinks.
 MD),
                 'published_at' => now(),
             ]);

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -47,6 +47,7 @@ import { remarkTabsDirective } from '@/lib/remark-tabs-directive';
 import { remarkTooltipDirective } from '@/lib/remark-tooltip-directive';
 import { remarkTreeDirective } from '@/lib/remark-tree-directive';
 import { remarkUpdateDirective } from '@/lib/remark-update-directive';
+import { remarkWikilinks } from '@/lib/remark-wikilinks';
 import { remarkZennDirective } from '@/lib/remark-zenn-directive';
 import { cn } from '@/lib/utils';
 
@@ -154,12 +155,15 @@ function MessageBox({
 type MarkdownContentProps = {
     content: string;
     components?: Components;
+    resolveWikilink?: (path: string) => string;
 };
 
 export default function MarkdownContent({
     content,
     components,
+    resolveWikilink,
 }: MarkdownContentProps) {
+    const resolveWikilinkFn = resolveWikilink ?? ((path: string) => `/${path}`);
     const dispenseHeadingId = createHeadingIdDispenser();
 
     const customMarkdownComponents = {
@@ -284,6 +288,7 @@ export default function MarkdownContent({
                     remarkTreeDirective,
                     remarkQuizDirective,
                     remarkCodeGroupDirective,
+                    [remarkWikilinks, resolveWikilinkFn],
                     remarkFallbackDirective,
                     remarkLinkifyToCard,
                     remarkSupersub,

--- a/resources/js/lib/remark-wikilinks.ts
+++ b/resources/js/lib/remark-wikilinks.ts
@@ -1,0 +1,54 @@
+import type { Link, Root, Text } from 'mdast';
+import { visit } from 'unist-util-visit';
+
+const WIKILINK_RE = /\[\[([^\]|]+?)(?:\|([^\]]+?))?\]\]/g;
+
+export function remarkWikilinks(resolveWikilink: (path: string) => string) {
+    return (tree: Root) => {
+        visit(tree, 'text', (node: Text, index, parent) => {
+            if (parent === undefined || index === undefined) return;
+
+            const parts: (Text | Link)[] = [];
+            let lastIndex = 0;
+            let match: RegExpExecArray | null;
+
+            WIKILINK_RE.lastIndex = 0;
+            while ((match = WIKILINK_RE.exec(node.value)) !== null) {
+                const [full, path, label] = match;
+                const trimmedPath = path.trim();
+                const displayLabel =
+                    label?.trim() ??
+                    trimmedPath.split('/').pop() ??
+                    trimmedPath;
+
+                if (match.index > lastIndex) {
+                    parts.push({
+                        type: 'text',
+                        value: node.value.slice(lastIndex, match.index),
+                    });
+                }
+
+                parts.push({
+                    type: 'link',
+                    url: resolveWikilink(trimmedPath),
+                    children: [{ type: 'text', value: displayLabel }],
+                });
+
+                lastIndex = match.index + full.length;
+            }
+
+            if (parts.length === 0) return;
+
+            if (lastIndex < node.value.length) {
+                parts.push({
+                    type: 'text',
+                    value: node.value.slice(lastIndex),
+                });
+            }
+
+            parent.children.splice(index, 1, ...parts);
+
+            return index;
+        });
+    };
+}

--- a/resources/js/pages/admin/namespaces/edit.tsx
+++ b/resources/js/pages/admin/namespaces/edit.tsx
@@ -42,6 +42,7 @@ type Namespace = {
     name: string;
     description: string | null;
     is_published: boolean;
+    display_mode: string | null;
     cover_image_url: string | null;
 };
 
@@ -99,13 +100,14 @@ export default function Edit({
         }
     }
 
-    const { data, setData, post, processing, errors } = useForm<{
+    const { data, setData, post, processing, errors, transform } = useForm<{
         _method: string;
         parent_id: number | null;
         name: string;
         slug: string;
         description: string;
         is_published: boolean;
+        display_mode: string;
         cover_image: File | null;
     }>({
         _method: 'put',
@@ -114,11 +116,19 @@ export default function Edit({
         slug: namespace.slug,
         description: namespace.description ?? '',
         is_published: namespace.is_published,
+        display_mode: namespace.display_mode ?? 'default',
         cover_image: null,
     });
 
     function submit(e: React.FormEvent) {
         e.preventDefault();
+        transform((currentData) => ({
+            ...currentData,
+            display_mode:
+                currentData.display_mode === 'default'
+                    ? ''
+                    : currentData.display_mode,
+        }));
         post(NamespaceController.update.url(namespace.id));
     }
 
@@ -269,6 +279,27 @@ export default function Edit({
                             Saved with 16:9 cropping. Recommended size is at
                             least 1600x900.
                         </p>
+                    </div>
+
+                    <div className="grid gap-2">
+                        <Label htmlFor="display_mode">Display Mode</Label>
+                        <Select
+                            value={data.display_mode}
+                            onValueChange={(v) => setData('display_mode', v)}
+                        >
+                            <SelectTrigger id="display_mode" className="w-full">
+                                <SelectValue placeholder="Default" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="default">Default</SelectItem>
+                                <SelectItem value="blog">Blog</SelectItem>
+                            </SelectContent>
+                        </Select>
+                        <p className="text-xs text-muted-foreground">
+                            Blog mode displays posts as a card grid with
+                            excerpts and tags.
+                        </p>
+                        <InputError message={errors.display_mode} />
                     </div>
 
                     <div className="flex items-center justify-between gap-2">

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -403,7 +403,7 @@ function NamespacesHeaderPanel({
                                     <Button variant="outline" size="lg" asChild>
                                         <Link href={backupsIndex.url()}>
                                             <Archive className="size-4" />
-                                            Open Backups
+                                            Backup / Restore
                                         </Link>
                                     </Button>
                                 </div>

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -49,9 +49,13 @@ type Post = {
     title: string;
     full_path: string;
     published_at: string | null;
+    excerpt?: string;
+    card_image?: string | null;
+    tags?: Array<{ name: string }>;
 };
 
 export default function Namespace({
+    blog_mode = false,
     breadcrumbs,
     children,
     navRoot,
@@ -59,6 +63,7 @@ export default function Namespace({
     posts,
     preview = false,
 }: {
+    blog_mode?: boolean;
     breadcrumbs: Array<{ name: string; full_path: string }>;
     children: ChildNamespace[];
     navRoot: ContentNavNode;
@@ -73,7 +78,9 @@ export default function Namespace({
     const { currentUrl } = useCurrentUrl();
     const isBelowDesktop = useBelowDesktop();
     const [mobileNavOpen, setMobileNavOpen] = useState(false);
-    const [navOverride, setNavOverride] = useState<boolean | null>(null);
+    const [navOverride, setNavOverride] = useState<boolean | null>(
+        blog_mode ? false : null,
+    );
     const navVisible = navOverride ?? !isBelowDesktop;
     const markdownPagesEnabled = thinkstream.markdown_pages.enabled;
     const markdownUrl = contentPathMarkdown.url({ path: namespace.full_path });
@@ -328,6 +335,77 @@ export default function Namespace({
                                 <p className="text-muted-foreground">
                                     No direct posts in this namespace yet.
                                 </p>
+                            ) : blog_mode ? (
+                                <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+                                    {posts.map((post) => (
+                                        <Link
+                                            key={post.id}
+                                            href={contentPath.url(
+                                                post.full_path,
+                                            )}
+                                            className="group overflow-hidden rounded-xl border transition-colors hover:bg-muted/50"
+                                        >
+                                            <div className="relative aspect-video overflow-hidden border-b">
+                                                {post.card_image ? (
+                                                    <img
+                                                        src={post.card_image}
+                                                        alt={post.title}
+                                                        className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                                                    />
+                                                ) : (
+                                                    <>
+                                                        <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
+                                                        <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 text-muted-foreground/50">
+                                                            <ImageOff className="size-6" />
+                                                            <span className="text-xs font-medium tracking-wide uppercase">
+                                                                No image
+                                                            </span>
+                                                        </div>
+                                                    </>
+                                                )}
+                                            </div>
+                                            <div className="space-y-2 p-5">
+                                                <p className="font-semibold">
+                                                    {post.title}
+                                                </p>
+                                                <p
+                                                    suppressHydrationWarning
+                                                    className="text-xs text-muted-foreground"
+                                                >
+                                                    {post.published_at
+                                                        ? timeAgo(
+                                                              post.published_at,
+                                                          )
+                                                        : 'Draft'}
+                                                </p>
+                                                {post.tags &&
+                                                    post.tags.length > 0 && (
+                                                        <div className="flex flex-wrap gap-1">
+                                                            {post.tags.map(
+                                                                (tag) => (
+                                                                    <span
+                                                                        key={
+                                                                            tag.name
+                                                                        }
+                                                                        className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+                                                                    >
+                                                                        {
+                                                                            tag.name
+                                                                        }
+                                                                    </span>
+                                                                ),
+                                                            )}
+                                                        </div>
+                                                    )}
+                                                {post.excerpt && (
+                                                    <p className="line-clamp-3 text-sm text-muted-foreground">
+                                                        {post.excerpt}
+                                                    </p>
+                                                )}
+                                            </div>
+                                        </Link>
+                                    ))}
+                                </div>
                             ) : (
                                 <div className="rounded-xl border">
                                     <div className="divide-y">

--- a/tests-node/markdown/remark-wikilinks.test.ts
+++ b/tests-node/markdown/remark-wikilinks.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { remarkWikilinks } from '../../resources/js/lib/remark-wikilinks.ts';
+
+test('remarkWikilinks converts wikilinks into markdown links', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'paragraph',
+                children: [
+                    {
+                        type: 'text',
+                        value: 'See [[docs/intro]] and [[blog/post|this post]].',
+                    },
+                ],
+            },
+        ],
+    };
+
+    remarkWikilinks((path) => `/${path}`)(tree as never);
+
+    assert.deepEqual(tree.children[0], {
+        type: 'paragraph',
+        children: [
+            { type: 'text', value: 'See ' },
+            {
+                type: 'link',
+                url: '/docs/intro',
+                children: [{ type: 'text', value: 'intro' }],
+            },
+            { type: 'text', value: ' and ' },
+            {
+                type: 'link',
+                url: '/blog/post',
+                children: [{ type: 'text', value: 'this post' }],
+            },
+            { type: 'text', value: '.' },
+        ],
+    });
+});

--- a/tests/Feature/Admin/NamespaceControllerTest.php
+++ b/tests/Feature/Admin/NamespaceControllerTest.php
@@ -355,6 +355,42 @@ test('updating a namespace accepts a valid parent namespace', function () {
     expect($namespace->fresh()->full_path)->toBe('parent/child');
 });
 
+test('updating a namespace can set blog display mode', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'display_mode' => null,
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.namespaces.update', $namespace), [
+            'slug' => $namespace->slug,
+            'name' => $namespace->name,
+            'display_mode' => 'blog',
+        ])
+        ->assertRedirect(route('admin.posts.namespace', $namespace));
+
+    expect($namespace->fresh()->display_mode)->toBe('blog');
+});
+
+test('updating a namespace can clear blog display mode', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'display_mode' => 'blog',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('admin.namespaces.update', $namespace), [
+            'slug' => $namespace->slug,
+            'name' => $namespace->name,
+            'display_mode' => '',
+        ])
+        ->assertRedirect(route('admin.posts.namespace', $namespace));
+
+    expect($namespace->fresh()->display_mode)->toBeNull();
+});
+
 test('updating a namespace can move it back to the root level', function () {
     $user = User::factory()->create();
     $parent = PostNamespace::factory()->create(['slug' => 'parent']);
@@ -523,6 +559,40 @@ test('storing a namespace accepts checkbox values', function () {
         ->assertRedirect(route('admin.posts.index'));
 
     $this->assertDatabaseHas('namespaces', ['slug' => 'published-guides', 'is_published' => true]);
+});
+
+test('storing a namespace can set blog display mode', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('admin.namespaces.store'), [
+            'slug' => 'blog-guides',
+            'name' => 'Blog Guides',
+            'display_mode' => 'blog',
+        ])
+        ->assertRedirect(route('admin.posts.index'));
+
+    $this->assertDatabaseHas('namespaces', [
+        'slug' => 'blog-guides',
+        'display_mode' => 'blog',
+    ]);
+});
+
+test('storing a namespace normalizes empty display mode to null', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('admin.namespaces.store'), [
+            'slug' => 'default-guides',
+            'name' => 'Default Guides',
+            'display_mode' => '',
+        ])
+        ->assertRedirect(route('admin.posts.index'));
+
+    $this->assertDatabaseHas('namespaces', [
+        'slug' => 'default-guides',
+        'display_mode' => null,
+    ]);
 });
 
 test('updating a namespace can toggle is_published', function () {

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -851,3 +851,42 @@ MARKDOWN,
             ->where('cardImage', url('/storage/namespaces/guide.png'))
         );
 });
+
+test('namespace with blog display_mode renders in blog mode with enriched post data', function () {
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'articles',
+        'is_published' => true,
+        'display_mode' => 'blog',
+    ]);
+    $tag = Tag::firstOrCreate(['name' => 'laravel']);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => 'Hello world, this is a test post.',
+    ]);
+    $post->tags()->attach($tag);
+
+    $this->get(route('posts.path', ['path' => 'articles']))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/namespace')
+            ->where('blog_mode', true)
+            ->has('posts.0.excerpt')
+            ->has('posts.0.tags')
+            ->has('posts.0.card_image')
+        );
+});
+
+test('namespace without blog display_mode does not render in blog mode', function () {
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'is_published' => true,
+        'display_mode' => null,
+    ]);
+    Post::factory()->for($namespace, 'namespace')->published()->create();
+
+    $this->get(route('posts.path', ['path' => 'guides']))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('posts/namespace')
+            ->where('blog_mode', false)
+        );
+});


### PR DESCRIPTION
## Summary
- add namespace blog-mode rendering, admin display-mode handling, and an additive compatibility migration
- add wikilink markdown support plus sample seeded content
- add focused feature and markdown tests for the new behavior

## Validation
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail artisan test --compact tests/Feature/PostControllerTest.php tests/Feature/Admin/NamespaceControllerTest.php
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build