### PR TITLE
Fix redirect after creating child namespace

### DIFF
--- a/app/Http/Controllers/Admin/NamespaceController.php
+++ b/app/Http/Controllers/Admin/NamespaceController.php
@@ -74,6 +74,12 @@ class NamespaceController extends Controller
 
         PostNamespace::create($data);
 
+        if (! empty($data['parent_id'])) {
+            $parent = PostNamespace::find($data['parent_id']);
+
+            return to_route('admin.posts.namespace', $parent);
+        }
+
         return to_route('admin.posts.index');
     }
 

--- a/tests/Feature/Admin/NamespaceControllerTest.php
+++ b/tests/Feature/Admin/NamespaceControllerTest.php
@@ -67,7 +67,7 @@ test('storing a namespace accepts a valid parent namespace', function () {
             'slug' => 'child',
             'name' => 'Child',
         ])
-        ->assertRedirect(route('admin.posts.index'));
+        ->assertRedirect(route('admin.posts.namespace', $parent));
 
     $this->assertDatabaseHas('namespaces', [
         'slug' => 'child',
@@ -108,7 +108,7 @@ test('storing a child namespace allows reserved slugs', function (string $slug) 
             'slug' => $slug,
             'name' => ucfirst($slug),
         ])
-        ->assertRedirect(route('admin.posts.index'));
+        ->assertRedirect(route('admin.posts.namespace', $parent));
 
     $this->assertDatabaseHas('namespaces', [
         'parent_id' => $parent->id,
@@ -182,7 +182,7 @@ test('storing a namespace allows the same slug under a different parent', functi
             'slug' => 'shared',
             'name' => 'Shared',
         ])
-        ->assertRedirect(route('admin.posts.index'));
+        ->assertRedirect(route('admin.posts.namespace', $parentB));
 
     $this->assertDatabaseHas('namespaces', [
         'parent_id' => $parentB->id,


### PR DESCRIPTION
## Summary
- redirect to the selected parent namespace page after creating a child namespace
- keep root namespace create flow redirecting to admin posts index
- update feature tests to assert parent redirect for child namespace creation cases

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/Admin/NamespaceControllerTest.php
- vendor/bin/sail bin pint --dirty --format agent