### PR TITLE
Fix Mintlify nesting colon-depth handling

### DIFF
--- a/resources/js/lib/markdown-syntax.ts
+++ b/resources/js/lib/markdown-syntax.ts
@@ -306,9 +306,21 @@ export function preprocessMintlifySyntax(markdown: string): string {
         chartType: ChartType;
         lines: string[];
     } | null = null;
-    let mintlifyTabsDepth = 0;
     const mintlifyCalloutColonCounts: number[] = [];
-    const mintlifyTagStack: Array<
+
+    // Dynamic colon depth: items increment this when opened, decrement when closed.
+    // Containers read it to pick colon counts that properly nest inside items.
+    // Base is 10 so we support up to 4 nesting levels before hitting the minimum of 3.
+    let mintlifyItemDepth = 0;
+    const MINTLIFY_BASE_COLONS = 10;
+
+    const colonC = (): string =>
+        ':'.repeat(MINTLIFY_BASE_COLONS - mintlifyItemDepth * 2);
+
+    const colonI = (): string =>
+        ':'.repeat(MINTLIFY_BASE_COLONS - mintlifyItemDepth * 2 - 1);
+
+    type MintlifyTagName =
         | 'Tabs'
         | 'Tab'
         | 'Card'
@@ -322,8 +334,11 @@ export function preprocessMintlifySyntax(markdown: string): string {
         | 'ParamField'
         | 'CodeGroup'
         | 'Update'
-        | MintlifyCalloutTag
-    > = [];
+        | MintlifyCalloutTag;
+
+    type MintlifyStackEntry = { name: MintlifyTagName; colonCount: number };
+
+    const mintlifyTagStack: MintlifyStackEntry[] = [];
     const mintlifyTagLeadingSpaces: number[] = [];
     let treeBuffer: string[] | null = null;
 
@@ -550,7 +565,7 @@ export function preprocessMintlifySyntax(markdown: string): string {
             pushLine(':'.repeat(colonCount) + directiveBody);
             pushLine('');
             mintlifyTagLeadingSpaces.push(leadingSpaces);
-            mintlifyTagStack.push(tag);
+            mintlifyTagStack.push({ name: tag, colonCount });
             mintlifyCalloutColonCounts.push(colonCount);
 
             continue;
@@ -564,7 +579,7 @@ export function preprocessMintlifySyntax(markdown: string): string {
             const tag = calloutCloseMatch.groups!.tag as MintlifyCalloutTag;
             let colonCount = 3;
 
-            if (mintlifyTagStack.at(-1) === tag) {
+            if (mintlifyTagStack.at(-1)?.name === tag) {
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
                 colonCount = mintlifyCalloutColonCounts.pop() ?? 3;
@@ -585,23 +600,32 @@ export function preprocessMintlifySyntax(markdown: string): string {
                 cardGroupOpenMatch.groups?.attributes ?? '',
             );
 
+            const cgColons = colonC();
+
             pushBlankLineIfNeeded();
-            pushLine(`::::cardgroup${buildDirectiveAttributes(attributes)}`);
+            pushLine(
+                `${cgColons}cardgroup${buildDirectiveAttributes(attributes)}`,
+            );
             pushLine('');
             mintlifyTagLeadingSpaces.push(leadingSpaces);
-            mintlifyTagStack.push('CardGroup');
+            mintlifyTagStack.push({
+                name: 'CardGroup',
+                colonCount: cgColons.length,
+            });
 
             continue;
         }
 
         if (trimmedLine === '</CardGroup>') {
-            if (mintlifyTagStack.at(-1) === 'CardGroup') {
+            const top = mintlifyTagStack.at(-1);
+
+            if (top?.name === 'CardGroup') {
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
             }
 
             pushBlankLineIfNeeded();
-            pushLine('::::');
+            pushLine(':'.repeat(top?.colonCount ?? colonC().length));
 
             continue;
         }
@@ -615,23 +639,32 @@ export function preprocessMintlifySyntax(markdown: string): string {
                 columnsOpenMatch.groups?.attributes ?? '',
             );
 
+            const colColons = colonC();
+
             pushBlankLineIfNeeded();
-            pushLine(`::::cardgroup${buildDirectiveAttributes(attributes)}`);
+            pushLine(
+                `${colColons}cardgroup${buildDirectiveAttributes(attributes)}`,
+            );
             pushLine('');
             mintlifyTagLeadingSpaces.push(leadingSpaces);
-            mintlifyTagStack.push('Columns');
+            mintlifyTagStack.push({
+                name: 'Columns',
+                colonCount: colColons.length,
+            });
 
             continue;
         }
 
         if (trimmedLine === '</Columns>') {
-            if (mintlifyTagStack.at(-1) === 'Columns') {
+            const top = mintlifyTagStack.at(-1);
+
+            if (top?.name === 'Columns') {
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
             }
 
             pushBlankLineIfNeeded();
-            pushLine('::::');
+            pushLine(':'.repeat(top?.colonCount ?? colonC().length));
 
             continue;
         }
@@ -646,28 +679,39 @@ export function preprocessMintlifySyntax(markdown: string): string {
                 : rawAttrs;
             const attributes = parseJsxAttributes(cleanAttrs);
 
+            const cardColons = colonI();
+
             pushBlankLineIfNeeded();
-            pushLine(`:::card${buildDirectiveAttributes(attributes)}`);
+            pushLine(
+                `${cardColons}card${buildDirectiveAttributes(attributes)}`,
+            );
             pushLine('');
 
             if (isSelfClosing) {
-                pushLine(':::');
+                pushLine(cardColons);
             } else {
+                mintlifyItemDepth++;
                 mintlifyTagLeadingSpaces.push(leadingSpaces);
-                mintlifyTagStack.push('Card');
+                mintlifyTagStack.push({
+                    name: 'Card',
+                    colonCount: cardColons.length,
+                });
             }
 
             continue;
         }
 
         if (trimmedLine === '</Card>') {
-            if (mintlifyTagStack.at(-1) === 'Card') {
+            const top = mintlifyTagStack.at(-1);
+
+            if (top?.name === 'Card') {
+                mintlifyItemDepth--;
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
             }
 
             pushBlankLineIfNeeded();
-            pushLine(':::');
+            pushLine(':'.repeat(top?.colonCount ?? colonI().length));
 
             continue;
         }
@@ -679,12 +723,18 @@ export function preprocessMintlifySyntax(markdown: string): string {
                 tabsOpenMatch.groups?.attributes ?? '',
             );
 
+            const tabsColons = colonC();
+
             pushBlankLineIfNeeded();
-            pushLine(`::::tabs${buildDirectiveAttributes(attributes)}`);
+            pushLine(
+                `${tabsColons}tabs${buildDirectiveAttributes(attributes)}`,
+            );
             pushLine('');
-            mintlifyTabsDepth++;
             mintlifyTagLeadingSpaces.push(leadingSpaces);
-            mintlifyTagStack.push('Tabs');
+            mintlifyTagStack.push({
+                name: 'Tabs',
+                colonCount: tabsColons.length,
+            });
 
             continue;
         }
@@ -696,58 +746,75 @@ export function preprocessMintlifySyntax(markdown: string): string {
                 tabOpenMatch.groups?.attributes ?? '',
             );
 
+            const tabColons = colonI();
+
             pushBlankLineIfNeeded();
-            pushLine(`:::tab${buildDirectiveAttributes(attributes)}`);
+            pushLine(`${tabColons}tab${buildDirectiveAttributes(attributes)}`);
             pushLine('');
+            mintlifyItemDepth++;
             mintlifyTagLeadingSpaces.push(leadingSpaces);
-            mintlifyTagStack.push('Tab');
+            mintlifyTagStack.push({
+                name: 'Tab',
+                colonCount: tabColons.length,
+            });
 
             continue;
         }
 
         if (trimmedLine === '</Tab>') {
-            if (mintlifyTagStack.at(-1) === 'Tab') {
+            const top = mintlifyTagStack.at(-1);
+
+            if (top?.name === 'Tab') {
+                mintlifyItemDepth--;
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
             }
 
             pushBlankLineIfNeeded();
-            pushLine(':::');
+            pushLine(':'.repeat(top?.colonCount ?? colonI().length));
 
             continue;
         }
 
         if (trimmedLine === '</Tabs>') {
-            if (mintlifyTagStack.at(-1) === 'Tabs') {
+            const top = mintlifyTagStack.at(-1);
+
+            if (top?.name === 'Tabs') {
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
             }
 
             pushBlankLineIfNeeded();
-            pushLine(mintlifyTabsDepth > 0 ? '::::' : ':::');
-            mintlifyTabsDepth = Math.max(0, mintlifyTabsDepth - 1);
+            pushLine(':'.repeat(top?.colonCount ?? colonC().length));
 
             continue;
         }
 
         if (trimmedLine === '<AccordionGroup>') {
+            const agColons = colonC();
+
             pushBlankLineIfNeeded();
-            pushLine('::::accordion-group');
+            pushLine(`${agColons}accordion-group`);
             pushLine('');
             mintlifyTagLeadingSpaces.push(leadingSpaces);
-            mintlifyTagStack.push('AccordionGroup');
+            mintlifyTagStack.push({
+                name: 'AccordionGroup',
+                colonCount: agColons.length,
+            });
 
             continue;
         }
 
         if (trimmedLine === '</AccordionGroup>') {
-            if (mintlifyTagStack.at(-1) === 'AccordionGroup') {
+            const top = mintlifyTagStack.at(-1);
+
+            if (top?.name === 'AccordionGroup') {
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
             }
 
             pushBlankLineIfNeeded();
-            pushLine('::::');
+            pushLine(':'.repeat(top?.colonCount ?? colonC().length));
 
             continue;
         }
@@ -762,24 +829,32 @@ export function preprocessMintlifySyntax(markdown: string): string {
             );
             const title =
                 typeof attributes.title === 'string' ? attributes.title : '';
+            const accColons = colonI();
 
             pushBlankLineIfNeeded();
-            pushLine(`:::details ${title}`);
+            pushLine(`${accColons}details ${title}`);
             pushLine('');
+            mintlifyItemDepth++;
             mintlifyTagLeadingSpaces.push(leadingSpaces);
-            mintlifyTagStack.push('Accordion');
+            mintlifyTagStack.push({
+                name: 'Accordion',
+                colonCount: accColons.length,
+            });
 
             continue;
         }
 
         if (trimmedLine === '</Accordion>') {
-            if (mintlifyTagStack.at(-1) === 'Accordion') {
+            const top = mintlifyTagStack.at(-1);
+
+            if (top?.name === 'Accordion') {
+                mintlifyItemDepth--;
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
             }
 
             pushBlankLineIfNeeded();
-            pushLine(':::');
+            pushLine(':'.repeat(top?.colonCount ?? colonI().length));
 
             continue;
         }
@@ -793,23 +868,34 @@ export function preprocessMintlifySyntax(markdown: string): string {
                 updateOpenMatch.groups?.attributes ?? '',
             );
 
+            const updColons = colonI();
+
             pushBlankLineIfNeeded();
-            pushLine(`:::update${buildDirectiveAttributes(attributes)}`);
+            pushLine(
+                `${updColons}update${buildDirectiveAttributes(attributes)}`,
+            );
             pushLine('');
+            mintlifyItemDepth++;
             mintlifyTagLeadingSpaces.push(leadingSpaces);
-            mintlifyTagStack.push('Update');
+            mintlifyTagStack.push({
+                name: 'Update',
+                colonCount: updColons.length,
+            });
 
             continue;
         }
 
         if (trimmedLine === '</Update>') {
-            if (mintlifyTagStack.at(-1) === 'Update') {
+            const top = mintlifyTagStack.at(-1);
+
+            if (top?.name === 'Update') {
+                mintlifyItemDepth--;
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
             }
 
             pushBlankLineIfNeeded();
-            pushLine(':::');
+            pushLine(':'.repeat(top?.colonCount ?? colonI().length));
 
             continue;
         }
@@ -819,23 +905,30 @@ export function preprocessMintlifySyntax(markdown: string): string {
         );
 
         if (stepsOpenMatch) {
+            const stepsColons = colonC();
+
             pushBlankLineIfNeeded();
-            pushLine('::::steps');
+            pushLine(`${stepsColons}steps`);
             pushLine('');
             mintlifyTagLeadingSpaces.push(leadingSpaces);
-            mintlifyTagStack.push('Steps');
+            mintlifyTagStack.push({
+                name: 'Steps',
+                colonCount: stepsColons.length,
+            });
 
             continue;
         }
 
         if (trimmedLine === '</Steps>') {
-            if (mintlifyTagStack.at(-1) === 'Steps') {
+            const top = mintlifyTagStack.at(-1);
+
+            if (top?.name === 'Steps') {
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
             }
 
             pushBlankLineIfNeeded();
-            pushLine('::::');
+            pushLine(':'.repeat(top?.colonCount ?? colonC().length));
 
             continue;
         }
@@ -847,23 +940,34 @@ export function preprocessMintlifySyntax(markdown: string): string {
                 stepOpenMatch.groups?.attributes ?? '',
             );
 
+            const stepColons = colonI();
+
             pushBlankLineIfNeeded();
-            pushLine(`:::step${buildDirectiveAttributes(attributes)}`);
+            pushLine(
+                `${stepColons}step${buildDirectiveAttributes(attributes)}`,
+            );
             pushLine('');
+            mintlifyItemDepth++;
             mintlifyTagLeadingSpaces.push(leadingSpaces);
-            mintlifyTagStack.push('Step');
+            mintlifyTagStack.push({
+                name: 'Step',
+                colonCount: stepColons.length,
+            });
 
             continue;
         }
 
         if (trimmedLine === '</Step>') {
-            if (mintlifyTagStack.at(-1) === 'Step') {
+            const top = mintlifyTagStack.at(-1);
+
+            if (top?.name === 'Step') {
+                mintlifyItemDepth--;
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
             }
 
             pushBlankLineIfNeeded();
-            pushLine(':::');
+            pushLine(':'.repeat(top?.colonCount ?? colonI().length));
 
             continue;
         }
@@ -879,28 +983,39 @@ export function preprocessMintlifySyntax(markdown: string): string {
                 : rawAttrs;
             const attributes = parseJsxAttributes(cleanAttrs);
 
+            const rfColons = colonI();
+
             pushBlankLineIfNeeded();
-            pushLine(`:::responsefield${buildDirectiveAttributes(attributes)}`);
+            pushLine(
+                `${rfColons}responsefield${buildDirectiveAttributes(attributes)}`,
+            );
             pushLine('');
 
             if (isSelfClosing) {
-                pushLine(':::');
+                pushLine(rfColons);
             } else {
+                mintlifyItemDepth++;
                 mintlifyTagLeadingSpaces.push(leadingSpaces);
-                mintlifyTagStack.push('ResponseField');
+                mintlifyTagStack.push({
+                    name: 'ResponseField',
+                    colonCount: rfColons.length,
+                });
             }
 
             continue;
         }
 
         if (trimmedLine === '</ResponseField>') {
-            if (mintlifyTagStack.at(-1) === 'ResponseField') {
+            const top = mintlifyTagStack.at(-1);
+
+            if (top?.name === 'ResponseField') {
+                mintlifyItemDepth--;
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
             }
 
             pushBlankLineIfNeeded();
-            pushLine(':::');
+            pushLine(':'.repeat(top?.colonCount ?? colonI().length));
 
             continue;
         }
@@ -917,50 +1032,70 @@ export function preprocessMintlifySyntax(markdown: string): string {
                 : rawAttrs;
             const attributes = parseJsxAttributes(cleanAttrs);
 
+            const pfColons = colonI();
+
             pushBlankLineIfNeeded();
-            pushLine(`:::paramfield${buildDirectiveAttributes(attributes)}`);
+            pushLine(
+                `${pfColons}paramfield${buildDirectiveAttributes(attributes)}`,
+            );
             pushLine('');
 
             if (isSelfClosing) {
-                pushLine(':::');
+                pushLine(pfColons);
             } else {
+                mintlifyItemDepth++;
                 mintlifyTagLeadingSpaces.push(leadingSpaces);
-                mintlifyTagStack.push('ParamField');
+                mintlifyTagStack.push({
+                    name: 'ParamField',
+                    colonCount: pfColons.length,
+                });
             }
 
             continue;
         }
 
         if (trimmedLine === '</ParamField>') {
-            if (mintlifyTagStack.at(-1) === 'ParamField') {
+            const top = mintlifyTagStack.at(-1);
+
+            if (top?.name === 'ParamField') {
+                mintlifyItemDepth--;
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
             }
 
             pushBlankLineIfNeeded();
-            pushLine(':::');
+            pushLine(':'.repeat(top?.colonCount ?? colonI().length));
 
             continue;
         }
 
         if (trimmedLine === '<CodeGroup>') {
+            const cgroupColons = colonI();
+
             pushBlankLineIfNeeded();
-            pushLine(':::codegroup');
+            pushLine(`${cgroupColons}codegroup`);
             pushLine('');
+            mintlifyItemDepth++;
             mintlifyTagLeadingSpaces.push(leadingSpaces);
-            mintlifyTagStack.push('CodeGroup');
+            mintlifyTagStack.push({
+                name: 'CodeGroup',
+                colonCount: cgroupColons.length,
+            });
 
             continue;
         }
 
         if (trimmedLine === '</CodeGroup>') {
-            if (mintlifyTagStack.at(-1) === 'CodeGroup') {
+            const top = mintlifyTagStack.at(-1);
+
+            if (top?.name === 'CodeGroup') {
+                mintlifyItemDepth--;
                 mintlifyTagStack.pop();
                 mintlifyTagLeadingSpaces.pop();
             }
 
             pushBlankLineIfNeeded();
-            pushLine(':::');
+            pushLine(':'.repeat(top?.colonCount ?? colonI().length));
 
             continue;
         }
@@ -1557,7 +1692,7 @@ export function preprocessMarkdownSyntax(markdown: string): string {
                         ':::message{.$1}',
                     )
                     // Convert :::details title to the label form remark-directive expects.
-                    .replace(/:::details\s+(.+?)$/, ':::details[$1]')
+                    .replace(/(:{3,})details\s+(.+?)$/, '$1details[$2]')
                     // Convert Zenn embeds to bare URL lines so remark-linkify-to-card picks them up.
                     .replace(
                         new RegExp(

--- a/tests-node/markdown/markdown-syntax.test.ts
+++ b/tests-node/markdown/markdown-syntax.test.ts
@@ -350,10 +350,14 @@ test('preprocessMarkdownSyntax converts Mintlify AccordionGroup to directive syn
   </Accordion>
 </AccordionGroup>`);
 
-    assert.match(output, /::::accordion-group/);
+    const lines = output.split('\n');
+    const openLine = lines.find((line) => line.includes('accordion-group')) ?? '';
+    const openColonCount = (openLine.match(/^(:{3,})/)?.[1] ?? '').length;
+
+    assert.ok(openColonCount >= 3);
     assert.match(output, /:::details\[What is ThinkStream\?\]/);
     assert.match(output, /:::details\[Which syntax is supported\?\]/);
-    assert.match(output, /^::::\s*$/m);
+    assert.match(output, new RegExp(`^:{${openColonCount}}\\s*$`, 'm'));
 });
 
 test('preprocessMarkdownSyntax converts Mintlify Steps/Step to directive syntax', () => {
@@ -474,10 +478,86 @@ x = 1
 
 </CodeGroup>`);
 
-    assert.match(output, /:::codegroup/);
-    assert.match(output, /^:::\s*$/m);
+    const lines = output.split('\n');
+    const openLine = lines.find((line) => line.includes('codegroup')) ?? '';
+    const openColonCount = (openLine.match(/^(:{3,})/)?.[1] ?? '').length;
+
+    assert.ok(openColonCount >= 3);
+    assert.match(output, new RegExp(`^:{${openColonCount}}\\s*$`, 'm'));
     assert.match(output, /```javascript JavaScript/);
     assert.match(output, /```python Python/);
+});
+
+test('preprocessMarkdownSyntax nests AccordionGroup > Accordion > Steps using decreasing colon depths', () => {
+    const output = preprocessMarkdownSyntax(`<AccordionGroup>
+  <Accordion title="Cloudflare">
+    Intro text.
+    <Steps>
+      <Step title="Step one">
+        Do this.
+      </Step>
+      <Step title="Step two">
+        Do that.
+      </Step>
+    </Steps>
+  </Accordion>
+</AccordionGroup>`);
+
+    const lines = output.split('\n');
+    const groupLine = lines.find((line) => line.includes('accordion-group')) ?? '';
+    const accordionLine = lines.find((line) => line.includes('details[Cloudflare]')) ?? '';
+    const stepsLine = lines.find((line) => line.includes('steps')) ?? '';
+    const stepLine = lines.find((line) => line.includes('step{title="Step one"}')) ?? '';
+    const groupColons = (groupLine.match(/^(:{3,})/)?.[1] ?? '').length;
+    const accordionColons = (accordionLine.match(/^(:{3,})/)?.[1] ?? '').length;
+    const stepsColons = (stepsLine.match(/^(:{3,})/)?.[1] ?? '').length;
+    const stepColons = (stepLine.match(/^(:{3,})/)?.[1] ?? '').length;
+
+    assert.ok(groupColons >= 3);
+    assert.ok(accordionColons >= 3);
+    assert.ok(stepsColons >= 3);
+    assert.ok(stepColons >= 3);
+    assert.ok(groupColons > accordionColons);
+    assert.ok(accordionColons > stepsColons);
+    assert.ok(stepsColons > stepColons);
+    assert.match(output, /Intro text\./);
+    assert.match(output, /Do this\./);
+    assert.match(output, /Do that\./);
+});
+
+test('preprocessMarkdownSyntax nests Steps > Step > Tabs using decreasing colon depths', () => {
+    const output = preprocessMarkdownSyntax(`<Steps>
+  <Step title="Choose method">
+    <Tabs>
+      <Tab title="Option A">
+        Content A.
+      </Tab>
+      <Tab title="Option B">
+        Content B.
+      </Tab>
+    </Tabs>
+  </Step>
+</Steps>`);
+
+    const lines = output.split('\n');
+    const stepsLine = lines.find((line) => line.includes('steps')) ?? '';
+    const stepLine = lines.find((line) => line.includes('step{title="Choose method"}')) ?? '';
+    const tabsLine = lines.find((line) => line.includes('tabs')) ?? '';
+    const tabLine = lines.find((line) => line.includes('tab{title="Option A"}')) ?? '';
+    const stepsColons = (stepsLine.match(/^(:{3,})/)?.[1] ?? '').length;
+    const stepColons = (stepLine.match(/^(:{3,})/)?.[1] ?? '').length;
+    const tabsColons = (tabsLine.match(/^(:{3,})/)?.[1] ?? '').length;
+    const tabColons = (tabLine.match(/^(:{3,})/)?.[1] ?? '').length;
+
+    assert.ok(stepsColons >= 3);
+    assert.ok(stepColons >= 3);
+    assert.ok(tabsColons >= 3);
+    assert.ok(tabColons >= 3);
+    assert.ok(stepsColons > stepColons);
+    assert.ok(stepColons > tabsColons);
+    assert.ok(tabsColons > tabColons);
+    assert.match(output, /Content A\./);
+    assert.match(output, /Content B\./);
 });
 
 test('preprocessMarkdownSyntax converts Mintlify Tree to a tree directive with JSON payload', () => {

--- a/tests/Feature/SyntaxNestingTest.php
+++ b/tests/Feature/SyntaxNestingTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use App\Models\Post;
+use App\Models\PostNamespace;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+// Helpers
+
+function makeNamespace(string $slug): PostNamespace
+{
+    return PostNamespace::factory()->create(['slug' => $slug]);
+}
+
+function makePost(PostNamespace $namespace, string $slug, string $content): Post
+{
+    return Post::factory()
+        ->for(User::factory())
+        ->published()
+        ->create([
+            'namespace_id' => $namespace->id,
+            'slug' => $slug,
+            'title' => $slug,
+            'content' => $content,
+        ]);
+}
+
+// Page load
+
+test('syntax nesting test page loads', function () {
+    $ns = makeNamespace('test');
+    makePost($ns, 'syntax-nesting', '## Heading');
+
+    $this->get('/test/syntax-nesting')->assertOk();
+});
+
+// Standalone components — content is passed through to Inertia correctly
+
+test('standalone Accordion content passes through', function () {
+    $ns = makeNamespace('test');
+    makePost($ns, 'p', <<<'MD'
+        <Accordion title="Hello">
+        Content here.
+        </Accordion>
+        MD);
+
+    $this->get('/test/p')
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('post.content', fn ($content) => str_contains($content, 'Accordion'))
+        );
+});
+
+test('AccordionGroup with multiple Accordion items passes through', function () {
+    $ns = makeNamespace('test');
+    makePost($ns, 'p', <<<'MD'
+        <AccordionGroup>
+        <Accordion title="First">One</Accordion>
+        <Accordion title="Second">Two</Accordion>
+        </AccordionGroup>
+        MD);
+
+    $this->get('/test/p')
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('post.content', fn ($content) => str_contains($content, 'AccordionGroup'))
+        );
+});
+
+test('Steps with Step items passes through', function () {
+    $ns = makeNamespace('test');
+    makePost($ns, 'p', <<<'MD'
+        <Steps>
+        <Step title="First">One</Step>
+        <Step title="Second">Two</Step>
+        </Steps>
+        MD);
+
+    $this->get('/test/p')
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('post.content', fn ($content) => str_contains($content, 'Steps'))
+        );
+});
+
+// Known broken nesting — these tests document current (broken) behavior.
+// When the nesting fix is applied, update these assertions to verify correct rendering.
+
+test('AccordionGroup > Accordion > Steps content passes through (nesting currently broken in renderer)', function () {
+    $ns = makeNamespace('test');
+    makePost($ns, 'p', <<<'MD'
+        <AccordionGroup>
+        <Accordion title="Cloudflare">
+        Intro text.
+
+        <Steps>
+        <Step title="Step one">Do this.</Step>
+        <Step title="Step two">Do that.</Step>
+        </Steps>
+        </Accordion>
+        </AccordionGroup>
+        MD);
+
+    // Page must load without error regardless of rendering correctness.
+    $this->get('/test/p')->assertOk();
+});
+
+test('Steps > Step > Tabs content passes through (nesting currently broken in renderer)', function () {
+    $ns = makeNamespace('test');
+    makePost($ns, 'p', <<<'MD'
+        <Steps>
+        <Step title="Choose method">
+        <Tabs>
+        <Tab title="Option A">Content A.</Tab>
+        <Tab title="Option B">Content B.</Tab>
+        </Tabs>
+        </Step>
+        </Steps>
+        MD);
+
+    // Page must load without error regardless of rendering correctness.
+    $this->get('/test/p')->assertOk();
+});


### PR DESCRIPTION
## Summary
- switch Mintlify component conversion to dynamic colon-depth handling using stack entries with explicit colon counts
- update markdown syntax tests to assert dynamic closers and nested depth behavior
- add a feature regression test file for syntax nesting page scenarios

## Validation
- vendor/bin/sail npm run markdown:test
- vendor/bin/sail artisan test --compact tests/Feature/SyntaxNestingTest.php
- vendor/bin/sail npm run types:check
- vendor/bin/sail bin pint --dirty --format agent