### PR TITLE
Add post wikilink suggestions

### DIFF
--- a/app/Http/Controllers/Api/PostSuggestController.php
+++ b/app/Http/Controllers/Api/PostSuggestController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Post;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PostSuggestController extends Controller
+{
+    public function suggest(Request $request): JsonResponse
+    {
+        $request->validate(['q' => ['nullable', 'string', 'max:100']]);
+
+        $q = $request->string('q')->toString();
+
+        $posts = Post::published()
+            ->when($q, fn ($query) => $query->where(
+                fn ($sub) => $sub
+                    ->where('title', 'like', "%{$q}%")
+                    ->orWhere('full_path', 'like', "%{$q}%")
+            ))
+            ->orderByDesc('published_at')
+            ->limit(8)
+            ->get(['title', 'full_path']);
+
+        return response()->json($posts);
+    }
+}

--- a/database/seeders/SyntaxSeeder.php
+++ b/database/seeders/SyntaxSeeder.php
@@ -1710,6 +1710,8 @@ Use `chart:bar` for a horizontal bar chart and `chart:radar` for a radar chart. 
 
 ### Bar Chart
 
+Live example:
+
 ```chart:bar
 _title: Flavor Profile
 _max: 10
@@ -1722,7 +1724,25 @@ sweetness: 2
 smoothness: 5
 ```
 
+Source:
+
+````md
+```chart:bar
+_title: Flavor Profile
+_max: 10
+juniper: 9
+citrus: 4
+spice: 6
+herbal: 5
+floral: 2
+sweetness: 2
+smoothness: 5
+```
+````
+
 ### Radar Chart
+
+Live example:
 
 ```chart:radar
 _title: Flavor Profile
@@ -1735,6 +1755,22 @@ floral: 2
 sweetness: 2
 smoothness: 5
 ```
+
+Source:
+
+````md
+```chart:radar
+_title: Flavor Profile
+_max: 10
+juniper: 9
+citrus: 4
+spice: 6
+herbal: 5
+floral: 2
+sweetness: 2
+smoothness: 5
+```
+````
 
 Reserved keys (prefixed with `_`): `_title`, `_max`, `_min`. All other `label: value` lines are data points.
 

--- a/resources/js/components/markdown-editor.tsx
+++ b/resources/js/components/markdown-editor.tsx
@@ -9,6 +9,7 @@ import {
     useState,
 } from 'react';
 import type React from 'react';
+import { suggest as suggestPosts } from '@/actions/App/Http/Controllers/Api/PostSuggestController';
 import InputError from '@/components/input-error';
 import MarkdownContent from '@/components/markdown-content';
 import { Label } from '@/components/ui/label';
@@ -52,10 +53,20 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
         }: Props,
         ref,
     ) {
+        type WikiSuggestion = { title: string; full_path: string };
+        type WikiState = {
+            query: string;
+            triggerStart: number;
+            suggestions: WikiSuggestion[];
+            activeIndex: number;
+            popupPosition: { top: number; left: number; above: boolean };
+        } | null;
+
         const [value, setValue] = useState(defaultValue);
         const [activeTab, setActiveTab] = useState<'write' | 'preview'>(
             'write',
         );
+        const [wikiState, setWikiState] = useState<WikiState>(null);
         const valueRef = useRef(defaultValue);
         const lastSelectionRef = useRef<{
             text: string;
@@ -105,6 +116,70 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
         );
         const textareaRef = useRef<HTMLTextAreaElement>(null);
         const previewRef = useRef<HTMLDivElement>(null);
+        const wikiQuery = wikiState?.query;
+
+        function getCaretCoords(
+            textarea: HTMLTextAreaElement,
+            position: number,
+        ) {
+            const cs = window.getComputedStyle(textarea);
+            const rect = textarea.getBoundingClientRect();
+            const mirror = document.createElement('div');
+            mirror.style.cssText = [
+                'position: fixed',
+                `top: ${rect.top - textarea.scrollTop}px`,
+                `left: ${rect.left}px`,
+                `width: ${textarea.clientWidth}px`,
+                `font: ${cs.font}`,
+                `line-height: ${cs.lineHeight}`,
+                `padding: ${cs.padding}`,
+                'box-sizing: border-box',
+                'white-space: pre-wrap',
+                'word-break: break-word',
+                'overflow-wrap: break-word',
+                'visibility: hidden',
+                'pointer-events: none',
+                'height: auto',
+            ].join('; ');
+            const pre = document.createTextNode(
+                textarea.value.slice(0, position),
+            );
+            const span = document.createElement('span');
+            span.textContent = '\u200b';
+            mirror.appendChild(pre);
+            mirror.appendChild(span);
+            document.body.appendChild(mirror);
+            const s = span.getBoundingClientRect();
+            document.body.removeChild(mirror);
+            const above = window.innerHeight - s.bottom < 200;
+
+            return {
+                top: above ? s.top - 4 : s.bottom + 4,
+                left: s.left,
+                above,
+            };
+        }
+
+        function insertWikiSuggestion(s: WikiSuggestion) {
+            if (!wikiState || !textareaRef.current) {
+                return;
+            }
+
+            const insert = `[[${s.full_path}|${s.title}]]`;
+            const cursor = textareaRef.current.selectionStart;
+            updateValue(
+                (prev) =>
+                    prev.slice(0, wikiState.triggerStart) +
+                    insert +
+                    prev.slice(cursor),
+            );
+            const newPos = wikiState.triggerStart + insert.length;
+            setTimeout(() => {
+                textareaRef.current?.setSelectionRange(newPos, newPos);
+                textareaRef.current?.focus();
+            }, 0);
+            setWikiState(null);
+        }
         const { props } = usePage<{ imageUrl?: string }>();
         const previousImageUrlRef = useRef<string | undefined>(undefined);
         const hasJumpedRef = useRef(false);
@@ -214,6 +289,50 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
 
             hasJumpedRef.current = true;
         }, [jumpTo]);
+
+        useEffect(() => {
+            if (wikiQuery === undefined) {
+                return;
+            }
+
+            const abortController = new AbortController();
+            const timeoutId = window.setTimeout(() => {
+                void (async () => {
+                    try {
+                        const res = await fetch(
+                            suggestPosts.url({
+                                query: { q: wikiQuery },
+                            }),
+                            { signal: abortController.signal },
+                        );
+
+                        if (!res.ok) {
+                            return;
+                        }
+
+                        const data = (await res.json()) as WikiSuggestion[];
+
+                        setWikiState((prev) =>
+                            prev?.query === wikiQuery
+                                ? { ...prev, suggestions: data, activeIndex: 0 }
+                                : prev,
+                        );
+                    } catch (error) {
+                        if (
+                            error instanceof DOMException &&
+                            error.name === 'AbortError'
+                        ) {
+                            return;
+                        }
+                    }
+                })();
+            }, 200);
+
+            return () => {
+                window.clearTimeout(timeoutId);
+                abortController.abort();
+            };
+        }, [wikiQuery]);
 
         const handleImageUpload = (file: File) => {
             if (!uploadUrl || !file.type.startsWith('image/')) {
@@ -415,6 +534,43 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
                                 onChange={(e) => {
                                     valueRef.current = e.target.value;
                                     setValue(e.target.value);
+
+                                    const cursor = e.target.selectionStart;
+                                    const before = e.target.value.slice(
+                                        0,
+                                        cursor,
+                                    );
+                                    const lastOpen = before.lastIndexOf('[[');
+
+                                    if (lastOpen !== -1) {
+                                        const between = before.slice(
+                                            lastOpen + 2,
+                                        );
+
+                                        if (
+                                            !between.includes(']]') &&
+                                            !between.includes('\n')
+                                        ) {
+                                            const pos = getCaretCoords(
+                                                e.target,
+                                                lastOpen,
+                                            );
+                                            setWikiState((prev) => ({
+                                                query: between,
+                                                triggerStart: lastOpen,
+                                                suggestions:
+                                                    prev?.query === between
+                                                        ? prev.suggestions
+                                                        : [],
+                                                activeIndex: 0,
+                                                popupPosition: pos,
+                                            }));
+
+                                            return;
+                                        }
+                                    }
+
+                                    setWikiState(null);
                                 }}
                                 onSelect={(e) => {
                                     const t = e.currentTarget;
@@ -464,6 +620,64 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
                                         : null;
                                     onSelectionChange?.(has);
                                 }}
+                                onKeyDown={(e) => {
+                                    if (
+                                        !wikiState ||
+                                        wikiState.suggestions.length === 0
+                                    ) {
+                                        return;
+                                    }
+
+                                    if (e.key === 'ArrowDown') {
+                                        e.preventDefault();
+                                        setWikiState((prev) =>
+                                            prev
+                                                ? {
+                                                      ...prev,
+                                                      activeIndex:
+                                                          (prev.activeIndex +
+                                                              1) %
+                                                          prev.suggestions
+                                                              .length,
+                                                  }
+                                                : prev,
+                                        );
+                                    } else if (e.key === 'ArrowUp') {
+                                        e.preventDefault();
+                                        setWikiState((prev) =>
+                                            prev
+                                                ? {
+                                                      ...prev,
+                                                      activeIndex:
+                                                          (prev.activeIndex -
+                                                              1 +
+                                                              prev.suggestions
+                                                                  .length) %
+                                                          prev.suggestions
+                                                              .length,
+                                                  }
+                                                : prev,
+                                        );
+                                    } else if (
+                                        e.key === 'Enter' ||
+                                        e.key === 'Tab'
+                                    ) {
+                                        const s =
+                                            wikiState.suggestions[
+                                                wikiState.activeIndex
+                                            ];
+
+                                        if (s) {
+                                            e.preventDefault();
+                                            insertWikiSuggestion(s);
+                                        }
+                                    } else if (e.key === 'Escape') {
+                                        setWikiState(null);
+                                    }
+                                }}
+                                onBlur={() =>
+                                    setTimeout(() => setWikiState(null), 150)
+                                }
                                 onDrop={uploadUrl ? handleDrop : undefined}
                                 onDragOver={
                                     uploadUrl
@@ -479,6 +693,44 @@ const MarkdownEditor = forwardRef<MarkdownEditorRef, Props>(
                                     disabled && 'cursor-not-allowed opacity-50',
                                 )}
                             />
+                            {wikiState && wikiState.suggestions.length > 0 && (
+                                <div
+                                    data-test="markdown-editor-wikilink-suggestions"
+                                    style={{
+                                        position: 'fixed',
+                                        top: wikiState.popupPosition.top,
+                                        left: wikiState.popupPosition.left,
+                                        transform: wikiState.popupPosition.above
+                                            ? 'translateY(-100%)'
+                                            : undefined,
+                                    }}
+                                    className="z-50 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md"
+                                >
+                                    {wikiState.suggestions.map((s, i) => (
+                                        <button
+                                            key={s.full_path}
+                                            type="button"
+                                            data-test="markdown-editor-wikilink-suggestion"
+                                            className={cn(
+                                                'w-full px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground',
+                                                i === wikiState.activeIndex &&
+                                                    'bg-accent text-accent-foreground',
+                                            )}
+                                            onMouseDown={(e) => {
+                                                e.preventDefault();
+                                                insertWikiSuggestion(s);
+                                            }}
+                                        >
+                                            <div className="truncate font-medium">
+                                                {s.title}
+                                            </div>
+                                            <div className="truncate text-xs text-muted-foreground">
+                                                {s.full_path}
+                                            </div>
+                                        </button>
+                                    ))}
+                                </div>
+                            )}
                         </div>
 
                         {/* Preview column */}

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -320,7 +320,7 @@ export default function Edit({
                                 <div className="flex flex-col xl:flex-row">
                                     {/* Main content */}
                                     <main className="min-w-0 flex-1 px-4 py-6 lg:px-8 lg:py-8">
-                                        <div className="mb-4 flex items-center justify-between gap-3">
+                                        <div className="sticky top-16 z-40 -mx-4 mb-4 flex items-center justify-between border-b border-border bg-background px-4 py-2 lg:-mx-8 lg:px-8">
                                             <div className="flex items-center gap-3">
                                                 <Button
                                                     variant="outline"

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\OgpController;
+use App\Http\Controllers\Api\PostSuggestController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ImageController;
 use App\Http\Controllers\PostController;
@@ -26,6 +27,10 @@ Route::middleware('private.mode')->group(function () {
 Route::get('/api/ogp', [OgpController::class, 'fetch'])
     ->middleware('throttle:60,1')
     ->name('api.ogp');
+
+Route::get('/api/posts/suggest', [PostSuggestController::class, 'suggest'])
+    ->middleware(['auth', 'throttle:120,1'])
+    ->name('api.posts.suggest');
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard', DashboardController::class)->name('dashboard');

--- a/tests/Browser/MarkdownEditorWikilinkSuggestTest.php
+++ b/tests/Browser/MarkdownEditorWikilinkSuggestTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('markdown editor inserts wikilink suggestions for published posts', function () {
+    $user = User::factory()->create();
+
+    $namespace = PostNamespace::factory()->create([
+        'slug' => 'guides',
+        'name' => 'Guides',
+    ]);
+
+    Post::factory()->for($namespace, 'namespace')->published()->create([
+        'slug' => 'laravel-scout-guide',
+        'title' => 'Laravel Scout Guide',
+        'content' => '# Scout',
+    ]);
+
+    Post::factory()->for($namespace, 'namespace')->draft()->create([
+        'slug' => 'laravel-scout-draft',
+        'title' => 'Laravel Scout Draft',
+        'content' => '# Draft',
+    ]);
+
+    $post = Post::factory()->for($namespace, 'namespace')->create([
+        'slug' => 'todo',
+        'title' => 'Todo',
+        'content' => '',
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('admin.posts.edit', [
+        'namespace' => $namespace,
+        'post' => $post,
+    ], absolute: false))->resize(1440, 900);
+
+    $page->assertNoJavaScriptErrors();
+
+    $page
+        ->click('textarea[name="content"]')
+        ->type('textarea[name="content"]', 'See [[Scout')
+        ->wait(0.7)
+        ->assertPresent('[data-test="markdown-editor-wikilink-suggestions"]');
+
+    expect($page->script(<<<'JS'
+        (() => {
+            return Array.from(document.querySelectorAll('[data-test="markdown-editor-wikilink-suggestion"]')).map((button) => ({
+                title: button.querySelector('.font-medium')?.textContent?.trim() ?? null,
+                path: button.querySelector('.text-xs')?.textContent?.trim() ?? null,
+            }));
+        })()
+    JS))->toBe([
+        [
+            'title' => 'Laravel Scout Guide',
+            'path' => 'guides/laravel-scout-guide',
+        ],
+    ]);
+
+    $page
+        ->click('[data-test="markdown-editor-wikilink-suggestion"]')
+        ->wait(0.2);
+
+    expect($page->script(<<<'JS'
+        (() => {
+            const textarea = document.querySelector('textarea[name="content"]');
+
+            if (! (textarea instanceof HTMLTextAreaElement)) {
+                return null;
+            }
+
+            return {
+                value: textarea.value,
+                selectionCollapsed: textarea.selectionStart === textarea.selectionEnd,
+            };
+        })()
+    JS))->toBe([
+        'value' => 'See [[guides/laravel-scout-guide|Laravel Scout Guide]]',
+        'selectionCollapsed' => true,
+    ]);
+});

--- a/tests/Feature/Api/PostSuggestTest.php
+++ b/tests/Feature/Api/PostSuggestTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+
+uses(LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->create());
+});
+
+it('requires authentication', function () {
+    auth()->logout();
+
+    $this->getJson('/api/posts/suggest')
+        ->assertUnauthorized();
+});
+
+it('returns published posts when no query given', function () {
+    Post::factory()->count(3)->published()->create();
+
+    $this->getJson('/api/posts/suggest')
+        ->assertOk()
+        ->assertJsonCount(3)
+        ->assertJsonStructure([['title', 'full_path']]);
+});
+
+it('filters posts by title', function () {
+    Post::factory()->published()->create(['title' => 'Laravel Scout Guide']);
+    Post::factory()->published()->create(['title' => 'Unrelated Post']);
+
+    $this->getJson('/api/posts/suggest?q=Scout')
+        ->assertOk()
+        ->assertJsonCount(1)
+        ->assertJsonPath('0.title', 'Laravel Scout Guide');
+});
+
+it('filters posts by full_path', function () {
+    Post::factory()->published()->create(['title' => 'Some Post', 'slug' => 'some-post']);
+    Post::factory()->published()->create(['title' => 'Other Post', 'slug' => 'other-post']);
+
+    $fullPath = Post::where('slug', 'some-post')->value('full_path');
+
+    $this->getJson("/api/posts/suggest?q={$fullPath}")
+        ->assertOk()
+        ->assertJsonCount(1)
+        ->assertJsonPath('0.full_path', $fullPath);
+});
+
+it('returns empty array when no match', function () {
+    Post::factory()->published()->create(['title' => 'Something']);
+
+    $this->getJson('/api/posts/suggest?q=xyzzy-nomatch')
+        ->assertOk()
+        ->assertJsonCount(0);
+});
+
+it('excludes draft posts', function () {
+    Post::factory()->draft()->create(['title' => 'Draft Post']);
+    Post::factory()->published()->create(['title' => 'Published Post']);
+
+    $this->getJson('/api/posts/suggest?q=Post')
+        ->assertOk()
+        ->assertJsonCount(1)
+        ->assertJsonPath('0.title', 'Published Post');
+});
+
+it('limits results to 8', function () {
+    Post::factory()->count(12)->published()->create();
+
+    $this->getJson('/api/posts/suggest')
+        ->assertOk()
+        ->assertJsonCount(8);
+});

--- a/tests/Feature/SyntaxSeederTest.php
+++ b/tests/Feature/SyntaxSeederTest.php
@@ -169,6 +169,9 @@ test('syntax seeder creates the thinkstream syntax page', function () {
     expect($post->content)->toContain('```chart:radar');
     expect($post->content)->toContain('_title: Flavor Profile');
     expect($post->content)->toContain('_max: 10');
+    expect($post->content)->toContain('Live example:');
+    expect($post->content)->toContain('Source:');
+    expect($post->content)->toContain('````md');
     expect($post->published_at)->not->toBeNull();
 });
 


### PR DESCRIPTION
## Summary
- add a throttled post suggestion API for wikilink completion and require auth for it
- wire the markdown editor to the generated Wayfinder route, keep requests cancellable, and add test selectors
- cover the API, syntax seeder content, and browser wikilink insertion flow

## Testing
- vendor/bin/sail php ./vendor/bin/pint --dirty --format agent
- vendor/bin/sail npm exec -- prettier --write resources/js/components/markdown-editor.tsx resources/js/pages/admin/posts/edit.tsx
- rm -f public/hot && vendor/bin/sail npm run build
- vendor/bin/sail artisan test --compact tests/Feature/Api/PostSuggestTest.php tests/Feature/SyntaxSeederTest.php tests/Browser/MarkdownEditorWikilinkSuggestTest.php
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail npm run types:check
- vendor/bin/sail npm exec -- eslint resources/js/components/markdown-editor.tsx resources/js/pages/admin/posts/edit.tsx
- vendor/bin/sail npm run format:check