### PR TITLE
Add chart support to Thinkstream markdown

### DIFF
--- a/database/seeders/SyntaxSeeder.php
+++ b/database/seeders/SyntaxSeeder.php
@@ -1704,6 +1704,42 @@ Source:
 
 ---
 
+## Charts
+
+Use `chart:bar` for a horizontal bar chart and `chart:radar` for a radar chart. Both use the same key-value format.
+
+### Bar Chart
+
+```chart:bar
+_title: Flavor Profile
+_max: 10
+juniper: 9
+citrus: 4
+spice: 6
+herbal: 5
+floral: 2
+sweetness: 2
+smoothness: 5
+```
+
+### Radar Chart
+
+```chart:radar
+_title: Flavor Profile
+_max: 10
+juniper: 9
+citrus: 4
+spice: 6
+herbal: 5
+floral: 2
+sweetness: 2
+smoothness: 5
+```
+
+Reserved keys (prefixed with `_`): `_title`, `_max`, `_min`. All other `label: value` lines are data points.
+
+---
+
 ## Wikilinks
 
 Wikilinks are a Thinkstream-specific syntax for linking to other posts by their `full_path`. Unlike standard Markdown links, they are path-independent and can be detected programmatically (e.g. to find broken links after a rename).

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
                 "react": "^19.2.0",
                 "react-dom": "^19.2.0",
                 "react-markdown": "^10.1.0",
+                "recharts": "^3.8.1",
                 "remark-definition-list": "^2.0.0",
                 "remark-directive": "^4.0.0",
                 "remark-emoji": "^5.0.2",
@@ -4243,6 +4244,42 @@
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
             }
         },
+        "node_modules/@reduxjs/toolkit": {
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+            "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/utils": "^0.3.0",
+                "immer": "^11.0.0",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@reduxjs/toolkit/node_modules/immer": {
+            "version": "11.1.8",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+            "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/@rolldown/binding-android-arm64": {
             "version": "1.0.0-rc.12",
             "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
@@ -4531,6 +4568,18 @@
             "funding": {
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
             }
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+            "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+            "license": "MIT"
         },
         "node_modules/@stylistic/eslint-plugin": {
             "version": "5.10.0",
@@ -5245,6 +5294,12 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "license": "MIT"
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -7047,6 +7102,12 @@
                 }
             }
         },
+        "node_modules/decimal.js-light": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+            "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+            "license": "MIT"
+        },
         "node_modules/decode-named-character-reference": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -7789,6 +7850,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "license": "MIT"
+        },
         "node_modules/extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -8449,6 +8516,16 @@
             "dev": true,
             "engines": {
                 "node": ">= 4"
+            }
+        },
+        "node_modules/immer": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+            "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
             }
         },
         "node_modules/import-fresh": {
@@ -12078,8 +12155,7 @@
         "node_modules/react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/react-markdown": {
             "version": "10.1.0",
@@ -12106,6 +12182,29 @@
             "peerDependencies": {
                 "@types/react": ">=18",
                 "react": ">=18"
+            }
+        },
+        "node_modules/react-redux": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+            "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25 || ^19",
+                "react": "^18.0 || ^19",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
             }
         },
         "node_modules/react-refresh": {
@@ -12180,6 +12279,51 @@
                 "@types/react": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/recharts": {
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+            "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+            "license": "MIT",
+            "workspaces": [
+                "www"
+            ],
+            "dependencies": {
+                "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+                "clsx": "^2.1.1",
+                "decimal.js-light": "^2.5.1",
+                "es-toolkit": "^1.39.3",
+                "eventemitter3": "^5.0.1",
+                "immer": "^10.1.1",
+                "react-redux": "8.x.x || 9.x.x",
+                "reselect": "5.1.1",
+                "tiny-invariant": "^1.3.3",
+                "use-sync-external-store": "^1.2.2",
+                "victory-vendor": "^37.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "license": "MIT"
+        },
+        "node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "redux": "^5.0.0"
             }
         },
         "node_modules/reflect.getprototypeof": {
@@ -12411,6 +12555,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/reselect": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+            "license": "MIT"
         },
         "node_modules/resolve": {
             "version": "2.0.0-next.6",
@@ -13069,6 +13219,12 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "license": "MIT"
+        },
         "node_modules/tinyexec": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
@@ -13647,6 +13803,28 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/victory-vendor": {
+            "version": "37.3.6",
+            "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+            "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+            "license": "MIT AND ISC",
+            "dependencies": {
+                "@types/d3-array": "^3.0.3",
+                "@types/d3-ease": "^3.0.0",
+                "@types/d3-interpolate": "^3.0.1",
+                "@types/d3-scale": "^4.0.2",
+                "@types/d3-shape": "^3.1.0",
+                "@types/d3-time": "^3.0.0",
+                "@types/d3-timer": "^3.0.0",
+                "d3-array": "^3.1.6",
+                "d3-ease": "^3.0.1",
+                "d3-interpolate": "^3.0.1",
+                "d3-scale": "^4.0.2",
+                "d3-shape": "^3.1.0",
+                "d3-time": "^3.0.0",
+                "d3-timer": "^3.0.1"
             }
         },
         "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
+        "recharts": "^3.8.1",
         "remark-definition-list": "^2.0.0",
         "remark-directive": "^4.0.0",
         "remark-emoji": "^5.0.2",

--- a/resources/ai/thinkstream-syntax-guide.md
+++ b/resources/ai/thinkstream-syntax-guide.md
@@ -144,3 +144,405 @@ Tables:
 |----------|----------|
 | value    | value    |
 ```
+
+---
+
+## Callouts (Mintlify style)
+
+These are aliases for the `:::message` callout blocks above. Use whichever form reads more naturally.
+
+```
+<Note>
+Neutral note.
+</Note>
+
+<Tip>
+Helpful tip.
+</Tip>
+
+<Info>
+Default info callout.
+</Info>
+
+<Warning>
+Warning or caution.
+</Warning>
+
+<Check>
+Success or confirmation.
+</Check>
+```
+
+---
+
+## Cards
+
+Cards display a title, optional icon, optional description, and optional link.
+
+```
+<CardGroup cols={2}>
+  <Card title="Getting Started" icon="rocket" href="/docs/start">
+    A short description of this card.
+  </Card>
+  <Card title="Reference" icon="code">
+    Cards without href are non-clickable.
+  </Card>
+</CardGroup>
+```
+
+`cols` defaults to `2`. Supported values: `1`, `2`, `3`, `4`.
+
+`icon` accepts Lucide icon names (`rocket`, `lock`, `zap`, `settings`, `user`, `database`, `code`, `search`, `star`, `mail`, `calendar`, `clock`, `brain`, `sparkles`, `leaf`, etc.) or Simple Icons brand names (e.g. `laravel`, `github`, `typescript`).
+
+Self-closing card (no body):
+
+```
+<Card title="Link only" icon="arrow-right" href="/path" />
+```
+
+`<Columns>` is an alias for `<CardGroup>`:
+
+```
+<Columns>
+  <Card title="Left">...</Card>
+  <Card title="Right">...</Card>
+</Columns>
+```
+
+---
+
+## Tabs
+
+````
+<Tabs>
+  <Tab title="PHP">
+
+```php
+echo "hello";
+````
+
+  </Tab>
+  <Tab title="JavaScript">
+
+```js
+console.log('hello');
+```
+
+  </Tab>
+</Tabs>
+```
+
+Tabs with the same `title` across multiple `<Tabs>` blocks on the page stay in sync automatically (selection is persisted in localStorage).
+
+---
+
+## Steps
+
+Numbered step list with optional titles.
+
+```
+<Steps>
+  <Step title="Install dependencies">
+    Run `npm install`.
+  </Step>
+  <Step title="Configure environment">
+    Copy `.env.example` to `.env` and fill in the values.
+  </Step>
+  <Step>
+    Steps without a title show only the number badge.
+  </Step>
+</Steps>
+```
+
+---
+
+## Accordion
+
+Collapsible section. Alias for `:::details`.
+
+```
+<Accordion title="Click to expand">
+Hidden content goes here.
+</Accordion>
+```
+
+---
+
+## Code Group
+
+Tabbed code blocks. Code blocks inside are grouped into tabs by filename or language. Tabs with the same title across groups on the page stay in sync.
+
+````
+<CodeGroup>
+```php:app/Models/User.php
+class User extends Model {}
+````
+
+```js:resources/js/app.js
+import './bootstrap';
+```
+
+</CodeGroup>
+```
+
+---
+
+## API Fields
+
+### ResponseField
+
+Documents a response body field.
+
+```
+<ResponseField name="id" type="string" required>
+  The unique identifier for the resource.
+</ResponseField>
+
+<ResponseField name="created_at" type="string" deprecated default="null">
+  ISO 8601 timestamp. Deprecated — use `timestamp` instead.
+</ResponseField>
+```
+
+Attributes: `name`, `type`, `required` (flag), `deprecated` (flag), `default`.
+
+### ParamField
+
+Documents a request parameter. The location attribute (`path`, `query`, or `body`) doubles as the parameter name when `name` is omitted.
+
+```
+<ParamField path="id" type="string" required>
+  The resource ID in the URL path.
+</ParamField>
+
+<ParamField query="page" type="integer" default="1">
+  Page number for pagination.
+</ParamField>
+
+<ParamField body="email" type="string" required>
+  The user's email address.
+</ParamField>
+```
+
+---
+
+## Update (Changelog)
+
+Timeline entry for changelogs and release notes.
+
+```
+<Update label="v2.1.0" description="2024-06-01" tags="new,breaking">
+  - Added dark mode support.
+  - **Breaking**: renamed `color` prop to `variant`.
+</Update>
+
+<Update label="v2.0.0" description="2024-04-15" tags="release">
+  Initial stable release.
+</Update>
+```
+
+`label` becomes the anchor link target. `tags` is a comma-separated list shown as badges.
+
+---
+
+## Badge (inline)
+
+Inline status/label badges.
+
+```
+Status: <Badge color="green">Stable</Badge>
+
+<Badge color="red" shape="pill">Deprecated</Badge>
+
+<Badge color="blue" size="sm" stroke>New</Badge>
+
+<Badge color="orange" icon="zap">Beta</Badge>
+```
+
+**`color`**: `gray` (default), `blue`, `green`, `yellow`, `orange`, `red`, `purple`, `white`, `surface`, `white-destructive`, `surface-destructive`
+
+**`size`**: `xs`, `sm`, `md` (default), `lg`
+
+**`shape`**: `rounded` (default), `pill`
+
+**`stroke`**: outline-only variant (flag attribute)
+
+**`disabled`**: grayed-out appearance (flag attribute)
+
+**`icon`**: Lucide or Simple Icons icon name
+
+---
+
+## Tooltip (inline)
+
+Hover tooltip on a word or phrase.
+
+```
+The <Tooltip tip="A runtime environment for JavaScript">Node.js</Tooltip> server handles requests.
+
+<Tooltip tip="Requests per minute" headline="Rate limit" cta="See docs" href="/docs/rate-limits">RPM</Tooltip>
+```
+
+`tip` is required. `headline` adds a bold title inside the tooltip. `cta` + `href` adds a link.
+
+---
+
+## Tree
+
+Visual file/folder tree. Two equivalent syntaxes:
+
+### Fenced code block (ASCII tree)
+
+````
+```tree
+src/
+├── index.ts
+└── components/
+    ├── Button.tsx
+    └── Input.tsx
+package.json
+```
+````
+
+The ASCII tree is parsed from `tree`-fenced code blocks. Lines beginning with `.` are treated as the root directory marker.
+
+### JSX tags
+
+```
+<Tree>
+  <Tree.Folder name="src" defaultOpen>
+    <Tree.File name="index.ts" />
+    <Tree.Folder name="components">
+      <Tree.File name="Button.tsx" />
+      <Tree.File name="Input.tsx" />
+    </Tree.Folder>
+  </Tree.Folder>
+  <Tree.File name="package.json" />
+</Tree>
+```
+
+`defaultOpen` on a `Tree.Folder` makes it expanded by default. `openable={false}` disables click-to-toggle.
+
+---
+
+## Quiz
+
+Interactive multiple-choice question in a `quiz`-fenced code block.
+
+````
+```quiz
+question: Which command installs Composer dependencies?
+A: npm install
+B: composer install
+C: php artisan install
+correct: B
+hint: Think about the PHP package manager.
+explanation: Composer is the PHP dependency manager. `composer install` reads composer.json.
+```
+````
+
+Required: `question`, at least two options (`A:`, `B:`, …), `correct` (the option label).
+
+Optional: `hint` (shown on request), `explanation` (shown after answering), `incorrect` (custom message for wrong answers), `correctMessage` (custom message for correct answer).
+
+---
+
+## Charts
+
+データをグラフで表示する fenced code block。
+
+````
+```chart:bar
+_title: Flavor Profile
+_max: 10
+juniper: 9
+citrus: 4
+spice: 6
+herbal: 5
+floral: 2
+sweetness: 2
+smoothness: 5
+```
+````
+
+````
+```chart:radar
+_title: Flavor Profile
+_max: 10
+juniper: 9
+citrus: 4
+spice: 6
+herbal: 5
+floral: 2
+sweetness: 2
+smoothness: 5
+```
+````
+
+Reserved keys (`_` prefix): `_title`（チャートタイトル）、`_max`（軸の最大値）、`_min`（軸の最小値）。  
+それ以外の `label: 数値` 行がデータポイント。`chart:bar` は横棒グラフ、`chart:radar` はレーダーチャート。
+
+---
+
+## Mermaid Diagrams
+
+Fenced code block with `mermaid` as the language.
+
+````
+```mermaid
+flowchart TD
+    A[Start] --> B{Decision}
+    B -- Yes --> C[Do something]
+    B -- No --> D[Do nothing]
+```
+````
+
+````
+```mermaid
+sequenceDiagram
+    Client->>Server: GET /api/users
+    Server-->>Client: 200 OK
+```
+````
+
+````
+```mermaid
+erDiagram
+    USER ||--o{ POST : "has many"
+    POST }o--|| NAMESPACE : "belongs to"
+```
+````
+
+All standard Mermaid diagram types are supported (flowchart, sequence, ER, Gantt, pie, class, state, etc.). Diagrams render in light/dark mode automatically.
+
+---
+
+## Text Highlight
+
+Wrap text in `==` to render as `<mark>` (highlighted).
+
+```
+This is ==highlighted== text.
+```
+
+---
+
+## Images
+
+### Size
+
+Append `=WIDTHxHEIGHT` (pixels) inside the image URL parentheses. Either dimension may be omitted.
+
+```
+![alt](url =800x600)
+![alt](url =400x)
+![alt](url =x300)
+```
+
+### Caption
+
+Place an italic line (`*caption*`) immediately after the image line. It is rendered as a visible caption below the image.
+
+```
+![screenshot](url)
+*Figure 1: the login screen*
+```

--- a/resources/js/components/markdown-chart.tsx
+++ b/resources/js/components/markdown-chart.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react';
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    PolarAngleAxis,
+    PolarGrid,
+    PolarRadiusAxis,
+    Radar,
+    RadarChart,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from 'recharts';
+import { getChartDomain, parseChart } from '@/lib/markdown-chart';
+
+interface MarkdownChartProps {
+    'data-chart'?: string;
+}
+
+export function MarkdownChart({ 'data-chart': json }: MarkdownChartProps) {
+    const chart = parseChart(json);
+    const [isDark, setIsDark] = useState(false);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') {
+            return;
+        }
+
+        const update = () => {
+            setIsDark(document.documentElement.classList.contains('dark'));
+        };
+
+        update();
+
+        const observer = new MutationObserver(update);
+        observer.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ['class'],
+        });
+
+        return () => observer.disconnect();
+    }, []);
+
+    if (chart === null) {
+        return null;
+    }
+
+    const gridColor = isDark ? '#374151' : '#e5e7eb';
+    const textColor = isDark ? '#9ca3af' : '#6b7280';
+    const fillColor = isDark ? '#818cf8' : '#4f46e5';
+    const strokeColor = isDark ? '#6366f1' : '#4338ca';
+
+    const [domainMin, domainMax] = getChartDomain(chart);
+
+    return (
+        <div
+            className="not-prose my-6 overflow-hidden rounded-2xl border border-border bg-background p-6"
+            data-test="markdown-chart"
+        >
+            {chart.title ? (
+                <p className="mb-4 text-center text-sm font-semibold text-foreground">
+                    {chart.title}
+                </p>
+            ) : null}
+
+            {chart.type === 'bar' ? (
+                <ResponsiveContainer
+                    width="100%"
+                    height={chart.data.length * 44 + 60}
+                >
+                    <BarChart
+                        layout="vertical"
+                        data={chart.data}
+                        margin={{ top: 4, right: 16, bottom: 4, left: 8 }}
+                    >
+                        <CartesianGrid
+                            strokeDasharray="3 3"
+                            horizontal={false}
+                            stroke={gridColor}
+                        />
+                        <XAxis
+                            type="number"
+                            domain={[domainMin, domainMax]}
+                            tick={{ fill: textColor, fontSize: 12 }}
+                            axisLine={{ stroke: gridColor }}
+                            tickLine={false}
+                        />
+                        <YAxis
+                            type="category"
+                            dataKey="label"
+                            width={96}
+                            tick={{ fill: textColor, fontSize: 12 }}
+                            axisLine={false}
+                            tickLine={false}
+                        />
+                        <Tooltip
+                            cursor={{ fill: isDark ? '#1f2937' : '#f3f4f6' }}
+                            contentStyle={{
+                                background: isDark ? '#111827' : '#ffffff',
+                                border: `1px solid ${gridColor}`,
+                                borderRadius: '8px',
+                                fontSize: '12px',
+                                color: textColor,
+                            }}
+                        />
+                        <Bar
+                            dataKey="value"
+                            fill={fillColor}
+                            radius={[0, 4, 4, 0]}
+                        />
+                    </BarChart>
+                </ResponsiveContainer>
+            ) : (
+                <ResponsiveContainer width="100%" height={340}>
+                    <RadarChart data={chart.data}>
+                        <PolarGrid stroke={gridColor} />
+                        <PolarAngleAxis
+                            dataKey="label"
+                            tick={{ fill: textColor, fontSize: 12 }}
+                        />
+                        <PolarRadiusAxis
+                            domain={[domainMin, domainMax]}
+                            tick={{ fill: textColor, fontSize: 10 }}
+                            axisLine={false}
+                        />
+                        <Radar
+                            dataKey="value"
+                            stroke={strokeColor}
+                            fill={fillColor}
+                            fillOpacity={0.35}
+                        />
+                        <Tooltip
+                            contentStyle={{
+                                background: isDark ? '#111827' : '#ffffff',
+                                border: `1px solid ${gridColor}`,
+                                borderRadius: '8px',
+                                fontSize: '12px',
+                                color: textColor,
+                            }}
+                        />
+                    </RadarChart>
+                </ResponsiveContainer>
+            )}
+        </div>
+    );
+}

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -19,6 +19,7 @@ import {
     MarkdownCard,
     MarkdownCardGroup,
 } from '@/components/markdown-card-group';
+import { MarkdownChart } from '@/components/markdown-chart';
 import { MarkdownCodeGroup } from '@/components/markdown-code-group';
 import { MarkdownQuiz } from '@/components/markdown-quiz';
 import { MarkdownStep, MarkdownSteps } from '@/components/markdown-steps';
@@ -35,6 +36,7 @@ import {
 import { remarkApiFieldsDirective } from '@/lib/remark-api-fields-directive';
 import { remarkBadgeDirective } from '@/lib/remark-badge-directive';
 import { remarkCardDirective } from '@/lib/remark-card-directive';
+import { remarkChartDirective } from '@/lib/remark-chart-directive';
 import { remarkCodeGroupDirective } from '@/lib/remark-code-group-directive';
 import { remarkCodeMeta } from '@/lib/remark-code-meta';
 import { remarkFallbackDirective } from '@/lib/remark-fallback-directive';
@@ -263,6 +265,14 @@ export default function MarkdownContent({
                 return <MarkdownQuiz data-quiz={quizJson} />;
             }
 
+            const chartJson = (props as Record<string, unknown>)[
+                'data-chart'
+            ] as string | undefined;
+
+            if (chartJson) {
+                return <MarkdownChart data-chart={chartJson} />;
+            }
+
             return <div {...props} />;
         },
         ...customMarkdownComponents,
@@ -287,6 +297,7 @@ export default function MarkdownContent({
                     remarkUpdateDirective,
                     remarkTreeDirective,
                     remarkQuizDirective,
+                    remarkChartDirective,
                     remarkCodeGroupDirective,
                     [remarkWikilinks, resolveWikilinkFn],
                     remarkFallbackDirective,

--- a/resources/js/lib/markdown-chart.ts
+++ b/resources/js/lib/markdown-chart.ts
@@ -1,0 +1,111 @@
+export type ChartType = 'bar' | 'radar';
+
+export type ChartDataPoint = {
+    label: string;
+    value: number;
+};
+
+export type ChartConfig = {
+    type: ChartType;
+    title?: string;
+    min?: number;
+    max?: number;
+    data: ChartDataPoint[];
+};
+
+export function getChartDomain(chart: ChartConfig): [number, number] {
+    const min = chart.min ?? 0;
+    const max = chart.max ?? Math.max(...chart.data.map((point) => point.value));
+
+    if (max <= min) {
+        return [min, min + 1];
+    }
+
+    return [min, max];
+}
+
+function parseChartNumber(value: unknown): number | undefined {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = Number(value);
+
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    }
+
+    return undefined;
+}
+
+export function parseChart(json: string | undefined): ChartConfig | null {
+    try {
+        if (!json) {
+            return null;
+        }
+
+        const raw = JSON.parse(json) as Partial<ChartConfig> & {
+            data?: Array<Partial<ChartDataPoint>>;
+        };
+
+        if (raw.type !== 'bar' && raw.type !== 'radar') {
+            return null;
+        }
+
+        const data: ChartDataPoint[] = [];
+
+        if (Array.isArray(raw.data)) {
+            for (const point of raw.data) {
+                if (typeof point !== 'object' || point === null) {
+                    continue;
+                }
+
+                const { label, value } = point as Partial<ChartDataPoint>;
+                const parsedValue = parseChartNumber(value);
+
+                if (
+                    typeof label !== 'string' ||
+                    label.trim() === '' ||
+                    parsedValue === undefined
+                ) {
+                    continue;
+                }
+
+                data.push({
+                    label: label.trim(),
+                    value: parsedValue,
+                });
+            }
+        }
+
+        if (data.length === 0) {
+            return null;
+        }
+
+        const min = parseChartNumber(raw.min);
+        const max = parseChartNumber(raw.max);
+
+        if (
+            min !== undefined &&
+            max !== undefined &&
+            min > max
+        ) {
+            return null;
+        }
+
+        return {
+            type: raw.type,
+            title:
+                typeof raw.title === 'string' && raw.title.trim() !== ''
+                    ? raw.title.trim()
+                    : undefined,
+            min,
+            max,
+            data,
+        };
+    } catch {
+        return null;
+    }
+}

--- a/resources/js/lib/markdown-chart.ts
+++ b/resources/js/lib/markdown-chart.ts
@@ -15,7 +15,8 @@ export type ChartConfig = {
 
 export function getChartDomain(chart: ChartConfig): [number, number] {
     const min = chart.min ?? 0;
-    const max = chart.max ?? Math.max(...chart.data.map((point) => point.value));
+    const max =
+        chart.max ?? Math.max(...chart.data.map((point) => point.value));
 
     if (max <= min) {
         return [min, min + 1];
@@ -87,11 +88,7 @@ export function parseChart(json: string | undefined): ChartConfig | null {
         const min = parseChartNumber(raw.min);
         const max = parseChartNumber(raw.max);
 
-        if (
-            min !== undefined &&
-            max !== undefined &&
-            min > max
-        ) {
+        if (min !== undefined && max !== undefined && min > max) {
             return null;
         }
 

--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -39,6 +39,16 @@ type QuizContent = {
     explanation?: string;
 };
 
+type ChartType = 'bar' | 'radar';
+
+type ChartContent = {
+    type: ChartType;
+    title?: string;
+    min?: number;
+    max?: number;
+    data: { label: string; value: number }[];
+};
+
 export function isAbsoluteUrl(url: string): boolean {
     return (
         url.startsWith('http://') ||
@@ -290,6 +300,12 @@ export function preprocessMintlifySyntax(markdown: string): string {
         fence: string;
         lines: string[];
     } | null = null;
+    let chartFence: {
+        openingLine: string;
+        fence: string;
+        chartType: ChartType;
+        lines: string[];
+    } | null = null;
     let mintlifyTabsDepth = 0;
     const mintlifyCalloutColonCounts: number[] = [];
     const mintlifyTagStack: Array<
@@ -398,6 +414,45 @@ export function preprocessMintlifySyntax(markdown: string): string {
             continue;
         }
 
+        if (chartFence !== null) {
+            const remainder = fenceMatch
+                ? trimmedLine.slice(fenceMatch[1].length)
+                : '';
+
+            if (
+                fenceMatch &&
+                fenceMatch[1][0] === chartFence.fence[0] &&
+                fenceMatch[1].length >= chartFence.fence.length &&
+                remainder.trim() === ''
+            ) {
+                const chart = parseChartContent(
+                    chartFence.chartType,
+                    chartFence.lines,
+                );
+
+                if (chart === null) {
+                    processedLines.push(
+                        chartFence.openingLine,
+                        ...chartFence.lines,
+                        line,
+                    );
+                } else {
+                    pushChartDirective(
+                        processedLines,
+                        chart,
+                        pushBlankLineIfNeeded,
+                        pushLine,
+                    );
+                }
+
+                chartFence = null;
+            } else {
+                chartFence.lines.push(line);
+            }
+
+            continue;
+        }
+
         if (fenceMatch && activeFence === null) {
             const fence = fenceMatch[1];
             const infoString = trimmedLine.slice(fence.length).trim();
@@ -410,6 +465,19 @@ export function preprocessMintlifySyntax(markdown: string): string {
 
             if (/^quiz(?:\s|$)/.test(infoString)) {
                 quizFence = { openingLine: line, fence, lines: [] };
+
+                continue;
+            }
+
+            const chartMatch = /^chart:(bar|radar)(?:\s|$)/.exec(infoString);
+
+            if (chartMatch) {
+                chartFence = {
+                    openingLine: line,
+                    fence,
+                    chartType: chartMatch[1] as ChartType,
+                    lines: [],
+                };
 
                 continue;
             }
@@ -891,6 +959,10 @@ export function preprocessMintlifySyntax(markdown: string): string {
         processedLines.push(quizFence.openingLine, ...quizFence.lines);
     }
 
+    if (chartFence !== null) {
+        processedLines.push(chartFence.openingLine, ...chartFence.lines);
+    }
+
     return processedLines.join('\n');
 }
 
@@ -1209,6 +1281,81 @@ function pushTreeDirective(
     pushLine(':::tree');
     pushLine('```json');
     pushLine(json);
+    pushLine('```');
+    pushLine('');
+    pushLine(':::');
+}
+
+function parseChartContent(
+    type: ChartType,
+    lines: string[],
+): ChartContent | null {
+    const config: { title?: string; min?: number; max?: number } = {};
+    const data: { label: string; value: number }[] = [];
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+
+        if (!trimmed) {
+            continue;
+        }
+
+        const reservedMatch = /^_(?<key>title|max|min):\s*(?<value>.+)$/.exec(
+            trimmed,
+        );
+
+        if (reservedMatch?.groups?.key) {
+            const { key, value } = reservedMatch.groups;
+
+            if (key === 'title') {
+                config.title = value.trim();
+            } else if (key === 'max') {
+                const n = Number(value);
+
+                if (!isNaN(n)) {
+                    config.max = n;
+                }
+            } else if (key === 'min') {
+                const n = Number(value);
+
+                if (!isNaN(n)) {
+                    config.min = n;
+                }
+            }
+
+            continue;
+        }
+
+        const dataMatch = /^(?<label>[^:]+):\s*(?<value>[\d.]+)\s*$/.exec(
+            trimmed,
+        );
+
+        if (dataMatch?.groups?.label) {
+            const num = Number(dataMatch.groups.value);
+
+            if (!isNaN(num)) {
+                data.push({ label: dataMatch.groups.label.trim(), value: num });
+            }
+        }
+    }
+
+    if (data.length === 0) {
+        return null;
+    }
+
+    return { type, ...config, data };
+}
+
+function pushChartDirective(
+    processedLines: string[],
+    chart: ChartContent,
+    pushBlankLineIfNeeded: () => void,
+    pushLine: (value: string) => void,
+): void {
+    pushBlankLineIfNeeded();
+    pushLine(':::chart');
+    pushLine('```json');
+    pushLine(JSON.stringify(chart));
     pushLine('```');
     pushLine('');
     pushLine(':::');

--- a/resources/js/lib/remark-chart-directive.ts
+++ b/resources/js/lib/remark-chart-directive.ts
@@ -1,0 +1,38 @@
+import type { Code, Root } from 'mdast';
+import type { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+interface ContainerDirectiveNode extends Node {
+    type: 'containerDirective';
+    name: string;
+    children: Node[];
+    data?: {
+        hName?: string;
+        hProperties?: Record<string, unknown>;
+    };
+}
+
+export function remarkChartDirective() {
+    return (tree: Root) => {
+        visit(tree, (node: Node) => {
+            if (node.type !== 'containerDirective') {
+                return;
+            }
+
+            const directiveNode = node as ContainerDirectiveNode;
+
+            if (directiveNode.name !== 'chart') {
+                return;
+            }
+
+            const codeChild = directiveNode.children.find(
+                (child) => child.type === 'code',
+            ) as Code | undefined;
+            const json = codeChild?.value ?? '{}';
+
+            directiveNode.data = directiveNode.data || {};
+            directiveNode.data.hName = 'div';
+            directiveNode.data.hProperties = { 'data-chart': json };
+        });
+    };
+}

--- a/resources/js/lib/remark-wikilinks.ts
+++ b/resources/js/lib/remark-wikilinks.ts
@@ -6,16 +6,20 @@ const WIKILINK_RE = /\[\[([^\]|]+?)(?:\|([^\]]+?))?\]\]/g;
 export function remarkWikilinks(resolveWikilink: (path: string) => string) {
     return (tree: Root) => {
         visit(tree, 'text', (node: Text, index, parent) => {
-            if (parent === undefined || index === undefined) return;
+            if (parent === undefined || index === undefined) {
+                return;
+            }
 
             const parts: (Text | Link)[] = [];
             let lastIndex = 0;
             let match: RegExpExecArray | null;
 
             WIKILINK_RE.lastIndex = 0;
+
             while ((match = WIKILINK_RE.exec(node.value)) !== null) {
                 const [full, path, label] = match;
                 const trimmedPath = path.trim();
+
                 const displayLabel =
                     label?.trim() ??
                     trimmedPath.split('/').pop() ??
@@ -37,7 +41,9 @@ export function remarkWikilinks(resolveWikilink: (path: string) => string) {
                 lastIndex = match.index + full.length;
             }
 
-            if (parts.length === 0) return;
+            if (parts.length === 0) {
+                return;
+            }
 
             if (lastIndex < node.value.length) {
                 parts.push({

--- a/resources/js/pages/admin/posts/namespace.tsx
+++ b/resources/js/pages/admin/posts/namespace.tsx
@@ -31,6 +31,7 @@ import {
     Trash2,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { destroy as destroyNamespace } from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import NamespaceHeader from '@/components/namespace-header';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -47,7 +48,6 @@ import {
 } from '@/components/ui/dialog';
 import { timeAgo } from '@/lib/time';
 import { dashboard } from '@/routes';
-import { destroy as destroyNamespace } from '@/actions/App/Http/Controllers/Admin/NamespaceController';
 import { create as namespaceCreate } from '@/routes/admin/namespaces';
 import {
     create,

--- a/resources/js/pages/admin/thinkstream/show.tsx
+++ b/resources/js/pages/admin/thinkstream/show.tsx
@@ -22,6 +22,7 @@ import {
     X,
 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
 import {
     destroyMany as thinkstreamDestroyMany,
     index as thinkstreamIndex,
@@ -56,7 +57,6 @@ import { getMarkdownLinkPasteResult } from '@/lib/markdown-link-paste';
 import { timeAgo } from '@/lib/time';
 import { cn } from '@/lib/utils';
 import { dashboard } from '@/routes';
-import { toast } from 'sonner';
 
 const thoughtMarkdownComponents = createMarkdownComponents();
 
@@ -172,6 +172,7 @@ export default function ThinkstreamShow({
 
         if (!trimmed || trimmed === pageTitle) {
             cancelTitleEdit();
+
             return;
         }
 
@@ -398,6 +399,7 @@ export default function ThinkstreamShow({
                 setStructuredTitle(title);
                 setStructuredContent(content);
                 setScrapUrl(null);
+
                 if (message) {
                     toast.success(message);
                 }
@@ -452,6 +454,7 @@ export default function ThinkstreamShow({
                     message: string;
                 };
                 setEditingContent(content);
+
                 if (message) {
                     toast.success(message);
                 }

--- a/resources/js/pages/posts/namespace.tsx
+++ b/resources/js/pages/posts/namespace.tsx
@@ -8,10 +8,9 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import type { ContentNavNode } from '@/components/content-nav-tree';
-import { SimpleIconSvg } from '@/components/markdown-card-group';
-import { getSimpleIcon } from '@/lib/simple-icon-lookup';
 import ContentNavTree from '@/components/content-nav-tree';
 import DocsHeaderActions from '@/components/docs-header-actions';
+import { SimpleIconSvg } from '@/components/markdown-card-group';
 import MarkdownPageActions from '@/components/markdown-page-actions';
 import { Button } from '@/components/ui/button';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
@@ -24,6 +23,7 @@ import {
 } from '@/components/ui/sheet';
 import { useBelowDesktop } from '@/hooks/use-below-desktop';
 import { useCurrentUrl } from '@/hooks/use-current-url';
+import { getSimpleIcon } from '@/lib/simple-icon-lookup';
 import { timeAgo } from '@/lib/time';
 import { namespace as adminNamespaceRoute } from '@/routes/admin/posts';
 import { path as contentPath } from '@/routes/posts';

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -12,10 +12,9 @@ import {
 import { useMemo, useState } from 'react';
 import { siX } from 'simple-icons';
 import type { ContentNavNode } from '@/components/content-nav-tree';
-import { SimpleIconSvg } from '@/components/markdown-card-group';
-import { getSimpleIcon } from '@/lib/simple-icon-lookup';
 import ContentNavTree from '@/components/content-nav-tree';
 import DocsHeaderActions from '@/components/docs-header-actions';
+import { SimpleIconSvg } from '@/components/markdown-card-group';
 import MarkdownContent from '@/components/markdown-content';
 import MarkdownPageActions from '@/components/markdown-page-actions';
 import TableOfContents from '@/components/table-of-contents';
@@ -30,6 +29,7 @@ import {
 import { useBelowDesktop } from '@/hooks/use-below-desktop';
 import { useCurrentUrl } from '@/hooks/use-current-url';
 import { useMarkdownToc } from '@/hooks/use-markdown-toc';
+import { getSimpleIcon } from '@/lib/simple-icon-lookup';
 import { timeAgo } from '@/lib/time';
 import {
     edit as adminPostEdit,

--- a/tests-node/markdown/markdown-chart-parser.test.ts
+++ b/tests-node/markdown/markdown-chart-parser.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    getChartDomain,
+    parseChart,
+} from '../../resources/js/lib/markdown-chart.ts';
+
+test('parseChart rejects charts without usable data points', () => {
+    assert.equal(
+        parseChart(
+            JSON.stringify({
+                type: 'bar',
+                data: [{ label: 'Juniper', value: 'not-a-number' }],
+            }),
+        ),
+        null,
+    );
+});
+
+test('parseChart normalizes valid chart payloads', () => {
+    const chart = parseChart(
+        JSON.stringify({
+            type: 'radar',
+            title: '  Flavor Profile  ',
+            min: ' 1 ',
+            max: 10,
+            data: [
+                { label: ' Juniper ', value: '9' },
+                { label: ' Citrus ', value: 4 },
+            ],
+        }),
+    );
+
+    assert.deepEqual(chart, {
+        type: 'radar',
+        title: 'Flavor Profile',
+        min: 1,
+        max: 10,
+        data: [
+            { label: 'Juniper', value: 9 },
+            { label: 'Citrus', value: 4 },
+        ],
+    });
+});
+
+test('parseChart rejects charts whose minimum exceeds the maximum', () => {
+    assert.equal(
+        parseChart(
+            JSON.stringify({
+                type: 'bar',
+                min: 10,
+                max: 2,
+                data: [{ label: 'Juniper', value: 9 }],
+            }),
+        ),
+        null,
+    );
+});
+
+test('getChartDomain expands collapsed ranges', () => {
+    assert.deepEqual(
+        getChartDomain({
+            type: 'bar',
+            min: 0,
+            data: [{ label: 'Juniper', value: 0 }],
+        }),
+        [0, 1],
+    );
+});

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -636,6 +636,49 @@ B: Two
     assert.match(output, /correct: A/);
 });
 
+test('preprocessMarkdownSyntax converts chart fenced blocks to a chart directive with JSON payload', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`chart:bar
+_title: Flavor Profile
+_min: 1
+_max: 10
+juniper: 9
+citrus: 4
+\`\`\``);
+
+    assert.match(output, /:::chart/);
+    assert.match(output, /```json/);
+    assert.match(output, /"type":"bar"/);
+    assert.match(output, /"title":"Flavor Profile"/);
+    assert.match(output, /"min":1/);
+    assert.match(output, /"max":10/);
+    assert.match(output, /"label":"juniper"/);
+    assert.match(output, /"value":9/);
+    assert.match(output, /^:::\s*$/m);
+});
+
+test('preprocessMarkdownSyntax leaves invalid chart fenced blocks untouched', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`chart:radar
+_title: Invalid Chart
+juniper: nope
+\`\`\``);
+
+    assert.doesNotMatch(output, /:::chart/);
+    assert.match(output, /```chart:radar/);
+    assert.match(output, /juniper: nope/);
+});
+
+test('preprocessMarkdownSyntax leaves chart fences untouched inside longer fenced code blocks', () => {
+    const output = preprocessMarkdownSyntax(`\`\`\`\`md
+\`\`\`chart:bar
+juniper: 9
+\`\`\`
+\`\`\`\``);
+
+    assert.doesNotMatch(output, /:::chart/);
+    assert.match(output, /```chart:bar/);
+    assert.match(output, /juniper: 9/);
+});
+
 test('preprocessMarkdownSyntax joins multiline Tree child tags before encoding JSON', () => {
     const output = preprocessMarkdownSyntax(`<Tree>
   <Tree.Folder

--- a/tests-node/markdown/remark-chart-directive.test.ts
+++ b/tests-node/markdown/remark-chart-directive.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { remarkChartDirective } from '../../resources/js/lib/remark-chart-directive.ts';
+
+test('remarkChartDirective maps chart container directives to renderable nodes', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'chart',
+                children: [
+                    {
+                        type: 'code',
+                        lang: 'json',
+                        value: '{"type":"bar","data":[{"label":"Juniper","value":9}]}',
+                    },
+                ],
+            },
+        ],
+    };
+
+    remarkChartDirective()(tree as never);
+
+    const directiveNode = tree.children[0] as {
+        data?: {
+            hName?: string;
+            hProperties?: Record<string, unknown>;
+        };
+    };
+
+    assert.equal(directiveNode.data?.hName, 'div');
+    assert.deepEqual(directiveNode.data?.hProperties, {
+        'data-chart': '{"type":"bar","data":[{"label":"Juniper","value":9}]}',
+    });
+});
+
+test('remarkChartDirective falls back to an empty object payload when code payload is missing', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'chart',
+                children: [],
+            },
+        ],
+    };
+
+    remarkChartDirective()(tree as never);
+
+    const directiveNode = tree.children[0] as {
+        data?: {
+            hProperties?: Record<string, unknown>;
+        };
+    };
+
+    assert.deepEqual(directiveNode.data?.hProperties, {
+        'data-chart': '{}',
+    });
+});
+
+test('remarkChartDirective ignores unrelated directives', () => {
+    const tree = {
+        type: 'root',
+        children: [
+            {
+                type: 'containerDirective',
+                name: 'quiz',
+                children: [],
+            },
+        ],
+    };
+
+    remarkChartDirective()(tree as never);
+
+    const directiveNode = tree.children[0] as {
+        data?: unknown;
+    };
+
+    assert.equal(directiveNode.data, undefined);
+});

--- a/tests/Feature/SyntaxSeederTest.php
+++ b/tests/Feature/SyntaxSeederTest.php
@@ -165,6 +165,10 @@ test('syntax seeder creates the thinkstream syntax page', function () {
     expect($post->content)->toContain('resources/js');
     expect($post->content)->toContain('app/');
     expect($post->content)->toContain('4 directories, 2 files');
+    expect($post->content)->toContain('```chart:bar');
+    expect($post->content)->toContain('```chart:radar');
+    expect($post->content)->toContain('_title: Flavor Profile');
+    expect($post->content)->toContain('_max: 10');
     expect($post->published_at)->not->toBeNull();
 });
 


### PR DESCRIPTION
## Summary
- add Thinkstream chart fenced-block support and renderer for bar/radar charts
- document the syntax in the AI guide and syntax seeder content
- add parser/directive regression tests and fix tracked frontend lint issues needed for CI

## Validation
- vendor/bin/sail bin pint --dirty --format agent
- tracked-file eslint via npm exec eslint
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm run types:check
- vendor/bin/sail artisan test --compact tests/Feature/SyntaxSeederTest.php tests/Feature/MermaidRenderingTest.php
- vendor/bin/sail npm run build