### PR TITLE
Add namespace cover image deletion

### DIFF
--- a/app/Http/Controllers/Admin/NamespaceController.php
+++ b/app/Http/Controllers/Admin/NamespaceController.php
@@ -181,6 +181,17 @@ class NamespaceController extends Controller
         return back();
     }
 
+    public function deleteCoverImage(PostNamespace $namespace): RedirectResponse
+    {
+        abort_if($namespace->is_system, 403);
+        abort_unless($namespace->cover_image, 404);
+
+        Storage::disk('public')->delete($namespace->cover_image);
+        $namespace->update(['cover_image' => null]);
+
+        return back();
+    }
+
     public function destroy(PostNamespace $namespace): RedirectResponse
     {
         abort_if($namespace->is_system, 403);

--- a/resources/js/pages/admin/namespaces/edit.tsx
+++ b/resources/js/pages/admin/namespaces/edit.tsx
@@ -1,7 +1,9 @@
 import { Head, router, setLayoutProps, useForm } from '@inertiajs/react';
-import { ExternalLink, Sparkles } from 'lucide-react';
+import { ExternalLink, Sparkles, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import NamespaceController from '@/actions/App/Http/Controllers/Admin/NamespaceController';
+import NamespaceController, {
+    deleteCoverImage,
+} from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import CoverImageDropzone from '@/components/cover-image-dropzone';
 import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
@@ -42,6 +44,7 @@ type Namespace = {
     name: string;
     description: string | null;
     is_published: boolean;
+    is_system: boolean;
     display_mode: string | null;
     cover_image_url: string | null;
 };
@@ -77,8 +80,11 @@ export default function Edit({
     });
 
     const [generating, setGenerating] = useState(false);
+    const [deletingCoverImage, setDeletingCoverImage] = useState(false);
     const [additionalPrompt, setAdditionalPrompt] = useState('');
     const [showGenerateConfirm, setShowGenerateConfirm] = useState(false);
+    const [showDeleteCoverImageConfirm, setShowDeleteCoverImageConfirm] =
+        useState(false);
 
     function generateCoverImage() {
         setShowGenerateConfirm(false);
@@ -90,6 +96,18 @@ export default function Edit({
                 onFinish: () => setGenerating(false),
             },
         );
+    }
+
+    function handleDeleteCoverImageClick() {
+        setShowDeleteCoverImageConfirm(true);
+    }
+
+    function confirmDeleteCoverImage() {
+        setShowDeleteCoverImageConfirm(false);
+        router.delete(deleteCoverImage.url(namespace.id), {
+            onStart: () => setDeletingCoverImage(true),
+            onFinish: () => setDeletingCoverImage(false),
+        });
     }
 
     function handleGenerateClick() {
@@ -229,24 +247,44 @@ export default function Edit({
                     <div className="grid gap-2">
                         <div className="flex items-center justify-between gap-3">
                             <Label htmlFor="cover_image">Cover Image</Label>
-                            {aiEnabled && (
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    size="sm"
-                                    disabled={generating || processing}
-                                    onClick={handleGenerateClick}
-                                >
-                                    {generating ? (
-                                        <Spinner className="mr-1.5" />
-                                    ) : (
-                                        <Sparkles className="mr-1.5 size-3.5" />
-                                    )}
-                                    {generating
-                                        ? 'Generating…'
-                                        : 'Generate with AI'}
-                                </Button>
-                            )}
+                            <div className="flex items-center gap-2">
+                                {namespace.cover_image_url && !namespace.is_system && (
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        disabled={
+                                            deletingCoverImage || processing
+                                        }
+                                        onClick={handleDeleteCoverImageClick}
+                                    >
+                                        {deletingCoverImage ? (
+                                            <Spinner className="mr-1.5" />
+                                        ) : (
+                                            <Trash2 className="mr-1.5 size-3.5" />
+                                        )}
+                                        Remove
+                                    </Button>
+                                )}
+                                {aiEnabled && (
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        disabled={generating || processing}
+                                        onClick={handleGenerateClick}
+                                    >
+                                        {generating ? (
+                                            <Spinner className="mr-1.5" />
+                                        ) : (
+                                            <Sparkles className="mr-1.5 size-3.5" />
+                                        )}
+                                        {generating
+                                            ? 'Generating…'
+                                            : 'Generate with AI'}
+                                    </Button>
+                                )}
+                            </div>
                         </div>
                         {aiEnabled && (
                             <Input
@@ -360,6 +398,29 @@ export default function Edit({
                         </DialogClose>
                         <Button onClick={generateCoverImage}>
                             Generate anyway
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+            <Dialog
+                open={showDeleteCoverImageConfirm}
+                onOpenChange={setShowDeleteCoverImageConfirm}
+            >
+                <DialogContent>
+                    <DialogTitle>Remove cover image?</DialogTitle>
+                    <DialogDescription>
+                        This will permanently delete the cover image for this
+                        namespace.
+                    </DialogDescription>
+                    <DialogFooter className="gap-2">
+                        <DialogClose asChild>
+                            <Button variant="secondary">Cancel</Button>
+                        </DialogClose>
+                        <Button
+                            variant="destructive"
+                            onClick={confirmDeleteCoverImage}
+                        >
+                            Remove
                         </Button>
                     </DialogFooter>
                 </DialogContent>

--- a/resources/js/pages/admin/namespaces/edit.tsx
+++ b/resources/js/pages/admin/namespaces/edit.tsx
@@ -248,24 +248,27 @@ export default function Edit({
                         <div className="flex items-center justify-between gap-3">
                             <Label htmlFor="cover_image">Cover Image</Label>
                             <div className="flex items-center gap-2">
-                                {namespace.cover_image_url && !namespace.is_system && (
-                                    <Button
-                                        type="button"
-                                        variant="outline"
-                                        size="sm"
-                                        disabled={
-                                            deletingCoverImage || processing
-                                        }
-                                        onClick={handleDeleteCoverImageClick}
-                                    >
-                                        {deletingCoverImage ? (
-                                            <Spinner className="mr-1.5" />
-                                        ) : (
-                                            <Trash2 className="mr-1.5 size-3.5" />
-                                        )}
-                                        Remove
-                                    </Button>
-                                )}
+                                {namespace.cover_image_url &&
+                                    !namespace.is_system && (
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            size="sm"
+                                            disabled={
+                                                deletingCoverImage || processing
+                                            }
+                                            onClick={
+                                                handleDeleteCoverImageClick
+                                            }
+                                        >
+                                            {deletingCoverImage ? (
+                                                <Spinner className="mr-1.5" />
+                                            ) : (
+                                                <Trash2 className="mr-1.5 size-3.5" />
+                                            )}
+                                            Remove
+                                        </Button>
+                                    )}
                                 {aiEnabled && (
                                     <Button
                                         type="button"

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -31,6 +31,7 @@ Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () 
     Route::patch('namespaces/reorder', [NamespaceController::class, 'reorder'])->name('namespaces.reorder');
     Route::resource('namespaces', NamespaceController::class)->except(['index', 'show']);
     Route::post('namespaces/{namespace}/generate-cover-image', [NamespaceController::class, 'generateCoverImage'])->name('namespaces.generate-cover-image');
+    Route::delete('namespaces/{namespace}/cover-image', [NamespaceController::class, 'deleteCoverImage'])->name('namespaces.delete-cover-image');
     Route::get('backups', [BackupController::class, 'index'])->name('backups.index');
     Route::post('backups/create', [BackupController::class, 'storeMany'])->name('backups.storeMany');
     Route::post('backups/delete', [BackupController::class, 'destroyMany'])->name('backups.destroyMany');

--- a/tests/Feature/Admin/NamespaceControllerTest.php
+++ b/tests/Feature/Admin/NamespaceControllerTest.php
@@ -837,3 +837,52 @@ test('reorder validates namespace ids are distinct and existing', function () {
         ->assertUnprocessable()
         ->assertJsonValidationErrors(['ids.1', 'ids.2']);
 });
+
+test('guests cannot delete cover image', function () {
+    $namespace = PostNamespace::factory()->create(['cover_image' => 'namespaces/test.jpg']);
+
+    $this->delete(route('admin.namespaces.delete-cover-image', $namespace))
+        ->assertRedirect(route('login'));
+});
+
+test('delete cover image removes file and clears column', function () {
+    Storage::fake('public');
+    $user = User::factory()->create();
+    $path = 'namespaces/test.jpg';
+    Storage::disk('public')->put($path, 'fake');
+    $namespace = PostNamespace::factory()->create(['cover_image' => $path]);
+
+    $this->actingAs($user)
+        ->delete(route('admin.namespaces.delete-cover-image', $namespace))
+        ->assertRedirect();
+
+    Storage::disk('public')->assertMissing($path);
+    expect($namespace->fresh()->cover_image)->toBeNull();
+});
+
+test('delete cover image returns 404 when no cover image set', function () {
+    $user = User::factory()->create();
+    $namespace = PostNamespace::factory()->create(['cover_image' => null]);
+
+    $this->actingAs($user)
+        ->delete(route('admin.namespaces.delete-cover-image', $namespace))
+        ->assertNotFound();
+});
+
+test('delete cover image is forbidden for system namespaces', function () {
+    Storage::fake('public');
+    $user = User::factory()->create();
+    $path = 'namespaces/system.jpg';
+    Storage::disk('public')->put($path, 'fake');
+    $namespace = PostNamespace::factory()->create([
+        'cover_image' => $path,
+        'is_system' => true,
+    ]);
+
+    $this->actingAs($user)
+        ->delete(route('admin.namespaces.delete-cover-image', $namespace))
+        ->assertForbidden();
+
+    Storage::disk('public')->assertExists($path);
+    expect($namespace->fresh()->cover_image)->toBe($path);
+});


### PR DESCRIPTION
## Summary
- add an admin endpoint to delete a namespace cover image
- add edit-page UI with a confirmation dialog and hide delete for system namespaces
- cover guest, success, missing-image, and system-namespace cases in feature tests

## Validation
- vendor/bin/sail artisan wayfinder:generate --with-form --no-interaction
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail artisan test --compact tests/Feature/Admin/NamespaceControllerTest.php
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build