### PR TITLE
Delay hash restoration until after mount

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -66,7 +66,7 @@ function restoreHashTarget(): void {
         requestAnimationFrame(scrollIntoView);
     };
 
-    requestAnimationFrame(scrollIntoView);
+    setTimeout(() => requestAnimationFrame(scrollIntoView), 0);
 }
 
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- Delay initial hash restoration with a zero-delay timeout so Inertia pages can mount before scrolling to anchored content

## Validation
- vendor/bin/sail npm run build
- vendor/bin/sail npm run types:check
- vendor/bin/sail artisan test --compact tests/Browser/SmokeTest.php --filter="table of contents supports encoded hashes for japanese headings|signed-in post pages keep sticky navigation and hash scrolling below the stacked headers|admin post deep links restore hashed headings and use gutter anchors"