### PR TITLE
Handle markdown lazy-load failures

### DIFF
--- a/resources/js/components/code-block.tsx
+++ b/resources/js/components/code-block.tsx
@@ -1,12 +1,35 @@
 import { Check, Copy, MoveHorizontal, WrapText } from 'lucide-react';
 import type { ComponentPropsWithoutRef } from 'react';
-import { useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import type { ExtraProps } from 'react-markdown';
-import { MermaidBlock } from '@/components/mermaid-block';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useClipboard } from '@/hooks/use-clipboard';
+
 import Prism, { ensurePrismLoaded } from '@/lib/prism';
 
 type CodeBlockProps = ComponentPropsWithoutRef<'code'> & ExtraProps;
+
+function MermaidBlockLoadFallback() {
+    return (
+        <div className="not-prose my-4 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-700/60 dark:bg-red-950/40 dark:text-red-200">
+            Failed to load Mermaid diagram. Please refresh and try again.
+        </div>
+    );
+}
+
+const MermaidBlock = lazy(async () => {
+    try {
+        const module = await import('@/components/mermaid-block');
+
+        return {
+            default: module.MermaidBlock,
+        };
+    } catch {
+        return {
+            default: MermaidBlockLoadFallback,
+        };
+    }
+});
 
 const escapeHtml = (value: string) =>
     value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -121,7 +144,15 @@ export function CodeBlock({
     const highlightLang = language === 'blade' ? 'html' : language;
 
     if (highlightLang === 'mermaid') {
-        return <MermaidBlock code={content} />;
+        return (
+            <Suspense
+                fallback={
+                    <Skeleton className="not-prose my-4 h-40 rounded-lg" />
+                }
+            >
+                <MermaidBlock code={content} />
+            </Suspense>
+        );
     }
 
     const handleCopy = async () => {

--- a/resources/js/components/markdown-content.tsx
+++ b/resources/js/components/markdown-content.tsx
@@ -1,4 +1,5 @@
 import { AlertTriangle, CircleCheck, Info, Lightbulb } from 'lucide-react';
+import { lazy, Suspense } from 'react';
 import type { Components } from 'react-markdown';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import {
@@ -19,7 +20,6 @@ import {
     MarkdownCard,
     MarkdownCardGroup,
 } from '@/components/markdown-card-group';
-import { MarkdownChart } from '@/components/markdown-chart';
 import { MarkdownCodeGroup } from '@/components/markdown-code-group';
 import { MarkdownQuiz } from '@/components/markdown-quiz';
 import { MarkdownStep, MarkdownSteps } from '@/components/markdown-steps';
@@ -51,7 +51,30 @@ import { remarkTreeDirective } from '@/lib/remark-tree-directive';
 import { remarkUpdateDirective } from '@/lib/remark-update-directive';
 import { remarkWikilinks } from '@/lib/remark-wikilinks';
 import { remarkZennDirective } from '@/lib/remark-zenn-directive';
+import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
+
+function MarkdownChartLoadFallback() {
+    return (
+        <div className="not-prose my-6 rounded-2xl border border-red-300 bg-red-50 px-6 py-4 text-sm text-red-700 dark:border-red-700/60 dark:bg-red-950/40 dark:text-red-200">
+            Failed to load chart. Please refresh and try again.
+        </div>
+    );
+}
+
+const MarkdownChart = lazy(async () => {
+    try {
+        const module = await import('@/components/markdown-chart');
+
+        return {
+            default: module.MarkdownChart,
+        };
+    } catch {
+        return {
+            default: MarkdownChartLoadFallback,
+        };
+    }
+});
 
 function DetailsBox({
     children,
@@ -270,7 +293,15 @@ export default function MarkdownContent({
             ] as string | undefined;
 
             if (chartJson) {
-                return <MarkdownChart data-chart={chartJson} />;
+                return (
+                    <Suspense
+                        fallback={
+                            <Skeleton className="not-prose my-6 h-48 rounded-2xl" />
+                        }
+                    >
+                        <MarkdownChart data-chart={chartJson} />
+                    </Suspense>
+                );
             }
 
             return <div {...props} />;

--- a/tests/Browser/MintlifyTabsRenderingTest.php
+++ b/tests/Browser/MintlifyTabsRenderingTest.php
@@ -107,6 +107,30 @@ MARKDOWN,
         ->assertSee('Success state.');
 });
 
+test('mintlify-style mermaid code blocks render without javascript errors', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Mermaid
+
+```mermaid
+graph TD
+  A[Start] --> B{Choice}
+  B -->|Yes| C[Success]
+```
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertDontSee('Mermaid render error:')
+        ->assertSee('Start')
+        ->assertSee('Choice')
+        ->assertSee('Success');
+});
+
 test('mintlify-style Columns renders as a card group grid', function () {
     $namespace = PostNamespace::factory()->create(['is_published' => true]);
     $post = Post::factory()->for($namespace, 'namespace')->published()->create([
@@ -131,6 +155,30 @@ MARKDOWN,
         ->assertPresent('[data-test="markdown-card-group"]')
         ->assertSee('Vite Plugin')
         ->assertSee('HTTP Requests');
+});
+
+test('mintlify-style chart blocks render without javascript errors', function () {
+    $namespace = PostNamespace::factory()->create(['is_published' => true]);
+    $post = Post::factory()->for($namespace, 'namespace')->published()->create([
+        'content' => <<<'MARKDOWN'
+# Chart
+
+```chart:bar
+_title: Flavor Profile
+juniper: 9
+citrus: 4
+```
+MARKDOWN,
+    ]);
+
+    $page = visit(route('posts.path', ['path' => $post->full_path]));
+
+    $page
+        ->assertNoJavaScriptErrors()
+        ->assertPresent('[data-test="markdown-chart"]')
+        ->assertSee('Flavor Profile')
+        ->assertSee('juniper')
+        ->assertSee('citrus');
 });
 
 test('mintlify-style codegroup renders icons declared in code meta', function () {


### PR DESCRIPTION
## Summary
- lazy-load Mermaid and chart markdown renderers behind Suspense skeletons
- surface inline fallbacks when those dynamic imports fail instead of crashing the page
- add browser coverage for Mermaid and chart markdown rendering

## Testing
- vendor/bin/sail bin pint --dirty --format agent
- vendor/bin/sail artisan test --compact tests/Feature/MermaidRenderingTest.php tests/Browser/MintlifyTabsRenderingTest.php
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm run build